### PR TITLE
update: lexical update v0.33.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prepare": "husky"
   },
   "devDependencies": {
-    "@lexical/eslint-plugin": "^0.32.1",
+    "@lexical/eslint-plugin": "^0.33.0",
     "@nx/devkit": "19.8.14",
     "@nx/eslint": "19.8.14",
     "@nx/eslint-plugin": "19.8.14",

--- a/packages/perf-react/package.json
+++ b/packages/perf-react/package.json
@@ -12,14 +12,14 @@
     "react-dom": ">=18.3.1"
   },
   "dependencies": {
-    "@lexical/headless": "^0.32.1",
-    "@lexical/html": "^0.32.1",
-    "@lexical/react": "^0.32.1",
-    "@lexical/selection": "^0.32.1",
-    "@lexical/utils": "^0.32.1",
+    "@lexical/headless": "^0.33.0",
+    "@lexical/html": "^0.33.0",
+    "@lexical/react": "^0.33.0",
+    "@lexical/selection": "^0.33.0",
+    "@lexical/utils": "^0.33.0",
     "base-64": "^1.0.0",
     "epitelete-html": "^0.2.21-beta.2",
-    "lexical": "^0.32.1",
+    "lexical": "^0.33.0",
     "open-patcher": "1.0.0-beta.1",
     "pure-uuid": "^1.8.1"
   },

--- a/packages/perf-vanilla/package.json
+++ b/packages/perf-vanilla/package.json
@@ -8,9 +8,9 @@
     "dev": "vite"
   },
   "dependencies": {
-    "@lexical/rich-text": "^0.32.1",
-    "@lexical/utils": "^0.32.1",
-    "lexical": "^0.32.1",
+    "@lexical/rich-text": "^0.33.0",
+    "@lexical/utils": "^0.33.0",
+    "lexical": "^0.33.0",
     "open-patcher": "1.0.0-beta.1"
   },
   "devDependencies": {

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -32,15 +32,15 @@
   },
   "dependencies": {
     "@eten-tech-foundation/scripture-utilities": "workspace:~",
-    "@lexical/react": "^0.32.1",
-    "@lexical/selection": "^0.32.1",
-    "@lexical/text": "^0.32.1",
-    "@lexical/utils": "^0.32.1",
-    "@lexical/yjs": "^0.32.1",
+    "@lexical/react": "^0.33.0",
+    "@lexical/selection": "^0.33.0",
+    "@lexical/text": "^0.33.0",
+    "@lexical/utils": "^0.33.0",
+    "@lexical/yjs": "^0.33.0",
     "@sillsdev/scripture": "^2.0.2",
     "fast-equals": "^5.2.2",
-    "lexical": "^0.32.1",
-    "yjs": "^13.6.20"
+    "lexical": "^0.33.0",
+    "yjs": "^13.6.27"
   },
   "devDependencies": {
     "@types/react": "^18.3.18",

--- a/packages/scribe/package.json
+++ b/packages/scribe/package.json
@@ -30,14 +30,14 @@
   },
   "dependencies": {
     "@eten-tech-foundation/scripture-utilities": "workspace:~",
-    "@floating-ui/dom": "^1.7.1",
-    "@lexical/mark": "^0.32.1",
-    "@lexical/react": "^0.32.1",
-    "@lexical/selection": "^0.32.1",
-    "@lexical/utils": "^0.32.1",
+    "@floating-ui/dom": "^1.7.2",
+    "@lexical/mark": "^0.33.0",
+    "@lexical/react": "^0.33.0",
+    "@lexical/selection": "^0.33.0",
+    "@lexical/utils": "^0.33.0",
     "autoprefixer": "^10.4.21",
     "fast-equals": "^5.2.2",
-    "lexical": "^0.32.1"
+    "lexical": "^0.33.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.18",
@@ -47,7 +47,7 @@
     "react-dom": "^18.3.1",
     "shared": "link:../shared",
     "shared-react": "link:../shared-react",
-    "sj-usfm-grammar": "^3.0.0",
+    "sj-usfm-grammar": "^3.0.8",
     "tailwindcss": "^3.4.17"
   },
   "volta": {

--- a/packages/shared-react/package.json
+++ b/packages/shared-react/package.json
@@ -17,11 +17,11 @@
   },
   "dependencies": {
     "@eten-tech-foundation/scripture-utilities": "workspace:*",
-    "@floating-ui/dom": "^1.6.13",
-    "@lexical/react": "^0.32.1",
-    "@lexical/utils": "^0.32.1",
+    "@floating-ui/dom": "^1.7.2",
+    "@lexical/react": "^0.33.0",
+    "@lexical/utils": "^0.33.0",
     "fast-equals": "^5.2.2",
-    "lexical": "^0.32.1"
+    "lexical": "^0.33.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.18",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,11 +15,11 @@
   },
   "dependencies": {
     "@eten-tech-foundation/scripture-utilities": "workspace:*",
-    "@lexical/mark": "^0.32.1",
-    "@lexical/utils": "^0.32.1",
+    "@lexical/mark": "^0.33.0",
+    "@lexical/utils": "^0.33.0",
     "@sillsdev/scripture": "^2.0.2",
     "epitelete": "^0.2.20",
-    "lexical": "^0.32.1",
+    "lexical": "^0.33.0",
     "open-patcher": "1.0.0-beta.1"
   },
   "devDependencies": {

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -36,7 +36,7 @@
     "@xmldom/xmldom": "^0.9.8"
   },
   "devDependencies": {
-    "lexical": "^0.32.1"
+    "lexical": "^0.33.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
   .:
     devDependencies:
       '@lexical/eslint-plugin':
-        specifier: ^0.32.1
-        version: 0.32.1(eslint@9.29.0(jiti@1.21.7))
+        specifier: ^0.33.0
+        version: 0.33.0(eslint@9.29.0(jiti@1.21.7))
       '@nx/devkit':
         specifier: 19.8.14
         version: 19.8.14(nx@19.8.14(@swc-node/register@1.10.10(@swc/core@1.12.3(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.5.4))(@swc/core@1.12.3(@swc/helpers@0.5.17)))
@@ -159,20 +159,20 @@ importers:
   packages/perf-react:
     dependencies:
       '@lexical/headless':
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
       '@lexical/html':
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
       '@lexical/react':
-        specifier: ^0.32.1
-        version: 0.32.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.27)
+        specifier: ^0.33.0
+        version: 0.33.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.27)
       '@lexical/selection':
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
       '@lexical/utils':
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
       base-64:
         specifier: ^1.0.0
         version: 1.0.0
