### PR TITLE
platform: BREAKING CHANGE: changed annotation and comment classnames

### DIFF
--- a/libs/shared/src/nodes/features/TypedMarkNode.ts
+++ b/libs/shared/src/nodes/features/TypedMarkNode.ts
@@ -35,8 +35,8 @@ export type SerializedTypedMarkNode = Spread<
   SerializedElementNode
 >;
 
-/** Reserved type for CommentPlugin. */
-export const COMMENT_MARK_TYPE = "comment";
+/** Reserved mark type for CommentPlugin. */
+export const COMMENT_MARK_TYPE = "internal-comment";
 
 /**
  * The name identifier for the typed mark node class.
@@ -376,4 +376,15 @@ export function $getMarkIDs(node: TextNode, type: string, offset: number): strin
     currentNode = currentNode.getParent();
   }
   return undefined;
+}
+
+/**
+ * Gets the external typed mark type.
+ *
+ * @remarks
+ * This is used to ensure unique identification of external typed marks. Along with reserved types
+ * prefaced with 'internal-' for internal typed marks @see {@link COMMENT_MARK_TYPE}.
+ */
+export function externalTypedMarkType(type: string): string {
+  return `external-${type}`;
 }

--- a/packages/platform/README.md
+++ b/packages/platform/README.md
@@ -156,9 +156,13 @@ If using the **commenting features** in the `<Marginal />` component:
 
 ### Annotation Styles
 
-Annotations are added with a specific `type` via the editor's reference API (see [Editorial Ref](#editorial-ref)). This `type` can then be used to apply custom CSS styles (e.g., a green squiggly underline for a _"grammar"_ type annotation). The CSS classname for an annotation takes the form of `.${annotationPrefix}-${type}`, where `type` is the string you pass to the `addAnnotation()` method and `annotationPrefix` is set by `config.theme.typedMark` (defaults to _"editor-typed-mark"_). If annotations overlap with each other an additional CSS classname is added where `annotationPrefix` is set by `config.theme.typedMarkOverlap` (defaults to _"editor-typed-markOverlap"_).
+Annotations are added with a specific `type` via the editor's reference API (see [Editorial Ref](#editorial-ref)). This `type` can then be used to apply custom CSS styles (e.g., a green squiggly underline for a _"grammar"_ type annotation). The CSS classname for an annotation takes the form of `.${annotationPrefix}-external-${type}`, where `type` is the string you pass to the `addAnnotation()` method and `annotationPrefix` is set by `config.theme.typedMark` (defaults to _"editor-typed-mark"_). If annotations overlap with each other an additional CSS classname is added where `annotationPrefix` is set by `config.theme.typedMarkOverlap` (defaults to _"editor-typed-markOverlap"_).
 
