### PR TITLE
BREAKING CHANGE: simplify `NodeOptions`

### DIFF
--- a/demos/platform/src/app/app.tsx
+++ b/demos/platform/src/app/app.tsx
@@ -10,7 +10,6 @@ import {
   EditorOptions,
   getDefaultViewMode,
   getViewOptions,
-  immutableNoteCallerNodeName,
   Marginal,
   MarginalRef,
   TextDirection,
@@ -33,7 +32,8 @@ interface Annotations {
 const defaultUsj = usxStringToUsj('<usx version="3.1" />');
 const defaultScrRef: SerializedVerseRef = { book: "PSA", chapterNum: 1, verseNum: 1 };
 const nodeOptions: UsjNodeOptions = {
-  [immutableNoteCallerNodeName]: { onClick: () => console.log("note node clicked") },
+  noteCallerOnClick: () => console.log("note node clicked"),
+  noteCallers: ["n1", "n2", "n3", "n4", "n5", "n6"],
 };
 // Word "man" inside first q1 of PSA 1:1.
 const annotationRange1 = {

--- a/libs/shared-react/src/nodes/usj/ImmutableNoteCallerNode.tsx
+++ b/libs/shared-react/src/nodes/usj/ImmutableNoteCallerNode.tsx
@@ -36,23 +36,6 @@ export type SerializedImmutableNoteCallerNode = Spread<
 export const GENERATOR_NOTE_CALLER = "+";
 export const IMMUTABLE_NOTE_CALLER_VERSION = 1;
 
-/**
- * The name identifier for the immutable note caller node class.
- *
- * @remarks
- * This constant is used to identify and reference options for an ImmutableNoteCallerNode instance.
- *
- * @example
- * ```tsx
- * const nodeOptions: UsjNodeOptions = {
- *  [immutableNoteCallerNodeName]: { onClick: () => console.log("note node clicked") },
- * };
- * ```
- *
- * @public
- */
-export const immutableNoteCallerNodeName = "ImmutableNoteCallerNode";
-
 export class ImmutableNoteCallerNode extends DecoratorNode<ReactNode> {
   __caller: string;
   __previewText: string;

--- a/libs/shared-react/src/nodes/usj/usj-node-options.model.ts
+++ b/libs/shared-react/src/nodes/usj/usj-node-options.model.ts
@@ -1,5 +1,5 @@
-import { NodeOptions, typedMarkNodeName } from "shared";
-import { OnClick, immutableNoteCallerNodeName } from "./ImmutableNoteCallerNode";
+import { NodeOptions } from "shared";
+import { OnClick } from "./ImmutableNoteCallerNode";
 
 /**
  * A function type that adds missing comments to a USJ document.
@@ -16,16 +16,10 @@ export type AddMissingComments = (usjCommentIds: string[]) => void;
  * @public
  */
 export interface UsjNodeOptions extends NodeOptions {
-  /** Configuration options for immutable note caller nodes. */
-  [immutableNoteCallerNodeName]?: {
-    /** Possible note callers to use when caller is '+'. Defaults to lowercase Latin characters. */
-    noteCallers?: string[];
-    /** Click handler method. */
-    onClick?: OnClick;
-  };
-  /** Configuration options for typed mark nodes. */
-  [typedMarkNodeName]?: {
-    /** Method to add missing comments. */
-    addMissingComments?: AddMissingComments;
-  };
+  /** Possible note callers to use when caller is '+'. Defaults to lowercase Latin characters. */
+  noteCallers?: string[];
+  /** Note caller click handler method. */
+  noteCallerOnClick?: OnClick;
+  /** Method to add missing comments. */
+  addMissingComments?: AddMissingComments;
 }

--- a/libs/shared-react/src/plugins/usj/NoteNodePlugin.test.tsx
+++ b/libs/shared-react/src/plugins/usj/NoteNodePlugin.test.tsx
@@ -3,7 +3,6 @@ import {
   defaultNoteCallers,
   GENERATOR_NOTE_CALLER,
   ImmutableNoteCallerNode,
-  immutableNoteCallerNodeName,
 } from "../../nodes/usj/ImmutableNoteCallerNode";
 import { $createImmutableVerseNode } from "../../nodes/usj/ImmutableVerseNode";
 import { UsjNodeOptions } from "../../nodes/usj/usj-node-options.model";
@@ -172,9 +171,7 @@ describe("NoteNodePlugin", () => {
 });
 
 async function testEnvironment(
-  nodeOptions: UsjNodeOptions = {
-    [immutableNoteCallerNodeName]: { noteCallers: defaultNoteCallers },
-  },
+  nodeOptions: UsjNodeOptions = { noteCallers: defaultNoteCallers },
   viewOptions: ViewOptions = { markerMode: "hidden", hasSpacing: true, isFormattedFont: true },
   $initialEditorState: () => void = $defaultInitialEditorState,
 ) {

--- a/libs/shared-react/src/plugins/usj/NoteNodePlugin.tsx
+++ b/libs/shared-react/src/plugins/usj/NoteNodePlugin.tsx
@@ -3,7 +3,6 @@ import {
   defaultNoteCallers,
   GENERATOR_NOTE_CALLER,
   ImmutableNoteCallerNode,
-  immutableNoteCallerNodeName,
 } from "../../nodes/usj/ImmutableNoteCallerNode";
 import { UsjNodeOptions } from "../../nodes/usj/usj-node-options.model";
 import { ViewOptions } from "../../views/view-options.utils";
@@ -68,7 +67,7 @@ export function NoteNodePlugin<TLogger extends LoggerBasic>({
  */
 function useNodeOptions(nodeOptions: UsjNodeOptions, logger?: LoggerBasic) {
   const previousNoteCallersRef = useRef<string[] | undefined>(undefined);
-  const nodeOptionsNoteCallers = nodeOptions[immutableNoteCallerNodeName]?.noteCallers;
+  const nodeOptionsNoteCallers = nodeOptions.noteCallers;
 
   useEffect(() => {
     let noteCallers = nodeOptionsNoteCallers;

--- a/libs/shared-react/src/plugins/usj/collab/delta-apply-update.utils.ts
+++ b/libs/shared-react/src/plugins/usj/collab/delta-apply-update.utils.ts
@@ -1,7 +1,6 @@
 import {
   $createImmutableNoteCallerNode,
   ImmutableNoteCallerNode,
-  immutableNoteCallerNodeName,
   OnClick,
 } from "../../../nodes/usj/ImmutableNoteCallerNode";
 import { $createImmutableVerseNode } from "../../../nodes/usj/ImmutableVerseNode";
@@ -1601,8 +1600,8 @@ function $createNote(op: DeltaOp, viewOptions: ViewOptions, nodeOptions: UsjNode
   } else {
     const previewText = getNoteCallerPreviewText(contentNodes);
     let onClick: OnClick = () => undefined;
-    if (nodeOptions?.[immutableNoteCallerNodeName]?.onClick) {
-      onClick = nodeOptions[immutableNoteCallerNodeName].onClick;
+    if (nodeOptions?.noteCallerOnClick) {
+      onClick = nodeOptions.noteCallerOnClick;
     }
     callerNode = $createImmutableNoteCallerNode(caller, previewText, onClick);
   }

--- a/libs/shared/src/adaptors/editor-adaptor.model.ts
+++ b/libs/shared/src/adaptors/editor-adaptor.model.ts
@@ -8,7 +8,7 @@ import { LoggerBasic } from "./logger-basic.model.js";
  */
 export interface NodeOptions {
   /** Configuration options for any node. */
-  [nodeClassName: string]: { [prop: string]: unknown } | undefined;
+  [prop: string]: unknown;
 }
 
 export interface EditorAdaptor {

--- a/libs/shared/src/nodes/features/TypedMarkNode.ts
+++ b/libs/shared/src/nodes/features/TypedMarkNode.ts
@@ -38,23 +38,6 @@ export type SerializedTypedMarkNode = Spread<
 /** Reserved mark type for CommentPlugin. */
 export const COMMENT_MARK_TYPE = "internal-comment";
 
-/**
- * The name identifier for the typed mark node class.
- *
- * @remarks
- * This constant is used to identify and reference options for a TypedMarkNode instance.
- *
- * @example
- * ```tsx
- * const nodeOptions: UsjNodeOptions = {
- *  [typedMarkNodeName]: { addMissingComments: () => console.log("added missing comments") },
- * };
- * ```
- *
- * @public
- */
-export const typedMarkNodeName = "TypedMarkNode";
-
 const reservedTypes = [COMMENT_MARK_TYPE];
 const TYPED_MARK_VERSION = 1;
 

--- a/libs/shared/src/nodes/usj/NoteNode.ts
+++ b/libs/shared/src/nodes/usj/NoteNode.ts
@@ -39,7 +39,6 @@ export type SerializedNoteNode = Spread<
 
 export const NOTE_VERSION = 1;
 
-export const noteNodeName = "NoteNode";
 export class NoteNode extends ElementNode {
   __marker: string;
   __caller: string;

--- a/packages/platform/README.md
+++ b/packages/platform/README.md
@@ -37,7 +37,7 @@ npm install @eten-tech-foundation/platform-editor
 > - Use the `<Marginal />` component for an editor with comments (comments appear in the margin).
 
 ```ts
-import { EditorOptions, immutableNoteCallerNodeName, Marginal, MarginalRef, usxStringToUsj, UsjNodeOptions } from "@eten-tech-foundation/platform-editor";
+import { EditorOptions, Marginal, MarginalRef, usxStringToUsj, UsjNodeOptions } from "@eten-tech-foundation/platform-editor";
 import { BookChapterControl } from "platform-bible-react";
 
 const emptyUsx = '<usx version="3.1" />';
@@ -54,7 +54,7 @@ const usx = `<?xml version="1.0" encoding="utf-8"?>
 `;
 const defaultUsj = usxStringToUsj(emptyUsx);
 const defaultScrRef = { book: "PSA", chapterNum: 1, verseNum: 1 };
-const nodeOptions: UsjNodeOptions = { [immutableNoteCallerNodeName]: { onClick: () => console.log("Note was clicked!") } };
+const nodeOptions: UsjNodeOptions = { noteCallerOnClick: () => console.log("Note was clicked!") };
 const options: EditorOptions = { isReadonly: false, textDirection: "ltr", nodes: nodeOptions };
 // Word "man" inside first q1 of PSA 1:1.
 const annotationRange1 = {
@@ -257,15 +257,9 @@ export interface EditorOptions {
 In `EditorOptions.nodes`, the note callers option defaults to:
 
 ```ts
-import {
-  EditorOptions,
-  immutableNoteCallerNodeName,
-  UsjNodeOptions,
-} from "@eten-tech-foundation/platform-editor";
+import { EditorOptions, UsjNodeOptions } from "@eten-tech-foundation/platform-editor";
 
-const nodes: UsjNodeOptions = {
-  [immutableNoteCallerNodeName]: { noteCallers: ["a", "b", "c", ... , "x", "y", "z"] },
-};
+const nodes: UsjNodeOptions = { noteCallers: ["a", "b", "c", ... , "x", "y", "z"] };
 const options: EditorOptions = { nodes };
 ```
 

--- a/packages/platform/etc/platform-editor.api.md
+++ b/packages/platform/etc/platform-editor.api.md
@@ -96,9 +96,6 @@ export function getViewMode(viewOptions: ViewOptions | undefined): ViewMode | un
 export function getViewOptions(viewMode?: string | undefined): ViewOptions | undefined;
 
 // @public
-export const immutableNoteCallerNodeName = "ImmutableNoteCallerNode";
-
-// @public
 export interface LoggerBasic {
     debug(...params: any[]): void;
     error(...params: any[]): void;
@@ -122,9 +119,7 @@ export interface MarginalRef extends EditorRef {
 
 // @public
 export interface NodeOptions {
-    [nodeClassName: string]: {
-        [prop: string]: unknown;
-    } | undefined;
+    [prop: string]: unknown;
 }
 
 // @public
@@ -148,9 +143,6 @@ export interface Thread {
 }
 
 // @public
-export const typedMarkNodeName = "TypedMarkNode";
-
-// @public
 export interface UsjLocation {
     jsonPath: string;
     offset: number;
@@ -158,13 +150,9 @@ export interface UsjLocation {
 
 // @public
 export interface UsjNodeOptions extends NodeOptions {
-    [immutableNoteCallerNodeName]?: {
-        noteCallers?: string[];
-        onClick?: OnClick;
-    };
-    [typedMarkNodeName]?: {
-        addMissingComments?: AddMissingComments;
-    };
+    addMissingComments?: AddMissingComments;
+    noteCallerOnClick?: OnClick;
+    noteCallers?: string[];
 }
 
 // @public

--- a/packages/platform/src/editor/adaptors/usj-editor-adaptor.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-editor-adaptor.test.ts
@@ -1,10 +1,9 @@
 import { MarkerObject } from "@eten-tech-foundation/scripture-utilities";
 import { SerializedEditorState } from "lexical";
-import { SerializedNoteNode, SerializedParaNode, typedMarkNodeName } from "shared";
+import { SerializedNoteNode, SerializedParaNode } from "shared";
 import {
   defaultNoteCallers,
   getViewOptions,
-  immutableNoteCallerNodeName,
   SerializedImmutableNoteCallerNode,
   UNFORMATTED_VIEW_MODE,
 } from "shared-react";
@@ -60,7 +59,7 @@ describe("USJ Editor Adaptor", () => {
   });
 
   it("should convert from USJ to Lexical editor state JSON", () => {
-    const nodeOptions = { [immutableNoteCallerNodeName]: { noteCallers: defaultNoteCallers } };
+    const nodeOptions = { noteCallers: defaultNoteCallers };
     initialize(nodeOptions, console);
 
     const serializedEditorState = serializeEditorState(usjGen1v1);
@@ -127,7 +126,7 @@ describe("USJ Editor Adaptor", () => {
 
   it("should call `addMissingComments` if it's set", () => {
     const mockAddMissingComments = vi.fn();
-    const nodeOptions = { [typedMarkNodeName]: { addMissingComments: mockAddMissingComments } };
+    const nodeOptions = { addMissingComments: mockAddMissingComments };
     initialize(nodeOptions, console);
 
     const serializedEditorState = serializeEditorState(usjMarks);
@@ -139,7 +138,7 @@ describe("USJ Editor Adaptor", () => {
   });
 
   it("should convert from USJ with unknown items to Lexical editor state JSON", () => {
-    const nodeOptions = { [immutableNoteCallerNodeName]: { noteCallers: defaultNoteCallers } };
+    const nodeOptions = { noteCallers: defaultNoteCallers };
     initialize(nodeOptions, console);
     reset();
 

--- a/packages/platform/src/editor/adaptors/usj-editor.adaptor.ts
+++ b/packages/platform/src/editor/adaptors/usj-editor.adaptor.ts
@@ -69,7 +69,6 @@ import {
   SerializedVerseNode,
   STARTING_MS_COMMENT_MARKER,
   TypedMarkNode,
-  typedMarkNodeName,
   UNKNOWN_VERSION,
   UnknownNode,
   VERSE_MARKER,
@@ -91,7 +90,6 @@ import {
   ViewOptions,
   getDefaultViewOptions,
   getVerseNodeClass,
-  immutableNoteCallerNodeName,
   isSomeSerializedVerseNode,
 } from "shared-react";
 
@@ -180,8 +178,8 @@ function setNodeOptions(nodeOptions: UsjNodeOptions | undefined) {
   if (nodeOptions) _nodeOptions = nodeOptions;
 
   // Set the `addMissingComments` method.
-  if (nodeOptions?.[typedMarkNodeName]?.addMissingComments) {
-    addMissingComments = nodeOptions[typedMarkNodeName].addMissingComments;
+  if (nodeOptions?.addMissingComments) {
+    addMissingComments = nodeOptions.addMissingComments;
   }
 }
 
@@ -366,8 +364,7 @@ function createNoteCaller(
 ): SerializedImmutableNoteCallerNode {
   const previewText = getPreviewTextFromSerializedNodes(childNodes);
   let onClick: OnClick = () => undefined;
-  if (_nodeOptions?.[immutableNoteCallerNodeName]?.onClick)
-    onClick = _nodeOptions[immutableNoteCallerNodeName].onClick;
+  if (_nodeOptions?.noteCallerOnClick) onClick = _nodeOptions.noteCallerOnClick;
 
   return removeUndefinedProperties({
     type: ImmutableNoteCallerNode.getType(),

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -31,14 +31,12 @@
 
 export { default as Editorial } from "./Editorial";
 export { default as Marginal } from "./marginal/Marginal";
-export { typedMarkNodeName } from "shared";
 export {
   directionToNames,
   getDefaultViewMode,
   getDefaultViewOptions,
   getViewMode,
   getViewOptions,
-  immutableNoteCallerNodeName,
   viewModeToViewNames,
 } from "shared-react";
 

--- a/packages/platform/src/marginal/comments/use-missing-comments-props.hook.tsx
+++ b/packages/platform/src/marginal/comments/use-missing-comments-props.hook.tsx
@@ -1,5 +1,5 @@
 import { RefObject, useEffect } from "react";
-import { LoggerBasic, typedMarkNodeName } from "shared";
+import { LoggerBasic } from "shared";
 import { CommentStore, Comments } from "./commenting";
 import { EditorProps } from "../../editor/Editor";
 
@@ -55,8 +55,7 @@ export default function useMissingCommentsProps<TLogger extends LoggerBasic>(
   useEffect(() => {
     editorProps.options ??= {};
     editorProps.options.nodes ??= {};
-    editorProps.options.nodes[typedMarkNodeName] ??= {};
-    editorProps.options.nodes[typedMarkNodeName].addMissingComments = (usjCommentIds: string[]) => {
+    editorProps.options.nodes.addMissingComments = (usjCommentIds: string[]) => {
       addMissingComments(usjCommentIds, commentStoreRef);
     };
   }, [commentStoreRef, editorProps]);

--- a/packages/scribe/README.md
+++ b/packages/scribe/README.md
@@ -42,7 +42,6 @@ import {
   UsjNodeOptions,
   getViewOptions,
   getDefaultViewMode,
-  immutableNoteCallerNodeName,
 } from "shared";
 
 const defaultUsj: Usj = {
@@ -54,10 +53,8 @@ const defaultUsj: Usj = {
 const defaultScrRef: ScriptureReference = { book: "PSA", chapterNum: 1, verseNum: 1 };
 
 const nodeOptions: UsjNodeOptions = {
-  [immutableNoteCallerNodeName]: {
-    onClick: (e: SyntheticEvent) => {
-      console.log("note node clicked", e);
-    },
+  noteCallerOnClick: (e: SyntheticEvent) => {
+    console.log("note node clicked", e);
   },
 };
 

--- a/packages/scribe/src/App.tsx
+++ b/packages/scribe/src/App.tsx
@@ -6,13 +6,7 @@ import "../../../libs/shared/src/styles/nodes-menu.css";
 import { Usj, USJ_TYPE, USJ_VERSION } from "@eten-tech-foundation/scripture-utilities";
 import { useState, useMemo, SyntheticEvent, useRef, useEffect } from "react";
 import { ScriptureReference } from "shared";
-import {
-  getDefaultViewMode,
-  getViewOptions,
-  immutableNoteCallerNodeName,
-  SelectionRange,
-  UsjNodeOptions,
-} from "shared-react";
+import { getDefaultViewMode, getViewOptions, SelectionRange, UsjNodeOptions } from "shared-react";
 // import { Usj2Usfm } from "@/hooks/usj2Usfm";
 import "@/styles/App.css";
 import Editor, { EditorRef } from "@/editor/Editor";
@@ -25,10 +19,8 @@ const defaultUsj: Usj = {
 };
 const defaultScrRef: ScriptureReference = { book: "PSA", chapterNum: 1, verseNum: 1 };
 const nodeOptions: UsjNodeOptions = {
-  [immutableNoteCallerNodeName]: {
-    onClick: (e: SyntheticEvent) => {
-      console.log("note node clicked", e);
-    },
+  noteCallerOnClick: (e: SyntheticEvent) => {
+    console.log("note node clicked", e);
   },
 };
 

--- a/packages/scribe/src/editor/adaptors/note-usj-editor.adaptor.ts
+++ b/packages/scribe/src/editor/adaptors/note-usj-editor.adaptor.ts
@@ -76,7 +76,6 @@ import {
   IMMUTABLE_NOTE_CALLER_VERSION,
   IMMUTABLE_VERSE_VERSION,
   ImmutableNoteCallerNode,
-  immutableNoteCallerNodeName,
   ImmutableVerseNode,
   OnClick,
   SerializedImmutableNoteCallerNode,
@@ -362,8 +361,7 @@ function createNoteCaller(
 ): SerializedImmutableNoteCallerNode {
   const previewText = getPreviewTextFromSerializedNodes(childNodes);
   let onClick: OnClick = () => undefined;
-  if (_nodeOptions?.[immutableNoteCallerNodeName]?.onClick)
-    onClick = _nodeOptions[immutableNoteCallerNodeName].onClick;
+  if (_nodeOptions?.noteCallerOnClick) onClick = _nodeOptions.noteCallerOnClick;
 
   return removeUndefinedProperties({
     type: ImmutableNoteCallerNode.getType(),

--- a/packages/scribe/src/editor/adaptors/usj-editor.adaptor.ts
+++ b/packages/scribe/src/editor/adaptors/usj-editor.adaptor.ts
@@ -70,7 +70,6 @@ import {
   SerializedVerseNode,
   STARTING_MS_COMMENT_MARKER,
   TypedMarkNode,
-  typedMarkNodeName,
   UNKNOWN_VERSION,
   UnknownNode,
   VERSE_MARKER,
@@ -92,7 +91,6 @@ import {
   ViewOptions,
   getDefaultViewOptions,
   getVerseNodeClass,
-  immutableNoteCallerNodeName,
   isSomeSerializedVerseNode,
 } from "shared-react";
 
@@ -184,8 +182,8 @@ function setNodeOptions(nodeOptions: UsjNodeOptions | undefined) {
   if (nodeOptions) _nodeOptions = nodeOptions;
 
   // Set the `addMissingComments` method.
-  if (nodeOptions?.[typedMarkNodeName]?.addMissingComments) {
-    addMissingComments = nodeOptions[typedMarkNodeName].addMissingComments;
+  if (nodeOptions?.addMissingComments) {
+    addMissingComments = nodeOptions.addMissingComments;
   }
 }
 
@@ -370,8 +368,7 @@ function createNoteCaller(
 ): SerializedImmutableNoteCallerNode {
   const previewText = getPreviewTextFromSerializedNodes(childNodes);
   let onClick: OnClick = () => undefined;
-  if (_nodeOptions?.[immutableNoteCallerNodeName]?.onClick)
-    onClick = _nodeOptions[immutableNoteCallerNodeName].onClick;
+  if (_nodeOptions?.noteCallerOnClick) onClick = _nodeOptions.noteCallerOnClick;
 
   return removeUndefinedProperties({
     type: ImmutableNoteCallerNode.getType(),

--- a/packages/scribe/src/index.ts
+++ b/packages/scribe/src/index.ts
@@ -5,5 +5,4 @@ export {
   getDefaultViewOptions,
   getViewMode,
   getViewOptions,
-  immutableNoteCallerNodeName,
 } from "shared-react";


### PR DESCRIPTION
- flatten structure by removing node-specific keys
- changes API signature