@@ -180,8 +180,8 @@ importers:
         specifier: ^0.2.21-beta.2
         version: 0.2.21-beta.2
       lexical:
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
       open-patcher:
         specifier: 1.0.0-beta.1
         version: 1.0.0-beta.1
@@ -214,14 +214,14 @@ importers:
   packages/perf-vanilla:
     dependencies:
       '@lexical/rich-text':
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
       '@lexical/utils':
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
       lexical:
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
       open-patcher:
         specifier: 1.0.0-beta.1
         version: 1.0.0-beta.1
@@ -236,20 +236,20 @@ importers:
         specifier: workspace:~
         version: link:../utilities
       '@lexical/react':
-        specifier: ^0.32.1
-        version: 0.32.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.27)
+        specifier: ^0.33.0
+        version: 0.33.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.27)
       '@lexical/selection':
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
       '@lexical/text':
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
       '@lexical/utils':
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
       '@lexical/yjs':
-        specifier: ^0.32.1
-        version: 0.32.1(yjs@13.6.27)
+        specifier: ^0.33.0
+        version: 0.33.0(yjs@13.6.27)
       '@sillsdev/scripture':
         specifier: ^2.0.2
         version: 2.0.2
@@ -257,10 +257,10 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
       lexical:
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
       yjs:
-        specifier: ^13.6.20
+        specifier: ^13.6.27
         version: 13.6.27
     devDependencies:
       '@types/react':
@@ -300,20 +300,20 @@ importers:
         specifier: workspace:~
         version: link:../utilities
       '@floating-ui/dom':
-        specifier: ^1.7.1
-        version: 1.7.1
+        specifier: ^1.7.2
+        version: 1.7.2
       '@lexical/mark':
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
       '@lexical/react':
-        specifier: ^0.32.1
-        version: 0.32.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.27)
+        specifier: ^0.33.0
+        version: 0.33.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.27)
       '@lexical/selection':
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
       '@lexical/utils':
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
@@ -321,8 +321,8 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
       lexical:
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
     devDependencies:
       '@types/react':
         specifier: ^18.3.18
@@ -346,7 +346,7 @@ importers:
         specifier: link:../shared-react
         version: link:../shared-react
       sj-usfm-grammar:
-        specifier: ^3.0.0
+        specifier: ^3.0.8
         version: 3.0.8
       tailwindcss:
         specifier: ^3.4.17
@@ -358,11 +358,11 @@ importers:
         specifier: workspace:*
         version: link:../utilities
       '@lexical/mark':
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
       '@lexical/utils':
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
       '@sillsdev/scripture':
         specifier: ^2.0.2
         version: 2.0.2
@@ -370,8 +370,8 @@ importers:
         specifier: ^0.2.20
         version: 0.2.20
       lexical:
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
       open-patcher:
         specifier: 1.0.0-beta.1
         version: 1.0.0-beta.1
