### PR TITLE
reduce bundle sizes

### DIFF
--- a/packages/platform/vite.config.mts
+++ b/packages/platform/vite.config.mts
@@ -3,7 +3,7 @@ import packageData from "./package.json" with { type: "json" };
 import { nxViteTsPaths } from "@nx/vite/plugins/nx-tsconfig-paths.plugin";
 import react from "@vitejs/plugin-react-swc";
 import * as path from "path";
-import { visualizer } from "rollup-plugin-visualizer";
+// import { visualizer } from "rollup-plugin-visualizer";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 
@@ -50,9 +50,12 @@ export default defineConfig({
         "react/jsx-runtime",
         ...Object.keys(packageData.peerDependencies ?? {}),
         ...Object.keys(packageData.dependencies ?? {}),
+        // Exclude all Lexical packages and their sub-modules
+        /^@lexical\/.*/,
+        /^lexical.*/,
       ],
       // open the HTML file manually or  set `open` to true
-      plugins: [visualizer({ filename: "dist/bundle-analysis.html", open: false })],
+      // plugins: [visualizer({ filename: "dist/bundle-analysis.html", open: false })],
     },
   },
   test: {

--- a/packages/scribe/vite.config.mts
+++ b/packages/scribe/vite.config.mts
@@ -2,6 +2,7 @@
 import { nxViteTsPaths } from "@nx/vite/plugins/nx-tsconfig-paths.plugin";
 import react from "@vitejs/plugin-react-swc";
 import * as path from "path";
+// import { visualizer } from "rollup-plugin-visualizer";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 
@@ -48,14 +49,16 @@ export default defineConfig({
         "react",
         "react-dom",
         "react/jsx-runtime",
-        // unwanted `libs/shared` dependencies
-        "epitelete",
-        "json-difference",
-        "open-patcher",
-        "proskomma-core",
-        "test-data",
-        "tslib",
+        // dependencies
+        "@eten-tech-foundation/scripture-utilities",
+        "@floating-ui/dom",
+        "fast-equals",
+        // Exclude all Lexical packages and their sub-modules
+        /^@lexical\/.*/,
+        /^lexical.*/,
       ],
+      // open the HTML file manually or  set `open` to true
+      // plugins: [visualizer({ filename: "dist/bundle-analysis.html", open: false })],
       output: {
         globals: {
           react: "React",

--- a/packages/utilities/vite.config.mts
+++ b/packages/utilities/vite.config.mts
@@ -1,5 +1,6 @@
 /// <reference types='vitest' />
 import * as path from "path";
+// import { visualizer } from "rollup-plugin-visualizer";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 
@@ -41,6 +42,8 @@ export default defineConfig({
     rollupOptions: {
       // External packages that should not be bundled into your library.
       external: ["@xmldom/xmldom"],
+      // open the HTML file manually or  set `open` to true
+      // plugins: [visualizer({ filename: "dist/bundle-analysis.html", open: false })],
     },
   },
   test: {


### PR DESCRIPTION
- temporarily un-comment the bundle analyzer to see the analysis HTML in the `dist` folder.