-For example, if an annotation of type _"grammar"_ is overlapping it will have both CSS classnames `editor-typed-mark-grammar` and `editor-typed-markOverlap-grammar`. If it's not overlapping it still has the first classname.
+For example, if an annotation of type _"grammar"_ is overlapping it will have both CSS classnames `editor-typed-mark-external-grammar` and `editor-typed-markOverlap-external-grammar`. If it's not overlapping it still has the first classname. Annotations and comments are the same when considering if it's overlapping.
+
+### Comment Styles
+
+These follow a similar patter to [Annotation Styles](#annotation-styles). If a comment is overlapping it will have both CSS classnames `editor-typed-mark-internal-comment` and `editor-typed-markOverlap-internal-comment`. If it's not overlapping it still has the first classname. Annotations and comments are the same when considering if it's overlapping.
 
 ## `<Editorial />` API
 

--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -60,6 +60,7 @@ import {
 import {
   blackListedChangeTags,
   DELTA_CHANGE_TAG,
+  externalTypedMarkType,
   LoggerBasic,
   SELECTION_CHANGE_TAG,
   TypedMarkNode,
@@ -246,10 +247,10 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
       );
     },
     addAnnotation(selection, type, id) {
-      annotationRef.current?.addAnnotation(selection, type, id);
+      annotationRef.current?.addAnnotation(selection, externalTypedMarkType(type), id);
     },
     removeAnnotation(type, id) {
-      annotationRef.current?.removeAnnotation(type, id);
+      annotationRef.current?.removeAnnotation(externalTypedMarkType(type), id);
     },
     get toolbarEndRef() {
       return toolbarEndRef;

--- a/packages/platform/src/editor/editor.css
+++ b/packages/platform/src/editor/editor.css
@@ -151,46 +151,46 @@
   color: #dd4a68;
 }
 
-.editor-typed-mark-spelling {
+.editor-typed-mark-external-spelling {
   background: inherit;
   text-decoration: underline wavy red;
 }
 
-.editor-typed-mark-grammar {
+.editor-typed-mark-external-grammar {
   background: inherit;
   text-decoration: underline wavy grey;
 }
 
-.editor-typed-mark-other {
+.editor-typed-mark-external-other {
   background: inherit;
   text-decoration: underline wavy green;
 }
 
-.editor-typed-mark-spelling.editor-typed-mark-grammar {
+.editor-typed-mark-external-spelling.editor-typed-mark-external-grammar {
   text-decoration-color: rgb(192, 64, 64);
 }
 
-.editor-typed-mark-spelling.editor-typed-mark-grammar.editor-typed-mark-other {
+.editor-typed-mark-external-spelling.editor-typed-mark-external-grammar.editor-typed-mark-external-other {
   text-decoration-color: rgb(128, 85, 43);
 }
 
-.editor-typed-mark-comment {
+.editor-typed-mark-internal-comment {
   background: rgba(255, 212, 0, 0.14);
   border-bottom: 2px solid rgba(255, 212, 0, 0.3);
   padding-bottom: 2px;
 }
 
-.editor-typed-mark-comment.selected {
+.editor-typed-mark-internal-comment.selected {
   background: rgba(255, 212, 0, 0.5);
   border-bottom: 2px solid rgba(255, 212, 0, 1);
 }
 
-.editor-typed-markOverlap-comment {
+.editor-typed-markOverlap-internal-comment {
   background: rgba(255, 212, 0, 0.3);
   border-bottom: 2px solid rgba(255, 212, 0, 0.7);
 }
 
-.editor-typed-markOverlap-comment.selected {
+.editor-typed-markOverlap-internal-comment.selected {
   background: rgba(255, 212, 0, 0.7);
   border-bottom: 2px solid rgba(255, 212, 0, 0.7);
 }

--- a/packages/utilities/src/converters/usj/converter-test.data.ts
+++ b/packages/utilities/src/converters/usj/converter-test.data.ts
@@ -1202,7 +1202,7 @@ export const editorStateMarks = {
           },
           {
             type: "typed-mark",
-            typedIDs: { comment: [] },
+            typedIDs: { "internal-comment": [] },
             direction: null,
             format: "",
             indent: 0,
@@ -1251,7 +1251,7 @@ export const editorStateMarks = {
           },
           {
             type: "typed-mark",
-            typedIDs: { comment: ["1"] },
+            typedIDs: { "internal-comment": ["1"] },
             direction: null,
             format: "",
             indent: 0,
@@ -1300,7 +1300,7 @@ export const editorStateMarks = {
           },
           {
             type: "typed-mark",
-            typedIDs: { comment: ["1"] },
+            typedIDs: { "internal-comment": ["1"] },
             direction: null,
             format: "",
             indent: 0,
@@ -1319,7 +1319,7 @@ export const editorStateMarks = {
           },
           {
             type: "typed-mark",
-            typedIDs: { comment: ["2"] },
+            typedIDs: { "internal-comment": ["2"] },
             direction: null,
             format: "",
             indent: 0,
@@ -1368,7 +1368,7 @@ export const editorStateMarks = {
           },
           {
             type: "typed-mark",
-            typedIDs: { comment: ["1"] },
+            typedIDs: { "internal-comment": ["1"] },
             direction: null,
             format: "",
             indent: 0,
@@ -1387,7 +1387,7 @@ export const editorStateMarks = {
           },
           {
             type: "typed-mark",
-            typedIDs: { comment: ["1", "2"] },
+            typedIDs: { "internal-comment": ["1", "2"] },
             direction: null,
             format: "",
             indent: 0,
@@ -1406,7 +1406,7 @@ export const editorStateMarks = {
           },
           {
             type: "typed-mark",
-            typedIDs: { comment: ["2"] },
+            typedIDs: { "internal-comment": ["2"] },
             direction: null,
             format: "",
             indent: 0,
@@ -1446,7 +1446,7 @@ export const editorStateMarks = {
           },
           {
             type: "typed-mark",
-            typedIDs: { comment: ["1"] },
+            typedIDs: { "internal-comment": ["1"] },
             direction: null,
             format: "",
             indent: 0,
@@ -1465,7 +1465,7 @@ export const editorStateMarks = {
           },
           {
             type: "typed-mark",
-            typedIDs: { comment: ["1", "2"] },
+            typedIDs: { "internal-comment": ["1", "2"] },
             direction: null,
             format: "",
             indent: 0,
@@ -1484,7 +1484,7 @@ export const editorStateMarks = {
           },
           {
             type: "typed-mark",
-            typedIDs: { comment: ["1"] },
+            typedIDs: { "internal-comment": ["1"] },
             direction: null,
             format: "",
             indent: 0,


### PR DESCRIPTION
- unique TypedMarkNode type between annotations and comments
- comments now have classnames of `editor-typed-mark-internal-comment` and `editor-typed-markOverlap-internal-comment`
- if your annotation type is "grammar" the class names are now `editor-typed-mark-external-grammar` and `editor-typed-markOverlap-external-grammar`