### PR TITLE
platform: fix markers on nodes

### DIFF
--- a/demos/platform/src/app/ViewModeDropDown.tsx
+++ b/demos/platform/src/app/ViewModeDropDown.tsx
@@ -2,12 +2,15 @@ import DropDown, { DropDownItem } from "./DropDown";
 import { ViewMode, viewModeToViewNames } from "@eten-tech-foundation/platform-editor";
 import { ReactElement } from "react";
 
+export const CUSTOM_VIEW_MODE = "custom";
+const customViewModeNames = { ...viewModeToViewNames, [CUSTOM_VIEW_MODE]: "Custom" };
+
 function viewModeToClassName(viewMode: string): string {
-  return viewMode in viewModeToViewNames ? viewMode : "";
+  return viewMode in customViewModeNames ? viewMode : "";
 }
 
 function viewModeLabel(viewMode: string): string {
-  return viewMode in viewModeToViewNames ? viewModeToViewNames[viewMode as ViewMode] : "select...";
+  return viewMode in customViewModeNames ? customViewModeNames[viewMode as ViewMode] : "select...";
 }
 
 function dropDownActiveClass(isActive: boolean): string {
@@ -31,14 +34,14 @@ export default function ViewModeDropDown({
       buttonLabel={viewModeLabel(viewMode)}
       buttonAriaLabel="Selection options for view mode"
     >
-      {Object.keys(viewModeToViewNames).map((itemViewMode) => (
+      {Object.keys(customViewModeNames).map((itemViewMode) => (
         <DropDownItem
           key={itemViewMode}
           className={"item view-mode " + dropDownActiveClass(viewMode === itemViewMode)}
           onClick={() => handleSelect(itemViewMode)}
         >
           <i className={"icon view-mode " + viewModeToClassName(itemViewMode)} />
-          {viewModeToViewNames[itemViewMode as ViewMode]}
+          {customViewModeNames[itemViewMode as ViewMode]}
         </DropDownItem>
       ))}
     </DropDown>

--- a/demos/platform/src/app/app.tsx
+++ b/demos/platform/src/app/app.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import AnnotationTypeSelect from "./AnnotationTypeSelect";
 import TextDirectionDropDown from "./TextDirectionDropDown";
-import ViewModeDropDown from "./ViewModeDropDown";
+import ViewModeDropDown, { CUSTOM_VIEW_MODE } from "./ViewModeDropDown";
 import {
   AnnotationRange,
   Comments,
@@ -84,13 +84,25 @@ export default function App() {
   const [hasSpellCheck, setHasSpellCheck] = useState(false);
   const [textDirection, setTextDirection] = useState<TextDirection>("ltr");
   const [viewMode, setViewMode] = useState<string>(getDefaultViewMode);
+  const [markerMode, setMarkerMode] = useState<"visible" | "editable" | "hidden">("hidden");
+  const [hasSpacing, setHasSpacing] = useState(true);
+  const [isFormattedFont, setIsFormattedFont] = useState(true);
   const [debug, setDebug] = useState(true);
   const [scrRef, setScrRef] = useState(defaultScrRef);
   const [annotations, setAnnotations] = useState(defaultAnnotations);
   const [annotationType, setAnnotationType] = useState("spelling");
   const [opsInput, setOpsInput] = useState("");
 
-  const viewOptions = useMemo<ViewOptions | undefined>(() => getViewOptions(viewMode), [viewMode]);
+  const viewOptions = useMemo<ViewOptions | undefined>(() => {
+    if (viewMode === CUSTOM_VIEW_MODE) {
+      return { markerMode, hasSpacing, isFormattedFont };
+    }
+    const viewOptions = getViewOptions(viewMode);
+    setMarkerMode(viewOptions?.markerMode ?? "hidden");
+    setHasSpacing(viewOptions?.hasSpacing ?? true);
+    setIsFormattedFont(viewOptions?.isFormattedFont ?? true);
+    return viewOptions;
+  }, [viewMode, markerMode, hasSpacing, isFormattedFont]);
 
   const options = useMemo<EditorOptions | undefined>(
     () => ({
@@ -259,6 +271,40 @@ export default function App() {
             </div>
             <TextDirectionDropDown textDirection={textDirection} handleSelect={setTextDirection} />
             <ViewModeDropDown viewMode={viewMode} handleSelect={setViewMode} />
+          </div>
+        )}
+        {viewMode === CUSTOM_VIEW_MODE && (
+          <div className="custom-view-options">
+            <div className="control">
+              <label htmlFor="markerModeSelect">Marker Mode</label>
+              <select
+                id="markerModeSelect"
+                value={markerMode}
+                onChange={(e) => setMarkerMode(e.target.value as "visible" | "editable" | "hidden")}
+              >
+                <option value="hidden">Hidden</option>
+                <option value="visible">Visible</option>
+                <option value="editable">Editable</option>
+              </select>
+            </div>
+            <div className="control">
+              <input
+                type="checkbox"
+                id="hasSpacingCheckBox"
+                checked={hasSpacing}
+                onChange={(e) => setHasSpacing(e.target.checked)}
+              />
+              <label htmlFor="hasSpacingCheckBox">Has Spacing</label>
+            </div>
+            <div className="control">
+              <input
+                type="checkbox"
+                id="isFormattedFontCheckBox"
+                checked={isFormattedFont}
+                onChange={(e) => setIsFormattedFont(e.target.checked)}
+              />
+              <label htmlFor="isFormattedFontCheckBox">Is Formatted Font</label>
+            </div>
           </div>
         )}
         <Marginal

--- a/demos/platform/src/styles.css
+++ b/demos/platform/src/styles.css
@@ -49,7 +49,7 @@ body {
 .controls {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 20px;
+  margin-bottom: 10px;
   color: black;
   font-size: 13.3333px;
 }
@@ -85,7 +85,23 @@ body {
 .defined-options {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 20px;
+  margin-bottom: 10px;
+}
+
+.custom-view-options {
+  margin-bottom: 10px;
+  display: flex;
+  flex-direction: row;
+  gap: 24px;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+
+  .control {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
 }
 
 .debug {

--- a/libs/shared-react/src/nodes/usj/ImmutableVerseNode.tsx
+++ b/libs/shared-react/src/nodes/usj/ImmutableVerseNode.tsx
@@ -45,7 +45,7 @@ export class ImmutableVerseNode extends DecoratorNode<ReactElement> {
   __unknownAttributes?: UnknownAttributes;
 
   constructor(
-    verseNumber: string,
+    verseNumber = "",
     showMarker = false,
     sid?: string,
     altnumber?: string,
@@ -81,19 +81,6 @@ export class ImmutableVerseNode extends DecoratorNode<ReactElement> {
     );
   }
 
-  static override importJSON(serializedNode: SerializedImmutableVerseNode): ImmutableVerseNode {
-    const { number, showMarker, sid, altnumber, pubnumber, unknownAttributes } = serializedNode;
-    const node = $createImmutableVerseNode(
-      number,
-      showMarker,
-      sid,
-      altnumber,
-      pubnumber,
-      unknownAttributes,
-    ).updateFromJSON(serializedNode);
-    return node;
-  }
-
   static override importDOM(): DOMConversionMap | null {
     return {
       span: (node: HTMLElement) => {
@@ -107,8 +94,20 @@ export class ImmutableVerseNode extends DecoratorNode<ReactElement> {
     };
   }
 
+  static override importJSON(serializedNode: SerializedImmutableVerseNode): ImmutableVerseNode {
+    return $createImmutableVerseNode().updateFromJSON(serializedNode);
+  }
+
   override updateFromJSON(serializedNode: LexicalUpdateJSON<SerializedImmutableVerseNode>): this {
-    return super.updateFromJSON(serializedNode).setMarker(serializedNode.marker);
+    return super
+      .updateFromJSON(serializedNode)
+      .setMarker(serializedNode.marker)
+      .setNumber(serializedNode.number)
+      .setShowMarker(serializedNode.showMarker)
+      .setSid(serializedNode.sid)
+      .setAltnumber(serializedNode.altnumber)
+      .setPubnumber(serializedNode.pubnumber)
+      .setUnknownAttributes(serializedNode.unknownAttributes);
   }
 
   setMarker(marker: VerseMarker): this {
@@ -204,6 +203,7 @@ export class ImmutableVerseNode extends DecoratorNode<ReactElement> {
     const dom = document.createElement("span");
     dom.setAttribute("data-marker", this.__marker);
     dom.classList.add(VERSE_CLASS_NAME, `usfm_${this.__marker}`);
+    if (this.__showMarker) dom.classList.add("marker");
     dom.setAttribute("data-number", this.__number);
     return dom;
   }
@@ -264,7 +264,7 @@ function $convertImmutableVerseElement(element: HTMLElement): DOMConversionOutpu
 }
 
 export function $createImmutableVerseNode(
-  verseNumber: string,
+  verseNumber?: string,
   showMarker?: boolean,
   sid?: string,
   altnumber?: string,

--- a/libs/shared-react/src/plugins/usj/NoteNodePlugin.test.tsx
+++ b/libs/shared-react/src/plugins/usj/NoteNodePlugin.test.tsx
@@ -1,7 +1,6 @@
 import {
   $createImmutableNoteCallerNode,
   defaultNoteCallers,
-  GENERATOR_NOTE_CALLER,
   ImmutableNoteCallerNode,
 } from "../../nodes/usj/ImmutableNoteCallerNode";
 import { $createImmutableVerseNode } from "../../nodes/usj/ImmutableVerseNode";
@@ -24,6 +23,7 @@ import {
   $createNoteNode,
   $createParaNode,
   $isCharNode,
+  GENERATOR_NOTE_CALLER,
   NBSP,
   NoteNode,
 } from "shared";

--- a/libs/shared-react/src/plugins/usj/NoteNodePlugin.tsx
+++ b/libs/shared-react/src/plugins/usj/NoteNodePlugin.tsx
@@ -1,7 +1,6 @@
 import {
   $isImmutableNoteCallerNode,
   defaultNoteCallers,
-  GENERATOR_NOTE_CALLER,
   ImmutableNoteCallerNode,
 } from "../../nodes/usj/ImmutableNoteCallerNode";
 import { UsjNodeOptions } from "../../nodes/usj/usj-node-options.model";
@@ -26,6 +25,7 @@ import {
   $isCharNode,
   $isNoteNode,
   CharNode,
+  GENERATOR_NOTE_CALLER,
   getNoteCallerPreviewText,
   LoggerBasic,
   NoteNode,

--- a/libs/shared-react/src/plugins/usj/collab/delta-apply-update.utils.test.tsx
+++ b/libs/shared-react/src/plugins/usj/collab/delta-apply-update.utils.test.tsx
@@ -1,7 +1,6 @@
 import {
   $createImmutableNoteCallerNode,
   $isImmutableNoteCallerNode,
-  GENERATOR_NOTE_CALLER,
 } from "../../../nodes/usj/ImmutableNoteCallerNode";
 import { $createImmutableVerseNode } from "../../../nodes/usj/ImmutableVerseNode";
 import { $isSomeVerseNode } from "../../../nodes/usj/node-react.utils";
@@ -36,6 +35,7 @@ import {
   $isParaNode,
   $isSomeChapterNode,
   charIdState,
+  GENERATOR_NOTE_CALLER,
   segmentState,
 } from "shared";
 import { MockInstance } from "vitest";

--- a/libs/shared-react/src/plugins/usj/collab/delta-apply-update.utils.ts
+++ b/libs/shared-react/src/plugins/usj/collab/delta-apply-update.utils.ts
@@ -1610,7 +1610,7 @@ function $createNote(op: DeltaOp, viewOptions: ViewOptions, nodeOptions: UsjNode
   let closingMarkerNode: MarkerNode | undefined;
   if (viewOptions?.markerMode === "visible" || viewOptions?.markerMode === "editable") {
     openingMarkerNode = $createMarkerNode(style);
-    closingMarkerNode = $createMarkerNode(style, false);
+    closingMarkerNode = $createMarkerNode(style, "closing");
   }
 
   if (openingMarkerNode) note.append(openingMarkerNode);

--- a/libs/shared-react/src/plugins/usj/collab/editor-delta.adaptor.test.tsx
+++ b/libs/shared-react/src/plugins/usj/collab/editor-delta.adaptor.test.tsx
@@ -1,7 +1,4 @@
-import {
-  $createImmutableNoteCallerNode,
-  GENERATOR_NOTE_CALLER,
-} from "../../../nodes/usj/ImmutableNoteCallerNode";
+import { $createImmutableNoteCallerNode } from "../../../nodes/usj/ImmutableNoteCallerNode";
 import { $createImmutableVerseNode } from "../../../nodes/usj/ImmutableVerseNode";
 import { baseTestEnvironment } from "../react-test.utils";
 import { LF } from "./delta-common.utils";
@@ -16,6 +13,7 @@ import {
   $createNoteNode,
   $createParaNode,
   charIdState,
+  GENERATOR_NOTE_CALLER,
   getEditableCallerText,
   segmentState,
 } from "shared";

--- a/libs/shared/src/nodes/features/ImmutableTypedTextNode.ts
+++ b/libs/shared/src/nodes/features/ImmutableTypedTextNode.ts
@@ -1,0 +1,169 @@
+import {
+  $applyNodeReplacement,
+  DecoratorNode,
+  DOMConversionMap,
+  DOMConversionOutput,
+  DOMExportOutput,
+  isHTMLElement,
+  LexicalEditor,
+  LexicalNode,
+  LexicalUpdateJSON,
+  NodeKey,
+  SerializedLexicalNode,
+  Spread,
+} from "lexical";
+
+export type SerializedImmutableTypedTextNode = Spread<
+  {
+    textType: string;
+    text: string;
+  },
+  SerializedLexicalNode
+>;
+
+export const IMMUTABLE_TYPED_TEXT_VERSION = 1;
+
+export class ImmutableTypedTextNode extends DecoratorNode<void> {
+  __textType: string;
+  __text: string;
+
+  constructor(textType = "", text = "", key?: NodeKey) {
+    super(key);
+    this.__textType = textType;
+    this.__text = text;
+  }
+
+  static override getType(): string {
+    return "typed-text";
+  }
+
+  static override clone(node: ImmutableTypedTextNode): ImmutableTypedTextNode {
+    const { __textType, __text, __key } = node;
+    return new ImmutableTypedTextNode(__textType, __text, __key);
+  }
+
+  static override importDOM(): DOMConversionMap | null {
+    return {
+      span: (node: HTMLElement) => {
+        if (!isTypedTextElement(node)) return null;
+
+        return {
+          conversion: $convertImmutableTypedTextElement,
+          priority: 1,
+        };
+      },
+    };
+  }
+
+  static override importJSON(
+    serializedNode: SerializedImmutableTypedTextNode,
+  ): ImmutableTypedTextNode {
+    return $createImmutableTypedTextNode().updateFromJSON(serializedNode);
+  }
+
+  override updateFromJSON(
+    serializedNode: LexicalUpdateJSON<SerializedImmutableTypedTextNode>,
+  ): this {
+    return super
+      .updateFromJSON(serializedNode)
+      .setTextType(serializedNode.textType)
+      .setTextContent(serializedNode.text);
+  }
+
+  setTextType(textType: string): this {
+    if (this.__textType === textType) return this;
+
+    const self = this.getWritable();
+    self.__textType = textType;
+    return self;
+  }
+
+  getTextType(): string {
+    const self = this.getLatest();
+    return self.__textType;
+  }
+
+  setTextContent(text: string): this {
+    if (this.__text === text) return this;
+
+    const self = this.getWritable();
+    self.__text = text;
+    return self;
+  }
+
+  override getTextContent(): string {
+    const self = this.getLatest();
+    return self.__text;
+  }
+
+  override createDOM(): HTMLElement {
+    const dom = document.createElement("span");
+    dom.setAttribute("data-text-type", this.__textType);
+    dom.classList.add(this.__textType);
+    return dom;
+  }
+
+  override updateDOM(): boolean {
+    // Returning false tells Lexical that this node does not need its
+    // DOM element replacing with a new copy from createDOM.
+    return false;
+  }
+
+  override exportDOM(editor: LexicalEditor): DOMExportOutput {
+    const { element } = super.exportDOM(editor);
+    if (element && isHTMLElement(element)) {
+      element.setAttribute("data-text-type", this.getTextType());
+    }
+
+    return { element };
+  }
+
+  override decorate(): string {
+    return this.getTextContent();
+  }
+
+  override exportJSON(): SerializedImmutableTypedTextNode {
+    return {
+      type: this.getType(),
+      textType: this.getTextType(),
+      text: this.getTextContent(),
+      version: IMMUTABLE_TYPED_TEXT_VERSION,
+    };
+  }
+
+  // Mutation
+
+  override isKeyboardSelectable(): false {
+    return false;
+  }
+}
+
+function $convertImmutableTypedTextElement(element: HTMLElement): DOMConversionOutput {
+  const textType = element.getAttribute("data-text-type") ?? "";
+  const text = element.textContent ?? "";
+  const node = $createImmutableTypedTextNode(textType, text);
+  return { node };
+}
+
+export function $createImmutableTypedTextNode(
+  textType?: string,
+  text?: string,
+): ImmutableTypedTextNode {
+  return $applyNodeReplacement(new ImmutableTypedTextNode(textType, text));
+}
+
+function isTypedTextElement(node: HTMLElement | null | undefined): boolean {
+  return node?.tagName === "span";
+}
+
+export function $isImmutableTypedTextNode(
+  node: LexicalNode | null | undefined,
+): node is ImmutableTypedTextNode {
+  return node instanceof ImmutableTypedTextNode;
+}
+
+export function isSerializedImmutableTypedTextNode(
+  node: SerializedLexicalNode | null | undefined,
+): node is SerializedImmutableTypedTextNode {
+  return node?.type === ImmutableTypedTextNode.getType();
+}

--- a/libs/shared/src/nodes/features/ImmutableUnmatchedNode.ts
+++ b/libs/shared/src/nodes/features/ImmutableUnmatchedNode.ts
@@ -8,6 +8,7 @@ import {
   isHTMLElement,
   LexicalEditor,
   LexicalNode,
+  LexicalUpdateJSON,
   NodeKey,
   SerializedLexicalNode,
   Spread,
@@ -26,7 +27,7 @@ export type SerializedImmutableUnmatchedNode = Spread<
 export class ImmutableUnmatchedNode extends DecoratorNode<void> {
   __marker: string;
 
-  constructor(marker: string, key?: NodeKey) {
+  constructor(marker = "", key?: NodeKey) {
     super(key);
     this.__marker = marker;
   }
@@ -40,14 +41,6 @@ export class ImmutableUnmatchedNode extends DecoratorNode<void> {
     return new ImmutableUnmatchedNode(__marker, __key);
   }
 
-  static override importJSON(
-    serializedNode: SerializedImmutableUnmatchedNode,
-  ): ImmutableUnmatchedNode {
-    const { marker } = serializedNode;
-    const node = $createImmutableUnmatchedNode(marker);
-    return node;
-  }
-
   static override importDOM(): DOMConversionMap | null {
     return {
       [UNMATCHED_TAG_NAME]: (node: HTMLElement) => {
@@ -59,6 +52,18 @@ export class ImmutableUnmatchedNode extends DecoratorNode<void> {
         };
       },
     };
+  }
+
+  static override importJSON(
+    serializedNode: SerializedImmutableUnmatchedNode,
+  ): ImmutableUnmatchedNode {
+    return $createImmutableUnmatchedNode().updateFromJSON(serializedNode);
+  }
+
+  override updateFromJSON(
+    serializedNode: LexicalUpdateJSON<SerializedImmutableUnmatchedNode>,
+  ): this {
+    return super.updateFromJSON(serializedNode).setMarker(serializedNode.marker);
   }
 
   setMarker(marker: string): this {
@@ -126,7 +131,7 @@ function $convertImmutableUnmatchedElement(element: HTMLElement): DOMConversionO
   return { node };
 }
 
-export function $createImmutableUnmatchedNode(marker: string): ImmutableUnmatchedNode {
+export function $createImmutableUnmatchedNode(marker?: string): ImmutableUnmatchedNode {
   return $applyNodeReplacement(new ImmutableUnmatchedNode(marker));
 }
 

--- a/libs/shared/src/nodes/features/MarkerNode.test.ts
+++ b/libs/shared/src/nodes/features/MarkerNode.test.ts
@@ -1,0 +1,191 @@
+import { createBasicTestEnvironment } from "../usj/test.utils.js";
+import {
+  $createMarkerNode,
+  MarkerNode,
+  MARKER_VERSION,
+  SerializedMarkerNode,
+  MarkerSyntax,
+} from "./MarkerNode.js";
+
+const testParaMarker = "p";
+const testVerseMarker = "v";
+const testChapterMarker = "c";
+
+describe("MarkerNode", () => {
+  describe("constructor", () => {
+    it("should create an opening marker node by default", () => {
+      const { editor } = createBasicTestEnvironment([MarkerNode]);
+      editor.update(() => {
+        const node = $createMarkerNode(testParaMarker);
+        expect(node).toBeDefined();
+        expect(node.getMarker()).toBe(testParaMarker);
+        expect(node.getMarkerSyntax()).toBe("opening");
+        expect(node.getTextContent()).toBe(`\\${testParaMarker}`);
+      });
+    });
+
+    it("should create a closing marker node when specified", () => {
+      const { editor } = createBasicTestEnvironment([MarkerNode]);
+      editor.update(() => {
+        const node = $createMarkerNode(testParaMarker, "closing");
+        expect(node).toBeDefined();
+        expect(node.getMarker()).toBe(testParaMarker);
+        expect(node.getMarkerSyntax()).toBe("closing");
+        expect(node.getTextContent()).toBe(`\\${testParaMarker}*`);
+      });
+    });
+
+    it("should create a self-closing marker node when specified", () => {
+      const { editor } = createBasicTestEnvironment([MarkerNode]);
+      editor.update(() => {
+        const node = $createMarkerNode(testParaMarker, "selfClosing");
+        expect(node).toBeDefined();
+        expect(node.getMarker()).toBe(testParaMarker);
+        expect(node.getMarkerSyntax()).toBe("selfClosing");
+        expect(node.getTextContent()).toBe(`\\*`);
+      });
+    });
+  });
+
+  describe("importJSON()", () => {
+    it("should import JSON correctly for opening marker", () => {
+      const { editor } = createBasicTestEnvironment([MarkerNode]);
+      editor.update(() => {
+        const serializedNode = createSerializedMarkerNode(testVerseMarker, "opening");
+
+        const node = MarkerNode.importJSON(serializedNode);
+        expect(node.getMarker()).toBe(testVerseMarker);
+        expect(node.getMarkerSyntax()).toBe("opening");
+        expect(node.getTextContent()).toBe(`\\${testVerseMarker}`);
+      });
+    });
+
+    it("should import JSON correctly for closing marker", () => {
+      const { editor } = createBasicTestEnvironment([MarkerNode]);
+      editor.update(() => {
+        const serializedNode = createSerializedMarkerNode(testVerseMarker, "closing");
+
+        const node = MarkerNode.importJSON(serializedNode);
+        expect(node.getMarker()).toBe(testVerseMarker);
+        expect(node.getMarkerSyntax()).toBe("closing");
+        expect(node.getTextContent()).toBe(`\\${testVerseMarker}*`);
+      });
+    });
+
+    it("should import JSON correctly for self-closing marker", () => {
+      const { editor } = createBasicTestEnvironment([MarkerNode]);
+      editor.update(() => {
+        const serializedNode = createSerializedMarkerNode(testVerseMarker, "selfClosing");
+
+        const node = MarkerNode.importJSON(serializedNode);
+        expect(node.getMarker()).toBe(testVerseMarker);
+        expect(node.getMarkerSyntax()).toBe("selfClosing");
+        expect(node.getTextContent()).toBe(`\\*`);
+      });
+    });
+  });
+
+  describe("updateFromJSON()", () => {
+    it("should update from JSON correctly to closing", () => {
+      const { editor } = createBasicTestEnvironment([MarkerNode]);
+      editor.update(() => {
+        const node = $createMarkerNode(testParaMarker, "opening");
+
+        const updateData = createSerializedMarkerNode(testChapterMarker, "closing");
+
+        const updatedNode = node.updateFromJSON(updateData);
+        expect(updatedNode.getMarker()).toBe(testChapterMarker);
+        expect(updatedNode.getMarkerSyntax()).toBe("closing");
+        expect(updatedNode.getTextContent()).toBe(`\\${testChapterMarker}*`);
+      });
+    });
+
+    it("should update from JSON correctly to self-closing", () => {
+      const { editor } = createBasicTestEnvironment([MarkerNode]);
+      editor.update(() => {
+        const node = $createMarkerNode(testParaMarker, "opening");
+
+        const updateData = createSerializedMarkerNode(testChapterMarker, "selfClosing");
+
+        const updatedNode = node.updateFromJSON(updateData);
+        expect(updatedNode.getMarker()).toBe(testChapterMarker);
+        expect(updatedNode.getMarkerSyntax()).toBe("selfClosing");
+        expect(updatedNode.getTextContent()).toBe(`\\*`);
+      });
+    });
+  });
+
+  describe("text content updates", () => {
+    it("should update text content when marker changes", () => {
+      const { editor } = createBasicTestEnvironment([MarkerNode]);
+      editor.update(() => {
+        const node = $createMarkerNode(testParaMarker, "opening");
+        expect(node.getTextContent()).toBe(`\\${testParaMarker}`);
+
+        node.setMarker(testVerseMarker);
+        expect(node.getTextContent()).toBe(`\\${testVerseMarker}`);
+      });
+    });
+
+    it("should update text content when marker syntax changes", () => {
+      const { editor } = createBasicTestEnvironment([MarkerNode]);
+      editor.update(() => {
+        const node = $createMarkerNode(testParaMarker, "opening");
+        expect(node.getTextContent()).toBe(`\\${testParaMarker}`);
+
+        node.setMarkerSyntax("closing");
+        expect(node.getTextContent()).toBe(`\\${testParaMarker}*`);
+      });
+    });
+
+    it("should update text content when marker syntax changes to self-closing", () => {
+      const { editor } = createBasicTestEnvironment([MarkerNode]);
+      editor.update(() => {
+        const node = $createMarkerNode(testParaMarker, "opening");
+        expect(node.getTextContent()).toBe(`\\${testParaMarker}`);
+
+        node.setMarkerSyntax("selfClosing");
+        expect(node.getTextContent()).toBe(`\\*`);
+      });
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty marker", () => {
+      const { editor } = createBasicTestEnvironment([MarkerNode]);
+      editor.update(() => {
+        const node = $createMarkerNode("", "opening");
+        expect(node.getMarker()).toBe("");
+        expect(node.getTextContent()).toBe("\\");
+      });
+    });
+
+    it("should handle markers with special characters", () => {
+      const { editor } = createBasicTestEnvironment([MarkerNode]);
+      editor.update(() => {
+        const specialMarker = "test-marker_123";
+        const node = $createMarkerNode(specialMarker, "opening");
+        expect(node.getMarker()).toBe(specialMarker);
+        expect(node.getTextContent()).toBe(`\\${specialMarker}`);
+      });
+    });
+  });
+});
+
+// Helper function to create a valid SerializedMarkerNode
+function createSerializedMarkerNode(
+  marker: string,
+  markerSyntax: MarkerSyntax = "opening",
+): SerializedMarkerNode {
+  return {
+    type: "marker",
+    marker,
+    markerSyntax,
+    text: "",
+    detail: 0,
+    format: 0,
+    mode: "normal",
+    style: "",
+    version: MARKER_VERSION,
+  };
+}

--- a/libs/shared/src/nodes/features/UnknownNode.ts
+++ b/libs/shared/src/nodes/features/UnknownNode.ts
@@ -6,6 +6,7 @@ import {
   DOMExportOutput,
   ElementNode,
   LexicalNode,
+  LexicalUpdateJSON,
   NodeKey,
   SerializedElementNode,
   SerializedLexicalNode,
@@ -29,7 +30,7 @@ export class UnknownNode extends ElementNode {
   __marker: string;
   __unknownAttributes?: UnknownAttributes;
 
-  constructor(tag: string, marker: string, unknownAttributes?: UnknownAttributes, key?: NodeKey) {
+  constructor(tag = "", marker = "", unknownAttributes?: UnknownAttributes, key?: NodeKey) {
     super(key);
     this.__tag = tag;
     this.__marker = marker;
@@ -45,11 +46,6 @@ export class UnknownNode extends ElementNode {
     return new UnknownNode(__tag, __marker, __unknownAttributes, __key);
   }
 
-  static override importJSON(serializedNode: SerializedUnknownNode): UnknownNode {
-    const { tag, marker, unknownAttributes } = serializedNode;
-    return $createUnknownNode(tag, marker, unknownAttributes).updateFromJSON(serializedNode);
-  }
-
   static override importDOM(): DOMConversionMap | null {
     return {
       [UNKNOWN_TAG_NAME]: (node: HTMLElement) => {
@@ -61,6 +57,18 @@ export class UnknownNode extends ElementNode {
         };
       },
     };
+  }
+
+  static override importJSON(serializedNode: SerializedUnknownNode): UnknownNode {
+    return $createUnknownNode().updateFromJSON(serializedNode);
+  }
+
+  override updateFromJSON(serializedNode: LexicalUpdateJSON<SerializedUnknownNode>): this {
+    return super
+      .updateFromJSON(serializedNode)
+      .setTag(serializedNode.tag)
+      .setMarker(serializedNode.marker)
+      .setUnknownAttributes(serializedNode.unknownAttributes);
   }
 
   setTag(tag: string): this {
@@ -154,8 +162,8 @@ function $convertUnknownElement(element: HTMLElement): DOMConversionOutput {
 }
 
 export function $createUnknownNode(
-  tag: string,
-  marker: string,
+  tag?: string,
+  marker?: string,
   unknownAttributes?: UnknownAttributes,
 ): UnknownNode {
   return $applyNodeReplacement(new UnknownNode(tag, marker, unknownAttributes));

--- a/libs/shared/src/nodes/features/index.ts
+++ b/libs/shared/src/nodes/features/index.ts
@@ -1,4 +1,5 @@
 export * from "./MarkerNode.js";
 export * from "./TypedMarkNode.js";
+export * from "./ImmutableTypedTextNode.js";
 export * from "./ImmutableUnmatchedNode.js";
 export * from "./UnknownNode.js";

--- a/libs/shared/src/nodes/usj/BookNode.ts
+++ b/libs/shared/src/nodes/usj/BookNode.ts
@@ -20,20 +20,19 @@ export type BookMarker = typeof BOOK_MARKER;
 export type SerializedBookNode = Spread<
   {
     marker: BookMarker;
-    code: BookCode;
+    code: BookCode | "";
     unknownAttributes?: UnknownAttributes;
   },
   SerializedElementNode
 >;
 
 export class BookNode extends ElementNode {
-  __marker: BookMarker;
-  __code: BookCode;
+  __marker: BookMarker = BOOK_MARKER;
+  __code: BookCode | "";
   __unknownAttributes?: UnknownAttributes;
 
-  constructor(code: BookCode, unknownAttributes?: UnknownAttributes, key?: NodeKey) {
+  constructor(code: BookCode | "" = "", unknownAttributes?: UnknownAttributes, key?: NodeKey) {
     super(key);
-    this.__marker = BOOK_MARKER;
     this.__code = code;
     this.__unknownAttributes = unknownAttributes;
   }
@@ -48,8 +47,8 @@ export class BookNode extends ElementNode {
   }
 
   static override importJSON(serializedNode: SerializedBookNode): BookNode {
-    const { code, unknownAttributes } = serializedNode;
-    return $createBookNode(code, unknownAttributes).updateFromJSON(serializedNode);
+    const { code } = serializedNode;
+    return $createBookNode(code).updateFromJSON(serializedNode);
   }
 
   static isValidBookCode(code: string): code is BookCode {
@@ -57,15 +56,10 @@ export class BookNode extends ElementNode {
   }
 
   override updateFromJSON(serializedNode: LexicalUpdateJSON<SerializedBookNode>): this {
-    return super.updateFromJSON(serializedNode).setMarker(serializedNode.marker);
-  }
-
-  setMarker(marker: BookMarker): this {
-    if (this.__marker === marker) return this;
-
-    const self = this.getWritable();
-    self.__marker = marker;
-    return self;
+    return super
+      .updateFromJSON(serializedNode)
+      .setCode(serializedNode.code)
+      .setUnknownAttributes(serializedNode.unknownAttributes);
   }
 
   getMarker(): BookMarker {
@@ -73,7 +67,7 @@ export class BookNode extends ElementNode {
     return self.__marker;
   }
 
-  setCode(code: BookCode): this {
+  setCode(code: BookCode | ""): this {
     if (this.__code === code) return this;
 
     const self = this.getWritable();
@@ -85,7 +79,7 @@ export class BookNode extends ElementNode {
    * Get the book code (ID).
    * @returns the book code (ID).
    */
-  getCode(): BookCode {
+  getCode(): BookCode | "" {
     const self = this.getLatest();
     return self.__code;
   }
@@ -127,7 +121,10 @@ export class BookNode extends ElementNode {
   }
 }
 
-export function $createBookNode(code: BookCode, unknownAttributes?: UnknownAttributes): BookNode {
+export function $createBookNode(
+  code?: BookCode | "",
+  unknownAttributes?: UnknownAttributes,
+): BookNode {
   return $applyNodeReplacement(new BookNode(code, unknownAttributes));
 }
 

--- a/libs/shared/src/nodes/usj/ChapterNode.ts
+++ b/libs/shared/src/nodes/usj/ChapterNode.ts
@@ -37,7 +37,7 @@ export class ChapterNode extends ElementNode {
   __unknownAttributes?: UnknownAttributes;
 
   constructor(
-    chapterNumber: string,
+    chapterNumber = "",
     sid?: string,
     altnumber?: string,
     pubnumber?: string,
@@ -63,14 +63,18 @@ export class ChapterNode extends ElementNode {
   }
 
   static override importJSON(serializedNode: SerializedChapterNode): ChapterNode {
-    const { number, sid, altnumber, pubnumber, unknownAttributes } = serializedNode;
-    return $createChapterNode(number, sid, altnumber, pubnumber, unknownAttributes).updateFromJSON(
-      serializedNode,
-    );
+    return $createChapterNode().updateFromJSON(serializedNode);
   }
 
   override updateFromJSON(serializedNode: LexicalUpdateJSON<SerializedChapterNode>): this {
-    return super.updateFromJSON(serializedNode).setMarker(serializedNode.marker);
+    return super
+      .updateFromJSON(serializedNode)
+      .setMarker(serializedNode.marker)
+      .setNumber(serializedNode.number)
+      .setSid(serializedNode.sid)
+      .setAltnumber(serializedNode.altnumber)
+      .setPubnumber(serializedNode.pubnumber)
+      .setUnknownAttributes(serializedNode.unknownAttributes);
   }
 
   setMarker(marker: ChapterMarker): this {
@@ -179,7 +183,7 @@ export class ChapterNode extends ElementNode {
 }
 
 export function $createChapterNode(
-  chapterNumber: string,
+  chapterNumber?: string,
   sid?: string,
   altnumber?: string,
   pubnumber?: string,

--- a/libs/shared/src/nodes/usj/CharNode.ts
+++ b/libs/shared/src/nodes/usj/CharNode.ts
@@ -8,6 +8,7 @@ import {
   ElementNode,
   LexicalEditor,
   LexicalNode,
+  LexicalUpdateJSON,
   NodeKey,
   SerializedElementNode,
   SerializedLexicalNode,
@@ -119,7 +120,7 @@ export class CharNode extends ElementNode {
   __marker: string;
   __unknownAttributes?: UnknownAttributes;
 
-  constructor(marker: string, unknownAttributes?: UnknownAttributes, key?: NodeKey) {
+  constructor(marker = "", unknownAttributes?: UnknownAttributes, key?: NodeKey) {
     super(key);
     this.__marker = marker;
     this.__unknownAttributes = unknownAttributes;
@@ -132,11 +133,6 @@ export class CharNode extends ElementNode {
   static override clone(node: CharNode): CharNode {
     const { __marker, __unknownAttributes, __key } = node;
     return new CharNode(__marker, __unknownAttributes, __key);
-  }
-
-  static override importJSON(serializedNode: SerializedCharNode): CharNode {
-    const { marker, unknownAttributes } = serializedNode;
-    return $createCharNode(marker, unknownAttributes).updateFromJSON(serializedNode);
   }
 
   static override importDOM(): DOMConversionMap | null {
@@ -152,6 +148,10 @@ export class CharNode extends ElementNode {
     };
   }
 
+  static override importJSON(serializedNode: SerializedCharNode): CharNode {
+    return $createCharNode().updateFromJSON(serializedNode);
+  }
+
   static isValidMarker(marker: string | undefined): boolean {
     return marker !== undefined && VALID_CHAR_MARKERS.includes(marker);
   }
@@ -162,6 +162,13 @@ export class CharNode extends ElementNode {
 
   static isValidCrossReferenceMarker(marker: string | undefined): boolean {
     return marker !== undefined && VALID_CHAR_CROSS_REFERENCE_MARKERS.includes(marker);
+  }
+
+  override updateFromJSON(serializedNode: LexicalUpdateJSON<SerializedCharNode>): this {
+    return super
+      .updateFromJSON(serializedNode)
+      .setMarker(serializedNode.marker)
+      .setUnknownAttributes(serializedNode.unknownAttributes);
   }
 
   setMarker(marker: string): this {
@@ -238,7 +245,7 @@ function $convertCharElement(element: HTMLElement): DOMConversionOutput {
   return { node };
 }
 
-export function $createCharNode(marker: string, unknownAttributes?: UnknownAttributes): CharNode {
+export function $createCharNode(marker?: string, unknownAttributes?: UnknownAttributes): CharNode {
   return $applyNodeReplacement(new CharNode(marker, unknownAttributes));
 }
 

--- a/libs/shared/src/nodes/usj/ImmutableChapterNode.ts
+++ b/libs/shared/src/nodes/usj/ImmutableChapterNode.ts
@@ -47,7 +47,7 @@ export class ImmutableChapterNode extends DecoratorNode<void> {
   __unknownAttributes?: UnknownAttributes;
 
   constructor(
-    chapterNumber: string,
+    chapterNumber = "",
     showMarker = false,
     sid?: string,
     altnumber?: string,
@@ -83,18 +83,6 @@ export class ImmutableChapterNode extends DecoratorNode<void> {
     );
   }
 
-  static override importJSON(serializedNode: SerializedImmutableChapterNode): ImmutableChapterNode {
-    const { number, showMarker, sid, altnumber, pubnumber, unknownAttributes } = serializedNode;
-    return $createImmutableChapterNode(
-      number,
-      showMarker,
-      sid,
-      altnumber,
-      pubnumber,
-      unknownAttributes,
-    ).updateFromJSON(serializedNode);
-  }
-
   static override importDOM(): DOMConversionMap | null {
     return {
       span: (node: HTMLElement) => {
@@ -108,8 +96,20 @@ export class ImmutableChapterNode extends DecoratorNode<void> {
     };
   }
 
+  static override importJSON(serializedNode: SerializedImmutableChapterNode): ImmutableChapterNode {
+    return $createImmutableChapterNode().updateFromJSON(serializedNode);
+  }
+
   override updateFromJSON(serializedNode: LexicalUpdateJSON<SerializedImmutableChapterNode>): this {
-    return super.updateFromJSON(serializedNode).setMarker(serializedNode.marker);
+    return super
+      .updateFromJSON(serializedNode)
+      .setMarker(serializedNode.marker)
+      .setNumber(serializedNode.number)
+      .setShowMarker(serializedNode.showMarker)
+      .setSid(serializedNode.sid)
+      .setAltnumber(serializedNode.altnumber)
+      .setPubnumber(serializedNode.pubnumber)
+      .setUnknownAttributes(serializedNode.unknownAttributes);
   }
 
   setMarker(marker: ChapterMarker): this {
@@ -205,6 +205,7 @@ export class ImmutableChapterNode extends DecoratorNode<void> {
     const dom = document.createElement(IMMUTABLE_CHAPTER_TAG_NAME);
     dom.setAttribute("data-marker", this.__marker);
     dom.classList.add(CHAPTER_CLASS_NAME, `usfm_${this.__marker}`);
+    if (this.__showMarker) dom.classList.add("marker");
     dom.setAttribute("data-number", this.__number);
     return dom;
   }
@@ -264,7 +265,7 @@ function $convertImmutableChapterElement(element: HTMLElement): DOMConversionOut
 }
 
 export function $createImmutableChapterNode(
-  chapterNumber: string,
+  chapterNumber?: string,
   showMarker?: boolean,
   sid?: string,
   altnumber?: string,

--- a/libs/shared/src/nodes/usj/MilestoneNode.ts
+++ b/libs/shared/src/nodes/usj/MilestoneNode.ts
@@ -4,6 +4,7 @@ import {
   $applyNodeReplacement,
   DecoratorNode,
   LexicalNode,
+  LexicalUpdateJSON,
   NodeKey,
   SerializedLexicalNode,
   Spread,
@@ -59,7 +60,7 @@ export class MilestoneNode extends DecoratorNode<void> {
   __unknownAttributes?: UnknownAttributes;
 
   constructor(
-    marker: string,
+    marker = "",
     sid?: string,
     eid?: string,
     unknownAttributes?: UnknownAttributes,
@@ -82,8 +83,7 @@ export class MilestoneNode extends DecoratorNode<void> {
   }
 
   static override importJSON(serializedNode: SerializedMilestoneNode): MilestoneNode {
-    const { marker, sid, eid, unknownAttributes } = serializedNode;
-    return $createMilestoneNode(marker, sid, eid, unknownAttributes);
+    return $createMilestoneNode().updateFromJSON(serializedNode);
   }
 
   static isValidMarker(marker: string | undefined): boolean {
@@ -92,6 +92,15 @@ export class MilestoneNode extends DecoratorNode<void> {
       (VALID_MILESTONE_MARKERS.includes(marker as (typeof VALID_MILESTONE_MARKERS)[number]) ||
         marker.startsWith("z"))
     );
+  }
+
+  override updateFromJSON(serializedNode: LexicalUpdateJSON<SerializedMilestoneNode>): this {
+    return super
+      .updateFromJSON(serializedNode)
+      .setMarker(serializedNode.marker)
+      .setSid(serializedNode.sid)
+      .setEid(serializedNode.eid)
+      .setUnknownAttributes(serializedNode.unknownAttributes);
   }
 
   setMarker(marker: string): this {
@@ -184,7 +193,7 @@ export function isMilestoneCommentMarker(marker: string) {
 }
 
 export function $createMilestoneNode(
-  marker: string,
+  marker?: string,
   sid?: string,
   eid?: string,
   unknownAttributes?: UnknownAttributes,

--- a/libs/shared/src/nodes/usj/ParaNode.ts
+++ b/libs/shared/src/nodes/usj/ParaNode.ts
@@ -8,6 +8,7 @@ import {
   ElementFormatType,
   LexicalEditor,
   LexicalNode,
+  LexicalUpdateJSON,
   NodeKey,
   ParagraphNode,
   RangeSelection,
@@ -161,11 +162,7 @@ export class ParaNode extends ParagraphNode {
   __marker: string;
   __unknownAttributes?: UnknownAttributes;
 
-  constructor(
-    marker: string = PARA_MARKER_DEFAULT,
-    unknownAttributes?: UnknownAttributes,
-    key?: NodeKey,
-  ) {
+  constructor(marker = PARA_MARKER_DEFAULT, unknownAttributes?: UnknownAttributes, key?: NodeKey) {
     super(key);
     this.__marker = marker;
     this.__unknownAttributes = unknownAttributes;
@@ -180,11 +177,6 @@ export class ParaNode extends ParagraphNode {
     return new ParaNode(__marker, __unknownAttributes, __key);
   }
 
-  static override importJSON(serializedNode: SerializedParaNode): ParaNode {
-    const { marker, unknownAttributes } = serializedNode;
-    return $createParaNode(marker, unknownAttributes).updateFromJSON(serializedNode);
-  }
-
   static override importDOM(): DOMConversionMap | null {
     return {
       p: () => ({
@@ -194,11 +186,22 @@ export class ParaNode extends ParagraphNode {
     };
   }
 
+  static override importJSON(serializedNode: SerializedParaNode): ParaNode {
+    return $createParaNode().updateFromJSON(serializedNode);
+  }
+
   static isValidMarker(marker: string | undefined): boolean {
     return (
       marker !== undefined &&
       VALID_PARA_MARKERS.includes(marker as (typeof VALID_PARA_MARKERS)[number])
     );
+  }
+
+  override updateFromJSON(serializedNode: LexicalUpdateJSON<SerializedParaNode>): this {
+    return super
+      .updateFromJSON(serializedNode)
+      .setMarker(serializedNode.marker)
+      .setUnknownAttributes(serializedNode.unknownAttributes);
   }
 
   setMarker(marker: string): this {

--- a/libs/shared/src/nodes/usj/VerseNode.ts
+++ b/libs/shared/src/nodes/usj/VerseNode.ts
@@ -1,5 +1,6 @@
 /** Conforms with USJ v3.1 @see https://docs.usfm.bible/usfm/3.1/cv/v.html */
 
+import { UnknownAttributes, VERSE_CLASS_NAME } from "./node-constants.js";
 import {
   $applyNodeReplacement,
   EditorConfig,
@@ -11,7 +12,6 @@ import {
   Spread,
   TextNode,
 } from "lexical";
-import { UnknownAttributes, VERSE_CLASS_NAME } from "./node-constants.js";
 
 export const VERSE_MARKER = "v";
 export const VERSE_VERSION = 1;
@@ -38,7 +38,7 @@ export class VerseNode extends TextNode {
   __unknownAttributes?: UnknownAttributes;
 
   constructor(
-    verseNumber: string,
+    verseNumber = "",
     text?: string,
     sid?: string,
     altnumber?: string,
@@ -73,19 +73,18 @@ export class VerseNode extends TextNode {
   }
 
   static override importJSON(serializedNode: SerializedVerseNode): VerseNode {
-    const { number, text, sid, altnumber, pubnumber, unknownAttributes } = serializedNode;
-    return $createVerseNode(
-      number,
-      text,
-      sid,
-      altnumber,
-      pubnumber,
-      unknownAttributes,
-    ).updateFromJSON(serializedNode);
+    return $createVerseNode().updateFromJSON(serializedNode);
   }
 
   override updateFromJSON(serializedNode: LexicalUpdateJSON<SerializedVerseNode>): this {
-    return super.updateFromJSON(serializedNode).setMarker(serializedNode.marker);
+    return super
+      .updateFromJSON(serializedNode)
+      .setMarker(serializedNode.marker)
+      .setNumber(serializedNode.number)
+      .setSid(serializedNode.sid)
+      .setAltnumber(serializedNode.altnumber)
+      .setPubnumber(serializedNode.pubnumber)
+      .setUnknownAttributes(serializedNode.unknownAttributes);
   }
 
   setMarker(marker: VerseMarker): this {
@@ -188,7 +187,7 @@ export class VerseNode extends TextNode {
 }
 
 export function $createVerseNode(
-  verseNumber: string,
+  verseNumber?: string,
   text?: string,
   sid?: string,
   altnumber?: string,

--- a/libs/shared/src/nodes/usj/index.ts
+++ b/libs/shared/src/nodes/usj/index.ts
@@ -1,3 +1,4 @@
+import { ImmutableTypedTextNode } from "../features/ImmutableTypedTextNode.js";
 import { ImmutableUnmatchedNode } from "../features/ImmutableUnmatchedNode.js";
 import { MarkerNode } from "../features/MarkerNode.js";
 import { UnknownNode } from "../features/UnknownNode.js";
@@ -34,6 +35,7 @@ export const usjBaseNodes: readonly (Klass<LexicalNode> | LexicalNodeReplacement
   MilestoneNode,
   MarkerNode,
   UnknownNode,
+  ImmutableTypedTextNode,
   ImmutableUnmatchedNode,
   ParaNode,
   ImpliedParaNode,

--- a/libs/shared/src/nodes/usj/node-constants.ts
+++ b/libs/shared/src/nodes/usj/node-constants.ts
@@ -4,10 +4,13 @@ export interface UnknownAttributes {
   [name: string]: string | undefined;
 }
 
-export const PARA_MARKER_DEFAULT = "p";
-
 export const NBSP = "\u00A0";
 export const ZWSP = "\u200B";
+
+export const NODE_ATTRIBUTE_PREFIX = `${NBSP}|`;
+
+export const PARA_MARKER_DEFAULT = "p";
+export const GENERATOR_NOTE_CALLER = "+";
 
 export const CHAPTER_CLASS_NAME = "chapter";
 export const VERSE_CLASS_NAME = "verse";

--- a/libs/shared/src/nodes/usj/node.utils.ts
+++ b/libs/shared/src/nodes/usj/node.utils.ts
@@ -306,7 +306,7 @@ export function removeNodesBeforeNode(
 
 /**
  * Gets the opening marker text.
- * @param marker - Verse marker.
+ * @param marker - The USFM marker.
  * @returns the opening marker text.
  */
 export function openingMarkerText(marker: string): string {
@@ -315,7 +315,7 @@ export function openingMarkerText(marker: string): string {
 
 /**
  * Gets the closing marker text.
- * @param marker - Verse marker.
+ * @param marker - The USFM marker.
  * @returns the closing marker text.
  */
 export function closingMarkerText(marker: string): string {

--- a/libs/test-data/src/data/WEB-PSA.usx.ts
+++ b/libs/test-data/src/data/WEB-PSA.usx.ts
@@ -1,6 +1,7 @@
 // Modified from original:
-//   unknown items (wat:z) added in first para:q1;
-//   custom annotation milestones in first para:q2.
+//   unknown items (wat:z) added in first para:q1 (v1).
+//   custom annotation milestones in first para:q2 (v2).
+//   ts milestones added in third para:q1 (v3).
 export const WEB_PSA_CH1_USX = `<?xml version="1.0" encoding="utf-8"?>
 <usx version="3.0">
   <book code="PSA" style="id">World English Bible (WEB)</book>
@@ -22,7 +23,7 @@ export const WEB_PSA_CH1_USX = `<?xml version="1.0" encoding="utf-8"?>
     <verse number="2" style="v" sid="PSA 1:2" />but his delight is in Yahweh’s<note caller="+" style="f"><char style="fr" closed="false">1:2 </char><char style="ft" closed="false">“Yahweh” is God’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</char></note> law.</para>
   <para style="q2" vid="PSA 1:2">On his law he meditates day and night.<verse eid="PSA 1:2" /></para>
   <para style="q1">
-    <verse number="3" style="v" sid="PSA 1:3" />He will be like a tree planted by the streams of water,</para>
+    <verse number="3" style="v" sid="PSA 1:3" />He will be like a <ms style="ts-s" sid="ts.PSA.tree" />tree<ms style="ts-e" eid="ts.PSA.tree" /> planted by the streams of water,</para>
   <para style="q2" vid="PSA 1:3">that produces its fruit in its season,</para>
   <para style="q2" vid="PSA 1:3">whose leaf also does not wither.</para>
   <para style="q2" vid="PSA 1:3">Whatever he does shall prosper.<verse eid="PSA 1:3" /></para>

--- a/packages/platform/src/editor/adaptors/editor-usj.adaptor.ts
+++ b/packages/platform/src/editor/adaptors/editor-usj.adaptor.ts
@@ -1,4 +1,5 @@
 import {
+  BookCode,
   MarkerContent,
   MarkerObject,
   USJ_TYPE,
@@ -20,6 +21,7 @@ import {
   ENDING_MS_COMMENT_MARKER,
   getEditableCallerText,
   ImmutableChapterNode,
+  ImmutableTypedTextNode,
   ImmutableUnmatchedNode,
   isSerializedImpliedParaNode,
   isSerializedTypedMarkNode,
@@ -28,6 +30,7 @@ import {
   MILESTONE_VERSION,
   MilestoneNode,
   NBSP,
+  NODE_ATTRIBUTE_PREFIX,
   NoteNode,
   ParaNode,
   parseNumberFromMarkerText,
@@ -97,7 +100,9 @@ function createBookMarker(
   node: SerializedBookNode,
   content: MarkerContent[] | undefined,
 ): MarkerObject {
-  const { type, marker, code, unknownAttributes } = node;
+  const { type, marker, unknownAttributes } = node;
+  let code: BookCode | undefined;
+  if (node.code !== "") code = node.code;
   return removeUndefinedProperties({
     type,
     marker,
@@ -374,6 +379,7 @@ function recurseNodes(
           ),
         );
         break;
+      case ImmutableTypedTextNode.getType():
       case ImmutableNoteCallerNode.getType():
       case LineBreakNode.getType():
       case MarkerNode.getType():
@@ -404,6 +410,7 @@ function recurseNodes(
         if (
           serializedTextNode.text &&
           serializedTextNode.text !== NBSP &&
+          !serializedTextNode.text.startsWith(NODE_ATTRIBUTE_PREFIX) &&
           (!noteCaller || serializedTextNode.text !== getEditableCallerText(noteCaller))
         ) {
           combineTextContentOrAdd(markers, createTextMarker(serializedTextNode));

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -18,6 +18,7 @@ import {
   $isTypedMarkNode,
   CharNode,
   createLexicalUsjNode,
+  GENERATOR_NOTE_CALLER,
   getNextVerse,
   Marker,
   MarkerAction,
@@ -27,7 +28,6 @@ import {
   $addTrailingSpace,
   $isSomeVerseNode,
   $removeLeadingSpace,
-  GENERATOR_NOTE_CALLER,
   ViewOptions,
 } from "shared-react";
 import usjEditorAdaptor from "./usj-editor.adaptor";

--- a/packages/platform/src/editor/editor.css
+++ b/packages/platform/src/editor/editor.css
@@ -195,6 +195,11 @@
   border-bottom: 2px solid rgba(255, 212, 0, 0.7);
 }
 
+.marker-editable [class^="editor-typed-mark"] {
+  background: none;
+  border-bottom: none;
+}
+
 .editor-paragraph {
   margin: 0;
   margin-bottom: 8px;

--- a/packages/platform/src/usj-nodes.css
+++ b/packages/platform/src/usj-nodes.css
@@ -49,7 +49,7 @@
   font-size: 100%;
 }
 
-.book[data-code]::before {
+.marker-hidden .book[data-code]::before {
   content: attr(data-code) " ";
 }
 
@@ -2062,8 +2062,16 @@ body {
 .marker {
   unicode-bidi: isolate;
 }
-.formatted-font .marker {
+
+.marker-visible .marker,
+.marker-hidden .marker,
+.marker-hidden .book[data-code]::before,
+.marker-editable .book .marker {
   color: rgba(140, 140, 140, 1);
+}
+
+.marker-visible .marker:not(.chapter),
+.marker-hidden .marker:not(.chapter) {
   font-size: 0.7em;
 }
 

--- a/packages/scribe/src/editor/adaptors/editor-usj.adaptor.ts
+++ b/packages/scribe/src/editor/adaptors/editor-usj.adaptor.ts
@@ -1,4 +1,5 @@
 import {
+  BookCode,
   MarkerContent,
   MarkerObject,
   USJ_TYPE,
@@ -20,6 +21,7 @@ import {
   ENDING_MS_COMMENT_MARKER,
   getEditableCallerText,
   ImmutableChapterNode,
+  ImmutableTypedTextNode,
   ImmutableUnmatchedNode,
   isSerializedImpliedParaNode,
   isSerializedTypedMarkNode,
@@ -97,7 +99,9 @@ function createBookMarker(
   node: SerializedBookNode,
   content: MarkerContent[] | undefined,
 ): MarkerObject {
-  const { type, marker, code, unknownAttributes } = node;
+  const { type, marker, unknownAttributes } = node;
+  let code: BookCode | undefined;
+  if (node.code !== "") code = node.code;
   return removeUndefinedProperties({
     type,
     marker,
@@ -374,6 +378,7 @@ export function recurseNodes(
           ),
         );
         break;
+      case ImmutableTypedTextNode.getType():
       case ImmutableNoteCallerNode.getType():
       case LineBreakNode.getType():
       case MarkerNode.getType():

--- a/packages/scribe/src/editor/adaptors/note-usj-editor.adaptor.ts
+++ b/packages/scribe/src/editor/adaptors/note-usj-editor.adaptor.ts
@@ -41,6 +41,7 @@ import {
   isSerializedTextNode,
   LoggerBasic,
   MarkerNode,
+  MarkerSyntax,
   MILESTONE_VERSION,
   MilestoneNode,
   NBSP,
@@ -391,7 +392,7 @@ function createNote(
   let closingMarkerNode: SerializedTextNode | undefined;
   if (_viewOptions?.markerMode === "visible" || _viewOptions?.markerMode === "editable") {
     openingMarkerNode = createMarker(marker);
-    closingMarkerNode = createMarker(marker, false);
+    closingMarkerNode = createMarker(marker, "closing");
   }
   const children: SerializedLexicalNode[] = [];
   if (openingMarkerNode) children.push(openingMarkerNode);
@@ -462,11 +463,14 @@ function createUnknown(
   });
 }
 
-function createMarker(marker: string, isOpening = true): SerializedMarkerNode {
+function createMarker(
+  marker: string,
+  markerSyntax: MarkerSyntax = "opening",
+): SerializedMarkerNode {
   return {
     type: MarkerNode.getType(),
     marker,
-    isOpening,
+    markerSyntax,
     text: "",
     detail: 0,
     format: 0,
@@ -499,7 +503,7 @@ function addClosingMarker(marker: string, nodes: SerializedLexicalNode[]) {
     (_viewOptions?.markerMode === "visible" || _viewOptions?.markerMode === "editable") &&
     !(CharNode.isValidFootnoteMarker(marker) || CharNode.isValidCrossReferenceMarker(marker))
   ) {
-    nodes.push(createMarker(marker, false));
+    nodes.push(createMarker(marker, "closing"));
   }
 }
 

--- a/packages/scribe/src/editor/adaptors/usj-editor.adaptor.ts
+++ b/packages/scribe/src/editor/adaptors/usj-editor.adaptor.ts
@@ -46,6 +46,7 @@ import {
   isSomeSerializedChapterNode,
   LoggerBasic,
   MarkerNode,
+  MarkerSyntax,
   MILESTONE_VERSION,
   MilestoneNode,
   NBSP,
@@ -398,7 +399,7 @@ function createNote(
   let closingMarkerNode: SerializedTextNode | undefined;
   if (_viewOptions?.markerMode === "visible" || _viewOptions?.markerMode === "editable") {
     openingMarkerNode = createMarker(marker);
-    closingMarkerNode = createMarker(marker, false);
+    closingMarkerNode = createMarker(marker, "closing");
   }
   const children: SerializedLexicalNode[] = [];
   if (openingMarkerNode) children.push(openingMarkerNode);
@@ -483,11 +484,14 @@ function createUnmatched(marker: string): SerializedImmutableUnmatchedNode {
   };
 }
 
-function createMarker(marker: string, isOpening = true): SerializedMarkerNode {
+function createMarker(
+  marker: string,
+  markerSyntax: MarkerSyntax = "opening",
+): SerializedMarkerNode {
   return {
     type: MarkerNode.getType(),
     marker,
-    isOpening,
+    markerSyntax,
     text: "",
     detail: 0,
     format: 0,
@@ -520,7 +524,7 @@ function addClosingMarker(marker: string, nodes: SerializedLexicalNode[]) {
     (_viewOptions?.markerMode === "visible" || _viewOptions?.markerMode === "editable") &&
     !(CharNode.isValidFootnoteMarker(marker) || CharNode.isValidCrossReferenceMarker(marker))
   ) {
-    nodes.push(createMarker(marker, false));
+    nodes.push(createMarker(marker, "closing"));
   }
 }
 

--- a/packages/scribe/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/scribe/src/editor/adaptors/usj-marker-action.utils.ts
@@ -17,6 +17,7 @@ import {
   $isTypedMarkNode,
   CharNode,
   createLexicalUsjNode,
+  GENERATOR_NOTE_CALLER,
   getNextVerse,
   Marker,
   MarkerAction,
@@ -27,7 +28,6 @@ import {
   $addTrailingSpace,
   $isSomeVerseNode,
   $removeLeadingSpace,
-  GENERATOR_NOTE_CALLER,
   ViewOptions,
 } from "shared-react";
 import usjEditorAdaptor from "./usj-editor.adaptor";

--- a/packages/utilities/src/converters/usj/converter-test.data.ts
+++ b/packages/utilities/src/converters/usj/converter-test.data.ts
@@ -417,6 +417,12 @@ export const editorStateGen1v1Editable = {
         version: 1,
         children: [
           {
+            type: "typed-text",
+            text: `\\id GEN${NBSP}`,
+            textType: "marker",
+            version: 1,
+          },
+          {
             type: "text",
             text: "Some Scripture Version",
             detail: 0,
@@ -461,7 +467,7 @@ export const editorStateGen1v1Editable = {
           {
             type: "marker",
             marker: "p",
-            isOpening: true,
+            markerSyntax: "opening",
             detail: 0,
             format: 0,
             mode: "normal",
@@ -536,7 +542,7 @@ export const editorStateGen1v1Editable = {
           {
             type: "marker",
             marker: "nd",
-            isOpening: true,
+            markerSyntax: "opening",
             detail: 0,
             format: 0,
             mode: "normal",
@@ -568,7 +574,7 @@ export const editorStateGen1v1Editable = {
           {
             type: "marker",
             marker: "nd",
-            isOpening: false,
+            markerSyntax: "closing",
             detail: 0,
             format: 0,
             mode: "normal",
@@ -588,7 +594,7 @@ export const editorStateGen1v1Editable = {
           {
             type: "marker",
             marker: "va",
-            isOpening: true,
+            markerSyntax: "opening",
             detail: 0,
             format: 0,
             mode: "normal",
@@ -620,7 +626,7 @@ export const editorStateGen1v1Editable = {
           {
             type: "marker",
             marker: "va",
-            isOpening: false,
+            markerSyntax: "closing",
             detail: 0,
             format: 0,
             mode: "normal",
@@ -645,7 +651,7 @@ export const editorStateGen1v1Editable = {
             marker: "b",
             detail: 0,
             format: 0,
-            isOpening: true,
+            markerSyntax: "opening",
             mode: "normal",
             style: "",
             text: "",
@@ -675,7 +681,7 @@ export const editorStateGen1v1Editable = {
           {
             type: "marker",
             marker: "q2",
-            isOpening: true,
+            markerSyntax: "opening",
             detail: 0,
             format: 0,
             mode: "normal",
@@ -722,7 +728,7 @@ export const editorStateGen1v1Editable = {
               {
                 type: "marker",
                 marker: "f",
-                isOpening: true,
+                markerSyntax: "opening",
                 text: "",
                 detail: 0,
                 format: 0,
@@ -742,7 +748,7 @@ export const editorStateGen1v1Editable = {
               {
                 type: "marker",
                 marker: "fr",
-                isOpening: true,
+                markerSyntax: "opening",
                 detail: 0,
                 format: 0,
                 mode: "normal",
@@ -774,7 +780,7 @@ export const editorStateGen1v1Editable = {
               {
                 type: "marker",
                 marker: "ft",
-                isOpening: true,
+                markerSyntax: "opening",
                 detail: 0,
                 format: 0,
                 mode: "normal",
@@ -806,7 +812,7 @@ export const editorStateGen1v1Editable = {
               {
                 type: "marker",
                 marker: "f",
-                isOpening: false,
+                markerSyntax: "closing",
                 text: "",
                 detail: 0,
                 format: 0,
@@ -842,7 +848,7 @@ export const editorStateGen1v1Editable = {
           {
             type: "marker",
             marker: "qs",
-            isOpening: true,
+            markerSyntax: "opening",
             detail: 0,
             format: 0,
             mode: "normal",
@@ -874,7 +880,7 @@ export const editorStateGen1v1Editable = {
           {
             type: "marker",
             marker: "qs",
-            isOpening: false,
+            markerSyntax: "closing",
             detail: 0,
             format: 0,
             mode: "normal",


### PR DESCRIPTION
- BookNode now displays marker and code
- MarkerNode, NoteNode and CharNodes now display a marker
- MilestoneNode now displays marker and attributes
- add custom view options to demo app
- fix styling
- also update nodes to Lexical `updateFromJSON` pattern