@@ -392,20 +392,20 @@ importers:
         specifier: workspace:*
         version: link:../utilities
       '@floating-ui/dom':
-        specifier: ^1.6.13
-        version: 1.7.1
+        specifier: ^1.7.2
+        version: 1.7.2
       '@lexical/react':
-        specifier: ^0.32.1
-        version: 0.32.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.27)
+        specifier: ^0.33.0
+        version: 0.33.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.27)
       '@lexical/utils':
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
       fast-equals:
         specifier: ^5.2.2
         version: 5.2.2
       lexical:
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
     devDependencies:
       '@types/react':
         specifier: ^18.3.18
@@ -430,8 +430,8 @@ importers:
         version: 0.9.8
     devDependencies:
       lexical:
-        specifier: ^0.32.1
-        version: 0.32.1
+        specifier: ^0.33.0
+        version: 0.33.0
 
   tools/usfm-markers:
     devDependencies:
@@ -1352,11 +1352,11 @@ packages:
   '@findr/perf@1.0.3-beta.17':
     resolution: {integrity: sha512-qOAG+MsGQfnvq6AEhnAYhpDCUt0bkmenQQn36Ty2WhN83wAIwGN1n0tyhzrnXZO6CcgKgtgMzbodchPLLijkhg==}
 
-  '@floating-ui/core@1.7.1':
-    resolution: {integrity: sha512-azI0DrjMMfIug/ExbBaeDVJXcY0a7EPvPjb2xAJPa4HeimBX+Z18HK8QQR3jb6356SnDDdxx+hinMLcJEDdOjw==}
+  '@floating-ui/core@1.7.2':
+    resolution: {integrity: sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==}
 
-  '@floating-ui/dom@1.7.1':
-    resolution: {integrity: sha512-cwsmW/zyw5ltYTUeeYJ60CnQuPqmGwuGVhG9w0PRaRKkAyi38BT5CKrpIbb+jtahSwUl04cWzSx9ZOIxeS6RsQ==}
+  '@floating-ui/dom@1.7.2':
+    resolution: {integrity: sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==}
 
   '@floating-ui/react-dom@2.1.3':
     resolution: {integrity: sha512-huMBfiU9UnQ2oBwIhgzyIiSpVgvlDstU8CX0AF+wS+KzmYMs0J2a3GwuFHV1Lz+jlrQGeC1fF+Nv0QoumyV0bA==}
@@ -1369,6 +1369,9 @@ packages:
     peerDependencies:
       react: '>=17.0.0'
       react-dom: '>=17.0.0'
+
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
@@ -1527,82 +1530,82 @@ packages:
     peerDependencies:
       jsep: ^0.4.0||^1.0.0
 
-  '@lexical/clipboard@0.32.1':
-    resolution: {integrity: sha512-oO7CuMVh3EFEqtE6+7Ccf7jMD5RNUmSdTnFm/X4kYNGqs9lgGt8j5PgSk7oP9OuAjxKNdBTbltSlh54CX3AUIg==}
+  '@lexical/clipboard@0.33.0':
+    resolution: {integrity: sha512-nM3HE8ekF+dhFoXvOS5G8KZDi1BJARh+dMFZlLe7MX44rEkxcMMdgtY2qr8j9cUL8d4k1BVql9nEIfF/kLp7Gw==}
 
-  '@lexical/code@0.32.1':
-    resolution: {integrity: sha512-2rXj8s/CG32XKQ2EpORpACfpzyAxB+/SrQW2cjwczarLs5Fxnx6u6HwahZnxaF0z5UHIPUy90qDiOiRExc74Yg==}
+  '@lexical/code@0.33.0':
+    resolution: {integrity: sha512-lJDrPtOpZ2J4XoU/WwjABSutbiEN8FWq/nDSQp8eD7vOlTLS5ZlT3nJNojxwVAwcxZ4evg3OU32WrVq46CNUyQ==}
 
-  '@lexical/devtools-core@0.32.1':
-    resolution: {integrity: sha512-3WnZQo6Qig7ccjDu2b8s1Kb5CCXowxnK0i8CCRG9mHAw7i6XpZUYAbk4rmcK/qbhLHrc7LwUrAMFzGtfLEH3XA==}
+  '@lexical/devtools-core@0.33.0':
+    resolution: {integrity: sha512-PXyA4H+gb3pzEuowpzJnL/nCnxxcdYGfmL1Nd6w1K835Ow8C6G/lzFfnulb7cDnzPNB61V4L7a1Qa0jtY6Qdxg==}
     peerDependencies:
       react: '>=17.x'
       react-dom: '>=17.x'
 
