### PR TITLE
fix NoteNodePlugin test warning

### DIFF
--- a/packages/shared-react/plugins/usj/NoteNodePlugin.test.tsx
+++ b/packages/shared-react/plugins/usj/NoteNodePlugin.test.tsx
@@ -8,7 +8,7 @@ import {
 import { $createImmutableVerseNode } from "../../nodes/usj/ImmutableVerseNode";
 import { UsjNodeOptions } from "../../nodes/usj/usj-node-options.model";
 import { ViewOptions } from "../../views/view-options.utils";
-import { NoteNodePlugin } from "./NoteNodePlugin";
+import { CounterStyleRuleLike, NoteNodePlugin } from "./NoteNodePlugin";
 import { baseTestEnvironment } from "./react-test.utils";
 import { act } from "@testing-library/react";
 import {
@@ -25,6 +25,7 @@ import { NBSP } from "shared/nodes/usj/node-constants";
 import { $createNoteNode, NoteNode } from "shared/nodes/usj/NoteNode";
 import { $createParaNode } from "shared/nodes/usj/ParaNode";
 
+let styleSheetsSpy: jest.SpyInstance;
 let firstVerseTextNode: TextNode;
 let firstNoteNode: NoteNode;
 let secondNoteNode: NoteNode;
@@ -59,6 +60,28 @@ function $defaultInitialEditorState() {
     $createParaNode().append(thirdVerseNode, thirdNoteNode, thirdVerseTextNode),
   );
 }
+
+beforeAll(() => {
+  const fakeRule: CounterStyleRuleLike = {
+    name: "note-callers",
+    symbols:
+      '"a" "b" "c" "d" "e" "f" "g" "h" "i" "j" "k" "l" "m" "n" "o" "p" "q" "r" "s" "t" "u" "v" "w" "x" "y" "z"',
+    type: 11, // CSSRule.COUNTER_STYLE_RULE
+  };
+  const fakeStyleSheet = {
+    cssRules: [fakeRule],
+    rules: [fakeRule],
+  };
+  styleSheetsSpy = jest
+    .spyOn(document, "styleSheets", "get")
+    .mockImplementation(() => [fakeStyleSheet] as any);
+});
+
+afterAll(() => {
+  if (styleSheetsSpy) {
+    styleSheetsSpy.mockRestore();
+  }
+});
 
 describe("NoteNodePlugin", () => {
   it("should load default initialEditorState (sanity check)", async () => {

--- a/packages/shared-react/plugins/usj/NoteNodePlugin.tsx
+++ b/packages/shared-react/plugins/usj/NoteNodePlugin.tsx
@@ -27,6 +27,12 @@ import { $isCharNode, CharNode } from "shared/nodes/usj/CharNode";
 import { $isNoteNode, NoteNode } from "shared/nodes/usj/NoteNode";
 import { $findFirstAncestorNoteNode, getNoteCallerPreviewText } from "shared/nodes/usj/node.utils";
 
+export interface CounterStyleRuleLike {
+  name: string;
+  symbols: string;
+  type?: number;
+}
+
 /**
  * This plugin is responsible for handling NoteNode and NoteNodeCaller interactions. It also
  * updates the counter style symbols for note callers when the node options change.
@@ -224,8 +230,7 @@ function updateCounterStyleSymbols(
 
       // Loop through all CSS rules in the current stylesheet
       for (const rule of cssRules) {
-        // Check if the rule is a counter-style rule with the matching name
-        if (rule instanceof CSSCounterStyleRule && rule.name === counterStyleName) {
+        if (isCounterStyleRuleLike(rule, counterStyleName)) {
           // Create the symbols string (space-separated symbols)
           const symbolsValue = newSymbols.map((symbol) => `"${symbol}"`).join(" ");
 
@@ -242,4 +247,19 @@ function updateCounterStyleSymbols(
 
   // If the counter-style wasn't found, you could create it
   logger?.warn(`Editor: counter style "${counterStyleName}" not found.`);
+}
+
+function isCounterStyleRuleLike(
+  rule: unknown,
+  counterStyleName: string,
+): rule is CSSCounterStyleRule | CounterStyleRuleLike {
+  return (
+    // This check could be simpler but as is also works for test mocks.
+    typeof rule === "object" &&
+    rule !== null &&
+    "name" in rule &&
+    rule.name === counterStyleName &&
+    "symbols" in rule &&
+    typeof rule.symbols === "string"
+  );
 }


### PR DESCRIPTION
- properly mocks the CSS rule. Now symbol updates can be checked using the spy.