### PR TITLE
Made `MarkerObject.marker` optional because of markers like `periph`

### DIFF
--- a/packages/utilities/src/converters/usj/usj.model.ts
+++ b/packages/utilities/src/converters/usj/usj.model.ts
@@ -38,7 +38,7 @@ export interface MarkerObject {
    * The corresponding marker in USFM or style in USX
    * @example `p`, `v`, `nd`
    */
-  marker: string;
+  marker?: string;
   /** This marker's contents laid out in order */
   content?: MarkerContent[];
   /** Indicates the Book-chapter-verse value in the paragraph based structure */


### PR DESCRIPTION
Not all `MarkerObject`s have `marker`: 
- [`periph`](https://github.com/usfm-bible/tcdocs/blob/usj/tests/advanced/periph/origin.json)
- [`table`](https://github.com/usfm-bible/tcdocs/blob/usj/tests/specExamples/table/origin.json)
- I believe `optbreak` and `ref` as well, but I didn't look for examples for them