-  '@lexical/dragon@0.32.1':
-    resolution: {integrity: sha512-Dlx8P2b/O7gZLmXnoanmDkFL5RgA8Vvix4ZuSvT0apblqySzgi8l3NHHwwqXy1g2nfSupvpr7Dsf10Lu3l0Hlw==}
+  '@lexical/dragon@0.33.0':
+    resolution: {integrity: sha512-p2rE0QUhZ9uhusc1VQX15Vn0+vssZ1jwAuhGvGqFZjb9gGME1FCpfcdIFbKZg547X0/L5aQeFmHrWzAgcnBPeQ==}
 
-  '@lexical/eslint-plugin@0.32.1':
-    resolution: {integrity: sha512-T9SYF0ajl+GAUDePkKom09+IwfcSmTHS+f59GcbVz2t1BNpcaf02Rd+ftwRYVqxkf60m1yQSPonEeYw5Qwqn/g==}
+  '@lexical/eslint-plugin@0.33.0':
+    resolution: {integrity: sha512-gaX6pD1r6fqwu2QbzauAOXaC745ztfMCnJ+DS1YLibNfuctSlDb+oyuZV1M9QE7Hn3pGr1SivUVGFuNLYLr00Q==}
     peerDependencies:
       eslint: '>=7.31.0 || ^8.0.0'
 
-  '@lexical/hashtag@0.32.1':
-    resolution: {integrity: sha512-S63bb7uIB4hO2V0UmzUiKlwAGegQlyFKqrOw9NJwOb8O96gHRxr27FUsEb8ToWLM8TSm2aw1WsZXs7CJQqGtCg==}
+  '@lexical/hashtag@0.33.0':
+    resolution: {integrity: sha512-cHgG5qeiqXdAP5aeues7B8AnCfqzYEbC5sUECEbbozfAg/imhH98cs+4sBjMRh8ong8aZe9BqO6HT6Akf44pxQ==}
 
-  '@lexical/headless@0.32.1':
-    resolution: {integrity: sha512-YAb2d36s75p7RKfKz5WqDqgfa/y3oMmCJOCRmjwsN1WHn8BTij4azzx5x3nkp7U9TMaQDdR9uMr4ISZvjeA0Sw==}
+  '@lexical/headless@0.33.0':
+    resolution: {integrity: sha512-eLhz3o+R3O/IgH+jGcSutxJVvLJttj3uLacYwL+rkZChFoMhAtWSuLgZsQuoWqEAltiEo1YGEHhX4Sfg2E33eg==}
 
-  '@lexical/history@0.32.1':
-    resolution: {integrity: sha512-IRsKllumYEWxmzR2evN30MFY+JBM723lSyzm2PAQcgHCeBxi8t0Vc3EdyJRay+YdN65JgrohQi1WbktbK923uQ==}
+  '@lexical/history@0.33.0':
+    resolution: {integrity: sha512-J1WV4P+9yVAGYIR7cgM5huhKKgVAkh/1YbcOozy+1DiIZAfciHdmVIl3mg9/zxRT1KYS0gJgwsG05IZXtKt29Q==}
 
-  '@lexical/html@0.32.1':
-    resolution: {integrity: sha512-uctCdC9gVzx/Sw9CimT4C2IDfSbfEGYunyIrJBpsfcdqp0rroGNizjIoZNBH3xcgkk9UDboSADo+wimbzEoy8A==}
+  '@lexical/html@0.33.0':
+    resolution: {integrity: sha512-m5xWpxPKNOnlPLSEDHdxHUXJy/WqnQSkHsDD+xQqXN9HwqZY1CaAgnJCWWBwiCNgr1FKZmJOuZd2eS5q1wRtgQ==}
 
