### PR TITLE
Use npm provenance

### DIFF
--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -24,6 +24,8 @@ permissions:
   actions: read
   contents: read
   pull-requests: read
+  # Required for npm provenance
+  id-token: write
 
 jobs:
   test:
@@ -86,8 +88,6 @@ jobs:
         run: |
           cd ./packages/platform
           pnpm publish --no-git-checks --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: pnpm publish scribe-editor
         if: ${{ matrix.os == 'ubuntu-latest' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/scribe_v') && contains(github.ref, '.') }}
@@ -104,8 +104,6 @@ jobs:
         run: |
           cd ./packages/utilities
           pnpm publish --no-git-checks --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session


### PR DESCRIPTION
- for each package you need to enable GHA as a Trusted Publisher, to set up go to e.g. https://www.npmjs.com/package/@eten-tech-foundation/platform-editor/access
- for set up details see https://docs.npmjs.com/trusted-publishers#step-1-add-a-trusted-publisher-on-npmjscom