### PR TITLE
platform: no trailing para space

### DIFF
--- a/libs/shared-react/src/plugins/usj/TextSpacingPlugin.tsx
+++ b/libs/shared-react/src/plugins/usj/TextSpacingPlugin.tsx
@@ -12,6 +12,7 @@ import { useEffect } from "react";
 import {
   $isCharNode,
   $isNoteNode,
+  $isParaLikeNode,
   $isTypedMarkNode,
   $isUnknownNode,
   CharNode,
@@ -49,13 +50,16 @@ function useTextSpacing(editor: LexicalEditor) {
 }
 
 /**
- * Adds a space to the end of a TextNode if it doesn't precede a note or isn't inside a CharNode,
- * TypedMarkNode, or UnknownNode. It doesn't add a space if the text node is not editable. It
- * removes a TextNode with only a space if it is not followed by a verse node.
+ * Ensures a TextNode has trailing spacing when needed for inline scripture content.
  *
- * When the next sibling is a CharNode or TypedMarkNode (inline marker or annotation), we skip
- * both adding trailing space and the space-only cleanup below, so spacing before inline content
- * is left unchanged.
+ * The transform does nothing when the node is not editable, already has meaningful trailing
+ * whitespace, precedes a note, or is inside or adjacent to CharNode, TypedMarkNode, or UnknownNode
+ * content.
+ *
+ * If the node contains only a single space and is not followed by a verse node, that placeholder
+ * space is removed instead of preserved.
+ *
+ * Trailing space is not added if the node is the last child of a para-like node.
  *
  * @param node - TextNode that might need updating.
  */
@@ -77,8 +81,16 @@ function $textNodeTrailingSpaceTransform(node: TextNode): void {
   )
     return;
 
-  if (text === " " && !$isSomeVerseNode(nextSibling)) node.setTextContent("");
-  else $addTrailingSpace(node);
+  // Remove space-only placeholders that don't precede a verse.
+  if (text === " " && !$isSomeVerseNode(nextSibling)) {
+    node.setTextContent("");
+    return;
+  }
+
+  // Don't add trailing space if it's the last node in a paragraph-like node.
+  if ($isParaLikeNode(parent) && node.is(parent.getLastChild())) return;
+
+  $addTrailingSpace(node);
 }
 
 /**

--- a/libs/shared-react/src/plugins/usj/annotation/selection.utils.ts
+++ b/libs/shared-react/src/plugins/usj/annotation/selection.utils.ts
@@ -1,4 +1,3 @@
-import { $isParaLikeNode } from "../collab/delta-common.utils";
 import { AnnotationRange, SelectionRange } from "./selection.model";
 import {
   type PropertyJsonPath,
@@ -34,6 +33,7 @@ import {
 } from "lexical";
 import {
   $isMarkerNode,
+  $isParaLikeNode,
   $isTypedMarkNode,
   $isVisibleMarkerNode,
   ImmutableTypedTextNode,

--- a/libs/shared-react/src/plugins/usj/collab/delta-apply-update.utils.ts
+++ b/libs/shared-react/src/plugins/usj/collab/delta-apply-update.utils.ts
@@ -6,14 +6,7 @@ import {
 } from "../../../nodes/usj/node-react.utils";
 import { UsjNodeOptions } from "../../../nodes/usj/usj-node-options.model";
 import { ViewOptions } from "../../../views/view-options.utils";
-import {
-  $isEmbedNode,
-  $isParaLikeNode,
-  DeltaOp,
-  EmbedNode,
-  isInsertEmbedOpOfType,
-  LF,
-} from "./delta-common.utils";
+import { $isEmbedNode, DeltaOp, EmbedNode, isInsertEmbedOpOfType, LF } from "./delta-common.utils";
 import {
   DeltaOpInsertNoteEmbed,
   OT_BOOK_PROPS,
@@ -66,6 +59,7 @@ import {
   $isImpliedParaNode,
   $isMilestoneNode,
   $isNoteNode,
+  $isParaLikeNode,
   $isParaNode,
   $isSomeChapterNode,
   $isSomeParaNode,

--- a/libs/shared-react/src/plugins/usj/collab/delta-common.utils.ts
+++ b/libs/shared-react/src/plugins/usj/collab/delta-common.utils.ts
@@ -13,20 +13,18 @@ import {
 } from "lexical";
 import { Op } from "quill-delta";
 import {
-  $isBookNode,
   $isDescendantOf,
   $isImmutableUnmatchedNode,
   $isMilestoneNode,
   $isNoteNode,
+  $isParaLikeNode,
   $isSomeChapterNode,
-  $isSomeParaNode,
   $isUnknownNode,
-  BookNode,
   ImmutableUnmatchedNode,
   MilestoneNode,
   NoteNode,
+  ParaLikeNode,
   SomeChapterNode,
-  SomeParaNode,
   UnknownNode,
 } from "shared";
 
@@ -59,8 +57,6 @@ export type EmbedNode =
   | MilestoneNode
   | NoteNode
   | ImmutableUnmatchedNode;
-
-export type ParaLikeNode = SomeParaNode | BookNode;
 
 interface OpenContentEmbed {
   node: NoteNode | UnknownNode;
@@ -331,14 +327,6 @@ export function $isEmbedNode(node: LexicalNode | null | undefined): node is Embe
     $isUnknownNode(node) ||
     $isImmutableUnmatchedNode(node)
   );
-}
-
-/**
- * Type guard to check if a node is para-like. Para-like nodes have an OT length of 1 that is
- * counted on its close (rather than its open).
- */
-export function $isParaLikeNode(node: LexicalNode | null | undefined): node is ParaLikeNode {
-  return $isSomeParaNode(node) || $isBookNode(node);
 }
 
 /**

--- a/libs/shared-react/src/plugins/usj/collab/editor-delta.adaptor.ts
+++ b/libs/shared-react/src/plugins/usj/collab/editor-delta.adaptor.ts
@@ -1,11 +1,5 @@
 import { $isSomeVerseNode, SomeVerseNode } from "../../../nodes/usj/node-react.utils";
-import {
-  $isElementNodeClosing,
-  $isParaLikeNode,
-  DeltaOp,
-  LF,
-  ParaLikeNode,
-} from "./delta-common.utils";
+import { $isElementNodeClosing, DeltaOp, LF } from "./delta-common.utils";
 import {
   DeltaOpInsertNoteEmbed,
   OTBookAttribute,
@@ -29,6 +23,7 @@ import {
   $isImpliedParaNode,
   $isMilestoneNode,
   $isNoteNode,
+  $isParaLikeNode,
   $isParaNode,
   $isSomeChapterNode,
   $isUnknownNode,
@@ -43,6 +38,7 @@ import {
   NBSP,
   NODE_ATTRIBUTE_PREFIX,
   NoteNode,
+  ParaLikeNode,
   ParaNode,
   segmentState,
   SomeChapterNode,

--- a/libs/shared/src/nodes/usj/node.utils.ts
+++ b/libs/shared/src/nodes/usj/node.utils.ts
@@ -60,6 +60,8 @@ export type NodesWithMarker =
 export type SomeChapterNode = ChapterNode | ImmutableChapterNode;
 export type SomeParaNode = ParaNode | ImpliedParaNode;
 
+export type ParaLikeNode = SomeParaNode | BookNode;
+
 /** RegEx to test for a string only containing digits. */
 const ONLY_DIGITS_TEST = /^\d+$/;
 
@@ -237,6 +239,14 @@ export function $getPreviousNode(selection: RangeSelection): LexicalNode | null 
 
   const anchorNode = selection.anchor.getNode();
   return anchorNode.getPreviousSibling() ?? anchorNode.getParent()?.getPreviousSibling() ?? null;
+}
+
+/**
+ * Type guard to check if a node is para-like. Para-like nodes have an OT length of 1 that is
+ * counted on its close (rather than its open).
+ */
+export function $isParaLikeNode(node: LexicalNode | null | undefined): node is ParaLikeNode {
+  return $isSomeParaNode(node) || $isBookNode(node);
 }
 
 /**


### PR DESCRIPTION
- don't automatically add space at the end of a para-like node
- move `$isParaLikeNode` to `node.utils.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/eten-tech-foundation/scripture-editors/pull/471" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/471)
<!-- Reviewable:end -->