-  '@lexical/link@0.32.1':
-    resolution: {integrity: sha512-atdwNpWjZ0U2/kgS0ATTkZ8lJLHiv3TsJgqJL33BuV9Gn7advJokd4faM79Y8XxkhiPi1lVTBSHgI8V4hs+c+Q==}
+  '@lexical/link@0.33.0':
+    resolution: {integrity: sha512-bUz8Nx/bH1neAM0KBfSF2mFTGcHK28QRIwMryecLzDltQHzz6ex3QZSk//MwMV7Ba7MrMDTRCPFjyacGrZEMhg==}
 
-  '@lexical/list@0.32.1':
-    resolution: {integrity: sha512-3zShCfEdAvodR6mQ5CNN1gcEwfV341LXJzWCIkZzG1cPwaiBHUlT7TynQtKTPn1sATCEMmxoDG0/T+itsRNZgA==}
+  '@lexical/list@0.33.0':
+    resolution: {integrity: sha512-NB29jUhteIE7kGT8Nbb7IQYCa6zpYj10j/WbvlKQMG7k6aOcTCFOV2/r3q+TnuvhAshQj88g1wqMSvQt8DfsfA==}
 
-  '@lexical/mark@0.32.1':
-    resolution: {integrity: sha512-AXF2wmUvvSI45y+sgZKnU0pnUdttd9v75DDQgdplqtCkyDqHVGxVCNCrLE+PJtzIrwJxtA2UyC8yFZMBM92HpA==}
+  '@lexical/mark@0.33.0':
+    resolution: {integrity: sha512-ikwPicu/poXdrBwRiFYr9XYGqdT++HHkJXASxiWeOMQqESr1vvDCMIi3Jd3RrfQPuYMGYPARkaqp+OVjHFzRWg==}
 
-  '@lexical/markdown@0.32.1':
-    resolution: {integrity: sha512-AmUTRRx6Je0AOiQqp48Xn92/71AzhFgi4nO1EtPW5eae1CihrtiEh5UQr48mV6EyjvH9D3OlOLU8XrzS+J9a+w==}
+  '@lexical/markdown@0.33.0':
+    resolution: {integrity: sha512-r9Zb3K0I6fwq7+vycL9PGsT6WGvvtKPPfgl9wy/Y6NxtdXMQn7xFGDkUc/rg53ljkvJErdtHLzFTb3rj6lVWsQ==}
 
-  '@lexical/offset@0.32.1':
-    resolution: {integrity: sha512-zfHqoLlQ0lq1akFHy81xnDaRRE5KkqFa7OovOxKPBpALQCiJIAb2ykqj/Woc2oUeYaEcnkaFU9+kEWMK9yY0fQ==}
+  '@lexical/offset@0.33.0':
+    resolution: {integrity: sha512-gig36qLOU49a5jCl+1p9TLE0K5Ax8PQvRTJJNFbHYE5ynCBCS5UORRfYLSpHRUkOVg+H0yQwZUsPzaijXNWd/A==}
 
-  '@lexical/overflow@0.32.1':
-    resolution: {integrity: sha512-wjcFGjzkbugds2Q5Wag59WrcxJwMUACEXms1FtFdu1/YcBPqNAKJSyfo8Z/5LGfstQEb2nPtSuEQZUb7v+XYyA==}
+  '@lexical/overflow@0.33.0':
+    resolution: {integrity: sha512-7Rb1FuCHKQiCfQE8pQjHY6et5vl7+Y7yxWoqrCLGsJteWErMDRaH0tI4iRcIv5um6zMOLW5QSJl2muEn9JXeyA==}
 
-  '@lexical/plain-text@0.32.1':
-    resolution: {integrity: sha512-uFS3xoETB3phnYHZXfMKvl8gh6YRW7rpokuJmQVMHNNBklORmMpN00rRQ/zsc/jt/nPzaPpE5cLwSHXeJdqJUg==}
+  '@lexical/plain-text@0.33.0':
+    resolution: {integrity: sha512-INdAo9GLfnv5un5Bejt/xRNVKoFZGi8lajqVmovkM/oHOThU3CZMJ5uPYdw5psmzIqqcD0oTjorWN0NL9Z2zrQ==}
 
-  '@lexical/react@0.32.1':
-    resolution: {integrity: sha512-PCiAiwGIGfkYb2o9Kx+gGGqXwxqb7/W4cGSnw1nzmNtCerJ3S64WZs87Lgcow0RlDSwqzpH534+eCyIddueSqw==}
+  '@lexical/react@0.33.0':
+    resolution: {integrity: sha512-vkGIOskQZYmk0W6yapBQKTcjX0+Qvx80ZfHpQANNm13Ne8O65cfGFdlHZtI3VS4s17TE3c+0hiFdwlHdFw59FA==}
     peerDependencies:
       react: '>=17.x'
       react-dom: '>=17.x'
 
-  '@lexical/rich-text@0.32.1':
-    resolution: {integrity: sha512-SnmpZ7boTLxeYfNezNLvchDiJOAALA2nD0Uq/SpkIOJ6R01R7m1aPdLv55LGKoBT9UxCRdo0HWXytwiVZI+ehQ==}
+  '@lexical/rich-text@0.33.0':
+    resolution: {integrity: sha512-cR8TfKtnczNDevae9pJgT+3uzGj8WyvxSTEgsyqR4RfCX/94gOrXTOHG02Rm076WNqjTctTKwjgqgJHfHjlKjQ==}
 
-  '@lexical/selection@0.32.1':
-    resolution: {integrity: sha512-X1aXJdq/5EOuSuMOqK3t+rEVmpqLf+vc2Kl5YuP8+gGWUbXuxR6iryrQuy1mAViZpF/5qw4HO/Sb+9JjubaZEg==}
+  '@lexical/selection@0.33.0':
+    resolution: {integrity: sha512-DffmfgnCrnf8OmoFG0d5g3jBn6AYNVA3Aoiyamri+aCX6wjL94D81LMNdnFFLICuHVb8AAmR/v7DA82aHRT8WA==}
 
-  '@lexical/table@0.32.1':
-    resolution: {integrity: sha512-sGk2jUbQHj5hatpxRyl6IE2oWsjRnYhmaP94THzn95/uK69o8eSizcnd148WzYsX8Zz+L9PTLS1xjvCbfLTP+A==}
+  '@lexical/table@0.33.0':
+    resolution: {integrity: sha512-+tZ+nUvhMesIFgy2um7rISWg6l7hsAhShaIhj7ibN0ZfZlAdfy0ZRVmY05BwSBuwG1s9o3oX6CRp25HrNLgZhQ==}
 
-  '@lexical/text@0.32.1':
-    resolution: {integrity: sha512-0Ek8F3KC4d16b2YaTHdyYFqDSBZ5KRtGrqU3GBog+VOGxucGaEbXEK1/ypX5CTe/wwkQDrH0FKWPQbd3l5t5YQ==}
+  '@lexical/text@0.33.0':
+    resolution: {integrity: sha512-17utR5AompKZhnPKFM+dRXl4838DelSTa9nGdqup9tIQ7b88W7tXhNnE8CVcrn9EJhujh6Cf4Liip6wE0MAs0A==}
 
-  '@lexical/utils@0.32.1':
-    resolution: {integrity: sha512-ZaqZZksNIHJd+g8GXc11D1ESi8JzsdLVQZ+9odXVaNxtwDIaGIqMSccFyuZ9VSoJDde4JXZkgp/0PShbAZDkyw==}
+  '@lexical/utils@0.33.0':
+    resolution: {integrity: sha512-vqjRMjokCEK/UXNIITMaFb00Q15bxr65hvAZfaHPCVHV7CDZxOjwi2hqA/HuTZAknIlFuWzfucPla6pBY/cldw==}
 
-  '@lexical/yjs@0.32.1':
-    resolution: {integrity: sha512-VHGTg5z4wcDkPe8NnhzA5+CoOKJ5tVmTmMvoiZ91rtNUFQPxWRky88Gjt1e3yXldYp4pImNEgtAjlWqvaJBYGA==}
+  '@lexical/yjs@0.33.0':
+    resolution: {integrity: sha512-BkYv8b2n0i1qMEk5q3P91yt/GIQP9qxD1scr7M4IVH+9o/FR+kCfQJJKX1oe8Q22XYFvp0O0LzEyMzqG+G9SYw==}
     peerDependencies:
       yjs: '>=13.5.22'
 
@@ -5265,8 +5268,8 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  lexical@0.32.1:
-    resolution: {integrity: sha512-Rvr9p00zUwzjXIqElIjMDyl/24QHw68yaqmXUWIT3lSdSAr8OpjSJK3iWBLZwVZwwpVhwShZRckomc+3vSb/zw==}
+  lexical@0.33.0:
+    resolution: {integrity: sha512-kH8EvPi0Ptgu+PGKeZKfZKXMpImkdVHXKoVFcseb0R/4Jkc/DzmR2VN1Z8n9UHQqxdgC9e0tSrN8iKWHZOtDKw==}
 
   lib0@0.2.108:
     resolution: {integrity: sha512-+3eK/B0SqYoZiQu9fNk4VEc6EX8cb0Li96tPGKgugzoGj/OdRdREtuTLvUW+mtinoB2mFiJjSqOJBIaMkAGhxQ==}
@@ -8230,18 +8233,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@floating-ui/core@1.7.1':
+  '@floating-ui/core@1.7.2':
     dependencies:
-      '@floating-ui/utils': 0.2.9
+      '@floating-ui/utils': 0.2.10
 
-  '@floating-ui/dom@1.7.1':
+  '@floating-ui/dom@1.7.2':
     dependencies:
-      '@floating-ui/core': 1.7.1
-      '@floating-ui/utils': 0.2.9
+      '@floating-ui/core': 1.7.2
+      '@floating-ui/utils': 0.2.10
 
   '@floating-ui/react-dom@2.1.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@floating-ui/dom': 1.7.1
+      '@floating-ui/dom': 1.7.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
@@ -8252,6 +8255,8 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tabbable: 6.2.0
+
+  '@floating-ui/utils@0.2.10': {}
 
   '@floating-ui/utils@0.2.9': {}
 
@@ -8508,158 +8513,158 @@ snapshots:
     dependencies:
       jsep: 1.4.0
 
-  '@lexical/clipboard@0.32.1':
+  '@lexical/clipboard@0.33.0':
     dependencies:
-      '@lexical/html': 0.32.1
-      '@lexical/list': 0.32.1
-      '@lexical/selection': 0.32.1
-      '@lexical/utils': 0.32.1
-      lexical: 0.32.1
+      '@lexical/html': 0.33.0
+      '@lexical/list': 0.33.0
+      '@lexical/selection': 0.33.0
+      '@lexical/utils': 0.33.0
+      lexical: 0.33.0
 
-  '@lexical/code@0.32.1':
+  '@lexical/code@0.33.0':
     dependencies:
-      '@lexical/utils': 0.32.1
-      lexical: 0.32.1
+      '@lexical/utils': 0.33.0
+      lexical: 0.33.0
       prismjs: 1.30.0
 
-  '@lexical/devtools-core@0.32.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@lexical/devtools-core@0.33.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@lexical/html': 0.32.1
-      '@lexical/link': 0.32.1
-      '@lexical/mark': 0.32.1
-      '@lexical/table': 0.32.1
-      '@lexical/utils': 0.32.1
-      lexical: 0.32.1
+      '@lexical/html': 0.33.0
+      '@lexical/link': 0.33.0
+      '@lexical/mark': 0.33.0
+      '@lexical/table': 0.33.0
+      '@lexical/utils': 0.33.0
+      lexical: 0.33.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@lexical/dragon@0.32.1':
+  '@lexical/dragon@0.33.0':
     dependencies:
-      lexical: 0.32.1
+      lexical: 0.33.0
 
-  '@lexical/eslint-plugin@0.32.1(eslint@9.29.0(jiti@1.21.7))':
+  '@lexical/eslint-plugin@0.33.0(eslint@9.29.0(jiti@1.21.7))':
     dependencies:
       eslint: 9.29.0(jiti@1.21.7)
 
-  '@lexical/hashtag@0.32.1':
+  '@lexical/hashtag@0.33.0':
     dependencies:
-      '@lexical/utils': 0.32.1
-      lexical: 0.32.1
+      '@lexical/utils': 0.33.0
+      lexical: 0.33.0
 
-  '@lexical/headless@0.32.1':
+  '@lexical/headless@0.33.0':
     dependencies:
-      lexical: 0.32.1
+      lexical: 0.33.0
 
-  '@lexical/history@0.32.1':
+  '@lexical/history@0.33.0':
     dependencies:
-      '@lexical/utils': 0.32.1
-      lexical: 0.32.1
+      '@lexical/utils': 0.33.0
+      lexical: 0.33.0
 
-  '@lexical/html@0.32.1':
+  '@lexical/html@0.33.0':
     dependencies:
-      '@lexical/selection': 0.32.1
-      '@lexical/utils': 0.32.1
-      lexical: 0.32.1
+      '@lexical/selection': 0.33.0
+      '@lexical/utils': 0.33.0
+      lexical: 0.33.0
 
-  '@lexical/link@0.32.1':
+  '@lexical/link@0.33.0':
     dependencies:
-      '@lexical/utils': 0.32.1
-      lexical: 0.32.1
+      '@lexical/utils': 0.33.0
+      lexical: 0.33.0
 
-  '@lexical/list@0.32.1':
+  '@lexical/list@0.33.0':
     dependencies:
-      '@lexical/selection': 0.32.1
-      '@lexical/utils': 0.32.1
-      lexical: 0.32.1
+      '@lexical/selection': 0.33.0
+      '@lexical/utils': 0.33.0
+      lexical: 0.33.0
 
-  '@lexical/mark@0.32.1':
+  '@lexical/mark@0.33.0':
     dependencies:
-      '@lexical/utils': 0.32.1
-      lexical: 0.32.1
+      '@lexical/utils': 0.33.0
+      lexical: 0.33.0
 
-  '@lexical/markdown@0.32.1':
+  '@lexical/markdown@0.33.0':
     dependencies:
-      '@lexical/code': 0.32.1
-      '@lexical/link': 0.32.1
-      '@lexical/list': 0.32.1
-      '@lexical/rich-text': 0.32.1
-      '@lexical/text': 0.32.1
-      '@lexical/utils': 0.32.1
-      lexical: 0.32.1
+      '@lexical/code': 0.33.0
+      '@lexical/link': 0.33.0
+      '@lexical/list': 0.33.0
+      '@lexical/rich-text': 0.33.0
+      '@lexical/text': 0.33.0
+      '@lexical/utils': 0.33.0
+      lexical: 0.33.0
 
-  '@lexical/offset@0.32.1':
+  '@lexical/offset@0.33.0':
     dependencies:
-      lexical: 0.32.1
+      lexical: 0.33.0
 
-  '@lexical/overflow@0.32.1':
+  '@lexical/overflow@0.33.0':
     dependencies:
-      lexical: 0.32.1
+      lexical: 0.33.0
 
-  '@lexical/plain-text@0.32.1':
+  '@lexical/plain-text@0.33.0':
     dependencies:
-      '@lexical/clipboard': 0.32.1
-      '@lexical/selection': 0.32.1
-      '@lexical/utils': 0.32.1
-      lexical: 0.32.1
+      '@lexical/clipboard': 0.33.0
+      '@lexical/selection': 0.33.0
+      '@lexical/utils': 0.33.0
+      lexical: 0.33.0
 
-  '@lexical/react@0.32.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.27)':
+  '@lexical/react@0.33.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.27)':
     dependencies:
       '@floating-ui/react': 0.27.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lexical/devtools-core': 0.32.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lexical/dragon': 0.32.1
-      '@lexical/hashtag': 0.32.1
-      '@lexical/history': 0.32.1
-      '@lexical/link': 0.32.1
-      '@lexical/list': 0.32.1
-      '@lexical/mark': 0.32.1
-      '@lexical/markdown': 0.32.1
-      '@lexical/overflow': 0.32.1
-      '@lexical/plain-text': 0.32.1
-      '@lexical/rich-text': 0.32.1
-      '@lexical/table': 0.32.1
-      '@lexical/text': 0.32.1
-      '@lexical/utils': 0.32.1
-      '@lexical/yjs': 0.32.1(yjs@13.6.27)
-      lexical: 0.32.1
+      '@lexical/devtools-core': 0.33.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lexical/dragon': 0.33.0
+      '@lexical/hashtag': 0.33.0
+      '@lexical/history': 0.33.0
+      '@lexical/link': 0.33.0
+      '@lexical/list': 0.33.0
+      '@lexical/mark': 0.33.0
+      '@lexical/markdown': 0.33.0
+      '@lexical/overflow': 0.33.0
+      '@lexical/plain-text': 0.33.0
+      '@lexical/rich-text': 0.33.0
+      '@lexical/table': 0.33.0
+      '@lexical/text': 0.33.0
+      '@lexical/utils': 0.33.0
+      '@lexical/yjs': 0.33.0(yjs@13.6.27)
+      lexical: 0.33.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-error-boundary: 3.1.4(react@18.3.1)
     transitivePeerDependencies:
       - yjs
 
-  '@lexical/rich-text@0.32.1':
+  '@lexical/rich-text@0.33.0':
     dependencies:
-      '@lexical/clipboard': 0.32.1
-      '@lexical/selection': 0.32.1
-      '@lexical/utils': 0.32.1
-      lexical: 0.32.1
+      '@lexical/clipboard': 0.33.0
+      '@lexical/selection': 0.33.0
+      '@lexical/utils': 0.33.0
+      lexical: 0.33.0
 
-  '@lexical/selection@0.32.1':
+  '@lexical/selection@0.33.0':
     dependencies:
-      lexical: 0.32.1
+      lexical: 0.33.0
 
-  '@lexical/table@0.32.1':
+  '@lexical/table@0.33.0':
     dependencies:
-      '@lexical/clipboard': 0.32.1
-      '@lexical/utils': 0.32.1
-      lexical: 0.32.1
+      '@lexical/clipboard': 0.33.0
+      '@lexical/utils': 0.33.0
+      lexical: 0.33.0
 
-  '@lexical/text@0.32.1':
+  '@lexical/text@0.33.0':
     dependencies:
-      lexical: 0.32.1
+      lexical: 0.33.0
 
-  '@lexical/utils@0.32.1':
+  '@lexical/utils@0.33.0':
     dependencies:
-      '@lexical/list': 0.32.1
-      '@lexical/selection': 0.32.1
-      '@lexical/table': 0.32.1
-      lexical: 0.32.1
+      '@lexical/list': 0.33.0
+      '@lexical/selection': 0.33.0
+      '@lexical/table': 0.33.0
+      lexical: 0.33.0
 
-  '@lexical/yjs@0.32.1(yjs@13.6.27)':
+  '@lexical/yjs@0.33.0(yjs@13.6.27)':
     dependencies:
-      '@lexical/offset': 0.32.1
-      '@lexical/selection': 0.32.1
-      lexical: 0.32.1
+      '@lexical/offset': 0.33.0
+      '@lexical/selection': 0.33.0
+      lexical: 0.33.0
       yjs: 13.6.27
 
   '@microsoft/api-extractor-model@7.30.6(@types/node@20.19.1)':
@@ -13429,7 +13434,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  lexical@0.32.1: {}
+  lexical@0.33.0: {}
 
   lib0@0.2.108:
     dependencies:


### PR DESCRIPTION
Updated lexical pacakge to v0.33.0
`vite-plugin-dts` still held at `v4.5.3` due to the regression bug 