### PR TITLE
feat(shared,platform): annotation hover events + suppressible CharNode title

### DIFF
--- a/libs/shared-react/src/plugins/usj/annotation/AnnotationPlugin.test.tsx
+++ b/libs/shared-react/src/plugins/usj/annotation/AnnotationPlugin.test.tsx
@@ -2,9 +2,15 @@ import { baseTestEnvironment } from "../react-test.utils";
 import { AnnotationPlugin, AnnotationRef } from "./AnnotationPlugin";
 import { AnnotationRange } from "./selection.model";
 import { act } from "@testing-library/react";
-import { $createTextNode, $getRoot, $isTextNode } from "lexical";
+import { $createTextNode, $getRoot, $isElementNode, $isTextNode, LexicalNode } from "lexical";
 import { createRef } from "react";
-import { $createParaNode, $createTypedMarkNode, $isParaNode, $isTypedMarkNode } from "shared";
+import {
+  $createParaNode,
+  $createTypedMarkNode,
+  $isParaNode,
+  $isTypedMarkNode,
+  TypedMarkNode,
+} from "shared";
 import { vi } from "vitest";
 
 describe("AnnotationPlugin", () => {
@@ -86,7 +92,140 @@ describe("AnnotationPlugin", () => {
       expect(fourthChild.getTextContent()).toBe(" stands");
     });
   });
+
+  describe("hover callbacks survive nested-mark resolution", () => {
+    it("preserves onMouseEnter when a second annotation is added to a range already inside a TypedMarkNode", async () => {
+      // Initial state: "the man who stands" with no marks - we'll add the first via setAnnotation
+      // so the AnnotationPlugin runs end-to-end (mirroring the consumer flow).
+      const onMouseEnter = vi.fn();
+      const onMouseLeave = vi.fn();
+      const text = "the man who stands";
+      const { annotationPlugin, editor } = await testEnvironment(() => {
+        $getRoot().append($createParaNode().append($createTextNode(text)));
+      });
+
+      const jsonPath = "$.content[0].content[0]";
+      const wordRange: AnnotationRange = {
+        // "man" - chars 4..7
+        start: { jsonPath, offset: 4 },
+        end: { jsonPath, offset: 7 },
+      };
+
+      // Annotation #1: a highlight mark with hover callbacks attached.
+      await act(async () => {
+        annotationPlugin.setAnnotation(
+          wordRange,
+          "highlight",
+          "hl-A",
+          undefined,
+          undefined,
+          onMouseEnter,
+          onMouseLeave,
+        );
+      });
+
+      // Annotation #2: a second annotation type ("dim") over the SAME range, no callbacks.
+      // This exercises the nested-element resolver path: the second setAnnotation lands on a
+      // range already wrapped by the first TypedMarkNode, and merge logic must preserve the
+      // hover callbacks registered on the first annotation.
+      await act(async () => {
+        annotationPlugin.setAnnotation(wordRange, "dim", "dim-A");
+      });
+
+      // After merge, find the surviving TypedMarkNode covering "man" and assert the hover
+      // callbacks survived the merge.
+      editor.getEditorState().read(() => {
+        const merged = $findMergedTypedMarkNode("man");
+        if (merged === null) throw new Error("Expected merged TypedMarkNode covering 'man'");
+
+        const typedIDs = merged.getTypedIDs();
+        expect(typedIDs["highlight"]).toContain("hl-A");
+        expect(typedIDs["dim"]).toContain("dim-A");
+
+        const onMouseEnters = merged.getTypedOnMouseEnters();
+        const onMouseLeaves = merged.getTypedOnMouseLeaves();
+        expect(onMouseEnters["highlight"]?.["hl-A"]).toBe(onMouseEnter);
+        expect(onMouseLeaves["highlight"]?.["hl-A"]).toBe(onMouseLeave);
+
+        const element = editor.getElementByKey(merged.getKey());
+        if (!(element instanceof HTMLElement)) {
+          throw new Error("Expected DOM element for merged mark node");
+        }
+        element.dispatchEvent(new window.MouseEvent("mouseenter"));
+      });
+
+      expect(onMouseEnter).toHaveBeenCalledTimes(1);
+      expect(onMouseEnter).toHaveBeenCalledWith(expect.anything(), "highlight", "hl-A", "man");
+    });
+
+    it("preserves the original mark and its IDs after applying a second annotation to the same range", async () => {
+      const text = "the man who stands";
+      const { annotationPlugin, editor } = await testEnvironment(() => {
+        $getRoot().append($createParaNode().append($createTextNode(text)));
+      });
+
+      const jsonPath = "$.content[0].content[0]";
+      const wordRange: AnnotationRange = {
+        start: { jsonPath, offset: 4 },
+        end: { jsonPath, offset: 7 },
+      };
+
+      await act(async () => {
+        annotationPlugin.setAnnotation(
+          wordRange,
+          "highlight",
+          "hl-A",
+          undefined,
+          undefined,
+          vi.fn(),
+          vi.fn(),
+        );
+      });
+
+      await act(async () => {
+        annotationPlugin.setAnnotation(wordRange, "dim", "dim-A");
+      });
+
+      // Editor should still contain at least one TypedMarkNode covering the word, and that mark
+      // should carry both type+id pairs after the second-annotation cascade resolves.
+      editor.getEditorState().read(() => {
+        const allMarks: TypedMarkNode[] = [];
+        $getRoot()
+          .getAllTextNodes()
+          .forEach((tn) => {
+            for (let p = tn.getParent(); p !== null; p = p.getParent()) {
+              if ($isTypedMarkNode(p) && !allMarks.includes(p)) allMarks.push(p);
+            }
+          });
+        expect(allMarks.length).toBeGreaterThan(0);
+
+        const carryingBoth = allMarks.find((m) => {
+          const ids = m.getTypedIDs();
+          return ids["highlight"]?.includes("hl-A") && ids["dim"]?.includes("dim-A");
+        });
+        expect(carryingBoth).toBeDefined();
+      });
+    });
+  });
 });
+
+/**
+ * Find the TypedMarkNode whose text content is exactly `expectedText` after merge.
+ */
+function $findMergedTypedMarkNode(expectedText: string): TypedMarkNode | null {
+  const stack: LexicalNode[] = $getRoot().getChildren();
+  while (stack.length > 0) {
+    const node = stack.shift();
+    if (node === undefined) break;
+    if ($isTypedMarkNode(node) && node.getTextContent() === expectedText) {
+      return node;
+    }
+    if ($isElementNode(node)) {
+      stack.push(...node.getChildren());
+    }
+  }
+  return null;
+}
 
 async function testEnvironment($initialEditorState: () => void) {
   const annotationPluginRef = createRef<AnnotationRef>();

--- a/libs/shared-react/src/plugins/usj/annotation/AnnotationPlugin.tsx
+++ b/libs/shared-react/src/plugins/usj/annotation/AnnotationPlugin.tsx
@@ -14,6 +14,8 @@ import {
   TypedIDs,
   TypedMarkNode,
   TypedMarkOnClick,
+  TypedMarkOnMouseEnter,
+  TypedMarkOnMouseLeave,
   TypedMarkOnRemove,
 } from "shared";
 
@@ -25,6 +27,8 @@ export interface AnnotationRef {
     id: string,
     onClick?: TypedMarkOnClick,
     onRemove?: TypedMarkOnRemove,
+    onMouseEnter?: TypedMarkOnMouseEnter,
+    onMouseLeave?: TypedMarkOnMouseLeave,
   ): void;
   removeAnnotation(type: string, id: string): void;
 }
@@ -50,17 +54,23 @@ function useAnnotations(editor: LexicalEditor, markNodeMap: Map<string, Set<Node
             from.getTypedIDs(),
             from.getTypedOnClicks(),
             from.getTypedOnRemoves(),
+            from.getTypedOnMouseEnters(),
+            from.getTypedOnMouseLeaves(),
           );
         },
         (from: TypedMarkNode, to: TypedMarkNode) => {
           // Merge the IDs
           const fromOnClicks = from.getTypedOnClicks();
           const fromOnRemoves = from.getTypedOnRemoves();
+          const fromOnMouseEnters = from.getTypedOnMouseEnters();
+          const fromOnMouseLeaves = from.getTypedOnMouseLeaves();
           for (const [type, ids] of Object.entries(from.getTypedIDs())) {
             ids.forEach((id) => {
               const onClick = fromOnClicks[type]?.[id];
               const onRemove = fromOnRemoves[type]?.[id];
-              to.addID(type, id, onClick, onRemove);
+              const onMouseEnter = fromOnMouseEnters[type]?.[id];
+              const onMouseLeave = fromOnMouseLeaves[type]?.[id];
+              to.addID(type, id, onClick, onRemove, onMouseEnter, onMouseLeave);
             });
           }
 
@@ -154,7 +164,15 @@ export const AnnotationPlugin = forwardRef(function AnnotationPlugin<TLogger ext
   };
 
   useImperativeHandle(ref, () => ({
-    setAnnotation(selection, type, id, onClick?: TypedMarkOnClick, onRemove?: TypedMarkOnRemove) {
+    setAnnotation(
+      selection,
+      type,
+      id,
+      onClick?: TypedMarkOnClick,
+      onRemove?: TypedMarkOnRemove,
+      onMouseEnter?: TypedMarkOnMouseEnter,
+      onMouseLeave?: TypedMarkOnMouseLeave,
+    ) {
       if (TypedMarkNode.isReservedType(type))
         throw new Error(
           `setAnnotation: Can't directly set this reserved annotation type '${type}'.` +
@@ -172,7 +190,15 @@ export const AnnotationPlugin = forwardRef(function AnnotationPlugin<TLogger ext
 
           $removeMarkNodesForTypeID(type, id);
 
-          $wrapSelectionInTypedMarkNode(editorSelection, type, id, onClick, onRemove);
+          $wrapSelectionInTypedMarkNode(
+            editorSelection,
+            type,
+            id,
+            onClick,
+            onRemove,
+            onMouseEnter,
+            onMouseLeave,
+          );
         },
         { tag: ANNOTATION_CHANGE_TAG },
       );

--- a/libs/shared-react/src/views/view-options.utils.ts
+++ b/libs/shared-react/src/views/view-options.utils.ts
@@ -56,6 +56,12 @@ export interface ViewOptions {
   hasSpacing: boolean;
   /** Is the text in a formatted font. */
   isFormattedFont: boolean;
+  /**
+   * When false, `CharNode.createDOM` skips setting the `title=__marker` attribute on rendered
+   * char spans. Useful for consumers that don't want the USFM marker name surfaced as a browser
+   * tooltip. Default (undefined or true) preserves the marker hint for consumers authoring USFM.
+   */
+  showCharMarkerTitles?: boolean;
 }
 
 let defaultViewMode: ViewMode;

--- a/libs/shared/src/nodes/features/TypedMarkNode.test.ts
+++ b/libs/shared/src/nodes/features/TypedMarkNode.test.ts
@@ -1,6 +1,12 @@
 import { $createParaNode, ParaNode } from "../usj/ParaNode.js";
 import { createBasicTestEnvironment } from "../usj/test.utils.js";
-import { $createTypedMarkNode, $isTypedMarkNode, TypedMarkNode } from "./TypedMarkNode.js";
+import {
+  $createTypedMarkNode,
+  $isTypedMarkNode,
+  TypedMarkNode,
+  TypedMarkOnMouseEnter,
+  TypedMarkOnMouseLeave,
+} from "./TypedMarkNode.js";
 import { $createTextNode, $getRoot, EditorConfig, TextNode } from "lexical";
 import { vi } from "vitest";
 
@@ -445,6 +451,175 @@ describe("TypedMarkNode", () => {
       });
 
       expect(onRemoveRight).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("TypedMarkNode hover events", () => {
+    it("fires onMouseEnter when the cursor enters the <mark>", () => {
+      const onMouseEnter = vi.fn<TypedMarkOnMouseEnter>();
+      let markNode: TypedMarkNode | null = null;
+      const { editor } = createBasicTestEnvironment([ParaNode, TypedMarkNode], () => {
+        markNode = $createTypedMarkNode({});
+        markNode.addID(testType1, testID1, undefined, undefined, onMouseEnter);
+        $getRoot().append($createParaNode().append(markNode.append($createTextNode("example"))));
+      });
+
+      editor.getEditorState().read(() => {
+        if (!markNode) throw new Error("Expected mark node to exist");
+        const element = editor.getElementByKey(markNode.getKey());
+        if (!(element instanceof HTMLElement)) {
+          throw new Error("Expected DOM element for mark node");
+        }
+        element.dispatchEvent(new window.MouseEvent("mouseenter"));
+
+        expect(onMouseEnter).toHaveBeenCalledTimes(1);
+        expect(onMouseEnter).toHaveBeenCalledWith(expect.anything(), testType1, testID1, "example");
+      });
+    });
+
+    it("fires onMouseLeave when the cursor leaves the <mark>", () => {
+      const onMouseLeave = vi.fn<TypedMarkOnMouseLeave>();
+      let markNode: TypedMarkNode | null = null;
+      const { editor } = createBasicTestEnvironment([ParaNode, TypedMarkNode], () => {
+        markNode = $createTypedMarkNode({});
+        markNode.addID(testType1, testID1, undefined, undefined, undefined, onMouseLeave);
+        $getRoot().append($createParaNode().append(markNode.append($createTextNode("example"))));
+      });
+
+      editor.getEditorState().read(() => {
+        if (!markNode) throw new Error("Expected mark node to exist");
+        const element = editor.getElementByKey(markNode.getKey());
+        if (!(element instanceof HTMLElement)) {
+          throw new Error("Expected DOM element for mark node");
+        }
+        element.dispatchEvent(new window.MouseEvent("mouseleave"));
+
+        expect(onMouseLeave).toHaveBeenCalledTimes(1);
+        expect(onMouseLeave).toHaveBeenCalledWith(expect.anything(), testType1, testID1, "example");
+      });
+    });
+
+    it("fires both callbacks for every (type, id) on a multi-id mark", () => {
+      const onMouseEnterA = vi.fn<TypedMarkOnMouseEnter>();
+      const onMouseEnterB = vi.fn<TypedMarkOnMouseEnter>();
+      let markNode: TypedMarkNode | null = null;
+      const { editor } = createBasicTestEnvironment([ParaNode, TypedMarkNode], () => {
+        markNode = $createTypedMarkNode({});
+        markNode.addID(testType1, testID1, undefined, undefined, onMouseEnterA);
+        markNode.addID(testType2, testID2, undefined, undefined, onMouseEnterB);
+        $getRoot().append($createParaNode().append(markNode.append($createTextNode("example"))));
+      });
+
+      editor.getEditorState().read(() => {
+        if (!markNode) throw new Error("Expected mark node to exist");
+        const element = editor.getElementByKey(markNode.getKey());
+        if (!(element instanceof HTMLElement)) {
+          throw new Error("Expected DOM element for mark node");
+        }
+        element.dispatchEvent(new window.MouseEvent("mouseenter"));
+
+        expect(onMouseEnterA).toHaveBeenCalledTimes(1);
+        expect(onMouseEnterA).toHaveBeenCalledWith(
+          expect.anything(),
+          testType1,
+          testID1,
+          "example",
+        );
+        expect(onMouseEnterB).toHaveBeenCalledTimes(1);
+        expect(onMouseEnterB).toHaveBeenCalledWith(
+          expect.anything(),
+          testType2,
+          testID2,
+          "example",
+        );
+      });
+    });
+
+    it("drops hover callbacks when deleteID is called", () => {
+      const onMouseEnter = vi.fn<TypedMarkOnMouseEnter>();
+      let markNode: TypedMarkNode | null = null;
+      const { editor } = createBasicTestEnvironment([ParaNode, TypedMarkNode], () => {
+        markNode = $createTypedMarkNode({});
+        markNode.addID(testType1, testID1, undefined, undefined, onMouseEnter);
+        $getRoot().append($createParaNode().append(markNode.append($createTextNode("example"))));
+      });
+
+      editor.update(() => {
+        if (!markNode) throw new Error("Expected mark node to exist");
+        markNode.deleteID(testType1, testID1);
+      });
+
+      // After deleteID the mark unwraps; if any element still exists, dispatching shouldn't fire
+      // the callback because it has been removed from the registry.
+      editor.getEditorState().read(() => {
+        if (!markNode) throw new Error("Expected mark node to exist");
+        const element = editor.getElementByKey(markNode.getKey());
+        if (element instanceof HTMLElement) {
+          element.dispatchEvent(new window.MouseEvent("mouseenter"));
+        }
+        expect(onMouseEnter).not.toHaveBeenCalled();
+      });
+    });
+
+    it("survives merge of adjacent typed marks with identical typedIDs", () => {
+      const grammarType = testType1;
+      const grammarId = testID1;
+      const spellingType = testType2;
+      const spellingId = testID2;
+      const onMouseEnterLeft = vi.fn<TypedMarkOnMouseEnter>();
+      const onMouseEnterRight = vi.fn<TypedMarkOnMouseEnter>();
+      let leftMark: TypedMarkNode | null = null;
+      let rightMark: TypedMarkNode | null = null;
+      const { editor } = createBasicTestEnvironment([ParaNode, TypedMarkNode], () => {
+        const paraNode = $createParaNode();
+        leftMark = $createTypedMarkNode({
+          [grammarType]: [grammarId],
+          [spellingType]: [spellingId],
+        });
+        rightMark = $createTypedMarkNode({
+          [grammarType]: [grammarId],
+        });
+        leftMark.addID(grammarType, grammarId, undefined, undefined, onMouseEnterLeft);
+        leftMark.addID(spellingType, spellingId);
+        rightMark.addID(grammarType, grammarId, undefined, undefined, onMouseEnterRight);
+        $getRoot().append(
+          paraNode.append(
+            leftMark.append($createTextNode("man")),
+            rightMark.append($createTextNode(" who")),
+          ),
+        );
+      });
+
+      editor.update(() => {
+        if (!leftMark || !rightMark) throw new Error("Expected mark nodes to exist");
+        // Removing the spelling ID makes the typedIDs equal between leftMark and rightMark and
+        // merges them. The merged node should retain the leftMark's onMouseEnter for grammar.
+        leftMark.deleteID(spellingType, spellingId);
+      });
+
+      editor.getEditorState().read(() => {
+        if (!leftMark) throw new Error("Expected left mark node");
+        const node = leftMark;
+        const element = editor.getElementByKey(node.getKey());
+        if (!(element instanceof HTMLElement)) {
+          throw new Error("Expected DOM element for merged mark node");
+        }
+        element.dispatchEvent(new window.MouseEvent("mouseenter"));
+
+        // The left callback (the primary, since left absorbs right) should fire exactly once for
+        // (grammarType, grammarId). Primary-wins is the intentional contract - see
+        // mergeTypedOnMouseEnterMaps. If two adjacent marks both register a callback under the
+        // same (type, id), the surviving (primary) mark's callback is preserved and the
+        // overwritten side is silently dropped.
+        expect(onMouseEnterLeft).toHaveBeenCalledTimes(1);
+        expect(onMouseEnterLeft).toHaveBeenCalledWith(
+          expect.anything(),
+          grammarType,
+          grammarId,
+          "man who",
+        );
+        expect(onMouseEnterRight).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/libs/shared/src/nodes/features/TypedMarkNode.ts
+++ b/libs/shared/src/nodes/features/TypedMarkNode.ts
@@ -85,6 +85,44 @@ export interface TypedOnRemoves {
   [type: string]: { [id: string]: TypedMarkOnRemove };
 }
 
+/**
+ * A callback function type for handling mouse-enter events on annotated marks.
+ *
+ * Fires once when the cursor enters the rendered `<mark>` element. Uses native `mouseenter`
+ * semantics (no bubbling, no re-fire as cursor crosses inner text-node boundaries).
+ *
+ * @public
+ */
+export type TypedMarkOnMouseEnter = (
+  event: DomMouseEvent,
+  type: string,
+  id: string,
+  textContent: string,
+) => void;
+
+export interface TypedOnMouseEnters {
+  [type: string]: { [id: string]: TypedMarkOnMouseEnter };
+}
+
+/**
+ * A callback function type for handling mouse-leave events on annotated marks.
+ *
+ * Fires once when the cursor leaves the rendered `<mark>` element. Uses native `mouseleave`
+ * semantics (no bubbling).
+ *
+ * @public
+ */
+export type TypedMarkOnMouseLeave = (
+  event: DomMouseEvent,
+  type: string,
+  id: string,
+  textContent: string,
+) => void;
+
+export interface TypedOnMouseLeaves {
+  [type: string]: { [id: string]: TypedMarkOnMouseLeave };
+}
+
 export type SerializedTypedMarkNode = Spread<
   {
     typedIDs: TypedIDs;
@@ -99,32 +137,48 @@ const reservedTypes = [COMMENT_MARK_TYPE];
 const NO_IDS: TypedIDs = Object.freeze({});
 const NO_ON_CLICKS: TypedOnClicks = Object.freeze({});
 const NO_ON_REMOVES: TypedOnRemoves = Object.freeze({});
+const NO_ON_MOUSE_ENTERS: TypedOnMouseEnters = Object.freeze({});
+const NO_ON_MOUSE_LEAVES: TypedOnMouseLeaves = Object.freeze({});
 const TYPED_MARK_VERSION = 1;
 
 const typedOnClickRegistry = new Map<NodeKey, TypedOnClicks>();
 const typedOnRemoveRegistry = new Map<NodeKey, TypedOnRemoves>();
+const typedOnMouseEnterRegistry = new Map<NodeKey, TypedOnMouseEnters>();
+const typedOnMouseLeaveRegistry = new Map<NodeKey, TypedOnMouseLeaves>();
 
 export class TypedMarkNode extends ElementNode {
   __typedIDs: TypedIDs;
   __typedOnClicks?: TypedOnClicks;
   __typedOnRemoves?: TypedOnRemoves;
+  __typedOnMouseEnters?: TypedOnMouseEnters;
+  __typedOnMouseLeaves?: TypedOnMouseLeaves;
   __domOnClickListener?: (event: DomMouseEvent) => void;
+  __domOnMouseEnterListener?: (event: DomMouseEvent) => void;
+  __domOnMouseLeaveListener?: (event: DomMouseEvent) => void;
   __suppressOnRemoveCallbacks?: boolean;
 
   constructor(
     typedIds: TypedIDs = NO_IDS,
     typedOnClicks?: TypedOnClicks,
     typedOnRemoves?: TypedOnRemoves,
+    typedOnMouseEnters?: TypedOnMouseEnters,
+    typedOnMouseLeaves?: TypedOnMouseLeaves,
     key?: NodeKey,
   ) {
     super(key);
     this.__typedIDs = cloneTypedIDs(typedIds);
     this.__typedOnClicks = cloneTypedOnClicks(typedOnClicks);
     this.__typedOnRemoves = cloneTypedOnRemoves(typedOnRemoves);
+    this.__typedOnMouseEnters = cloneTypedOnMouseEnters(typedOnMouseEnters);
+    this.__typedOnMouseLeaves = cloneTypedOnMouseLeaves(typedOnMouseLeaves);
     this.pruneTypedOnClicks();
     this.pruneTypedOnRemoves();
+    this.pruneTypedOnMouseEnters();
+    this.pruneTypedOnMouseLeaves();
     this.syncTypedOnClicksToRegistry();
     this.syncTypedOnRemovesToRegistry();
+    this.syncTypedOnMouseEntersToRegistry();
+    this.syncTypedOnMouseLeavesToRegistry();
   }
 
   static override getType(): string {
@@ -135,7 +189,16 @@ export class TypedMarkNode extends ElementNode {
     const __typedIDs = cloneTypedIDs(node.__typedIDs);
     const __typedOnClicks = cloneTypedOnClicks(node.__typedOnClicks);
     const __typedOnRemoves = cloneTypedOnRemoves(node.__typedOnRemoves);
-    return new TypedMarkNode(__typedIDs, __typedOnClicks, __typedOnRemoves, node.__key);
+    const __typedOnMouseEnters = cloneTypedOnMouseEnters(node.__typedOnMouseEnters);
+    const __typedOnMouseLeaves = cloneTypedOnMouseLeaves(node.__typedOnMouseLeaves);
+    return new TypedMarkNode(
+      __typedIDs,
+      __typedOnClicks,
+      __typedOnRemoves,
+      __typedOnMouseEnters,
+      __typedOnMouseLeaves,
+      node.__key,
+    );
   }
 
   static isReservedType(type: string): boolean {
@@ -172,6 +235,10 @@ export class TypedMarkNode extends ElementNode {
     }
     const clickListener = this.getOrCreateDOMClickListener(editor);
     element.addEventListener("click", clickListener);
+    const mouseEnterListener = this.getOrCreateDOMMouseEnterListener(editor);
+    element.addEventListener("mouseenter", mouseEnterListener);
+    const mouseLeaveListener = this.getOrCreateDOMMouseLeaveListener(editor);
+    element.addEventListener("mouseleave", mouseLeaveListener);
     return element;
   }
 
@@ -251,8 +318,12 @@ export class TypedMarkNode extends ElementNode {
     self.dispatchRemovedIDs(previousIDs, self.__typedIDs, "removed");
     self.pruneTypedOnClicks();
     self.pruneTypedOnRemoves();
+    self.pruneTypedOnMouseEnters();
+    self.pruneTypedOnMouseLeaves();
     self.syncTypedOnClicksToRegistry();
     self.syncTypedOnRemovesToRegistry();
+    self.syncTypedOnMouseEntersToRegistry();
+    self.syncTypedOnMouseLeavesToRegistry();
     const mergedNode = self.mergeWithAdjacentTypedMarks();
     if (mergedNode.hasNoIDsForEveryType() && mergedNode.getParent() !== null)
       $unwrapTypedMarkNode(mergedNode);
@@ -289,7 +360,44 @@ export class TypedMarkNode extends ElementNode {
     return stored ?? {};
   }
 
-  addID(type: string, id: string, onClick?: TypedMarkOnClick, onRemove?: TypedMarkOnRemove): void {
+  setTypedOnMouseEnters(typedOnMouseEnters: TypedOnMouseEnters): this {
+    const self = this.getWritable();
+    self.__typedOnMouseEnters = cloneTypedOnMouseEnters(typedOnMouseEnters);
+    self.pruneTypedOnMouseEnters();
+    self.syncTypedOnMouseEntersToRegistry();
+    return self;
+  }
+
+  getTypedOnMouseEnters(): TypedOnMouseEnters {
+    const self = this.getLatest();
+    if (!$isTypedMarkNode(self)) return {};
+    const stored = typedOnMouseEnterRegistry.get(self.getKey());
+    return stored ?? {};
+  }
+
+  setTypedOnMouseLeaves(typedOnMouseLeaves: TypedOnMouseLeaves): this {
+    const self = this.getWritable();
+    self.__typedOnMouseLeaves = cloneTypedOnMouseLeaves(typedOnMouseLeaves);
+    self.pruneTypedOnMouseLeaves();
+    self.syncTypedOnMouseLeavesToRegistry();
+    return self;
+  }
+
+  getTypedOnMouseLeaves(): TypedOnMouseLeaves {
+    const self = this.getLatest();
+    if (!$isTypedMarkNode(self)) return {};
+    const stored = typedOnMouseLeaveRegistry.get(self.getKey());
+    return stored ?? {};
+  }
+
+  addID(
+    type: string,
+    id: string,
+    onClick?: TypedMarkOnClick,
+    onRemove?: TypedMarkOnRemove,
+    onMouseEnter?: TypedMarkOnMouseEnter,
+    onMouseLeave?: TypedMarkOnMouseLeave,
+  ): void {
     const self = this.getWritable();
     if (!$isTypedMarkNode(self)) return;
 
@@ -305,12 +413,16 @@ export class TypedMarkNode extends ElementNode {
       if (id === existingId) {
         if (onClick) self.setOnClickFor(type, id, onClick);
         if (onRemove) self.setOnRemoveFor(type, id, onRemove);
+        if (onMouseEnter) self.setOnMouseEnterFor(type, id, onMouseEnter);
+        if (onMouseLeave) self.setOnMouseLeaveFor(type, id, onMouseLeave);
         return;
       }
     }
     ids.push(id);
     if (onClick) self.setOnClickFor(type, id, onClick);
     if (onRemove) self.setOnRemoveFor(type, id, onRemove);
+    if (onMouseEnter) self.setOnMouseEnterFor(type, id, onMouseEnter);
+    if (onMouseLeave) self.setOnMouseLeaveFor(type, id, onMouseLeave);
   }
 
   deleteID(type: string, id: string): void {
@@ -330,8 +442,12 @@ export class TypedMarkNode extends ElementNode {
 
     self.removeOnClickFor(type, id);
     self.removeOnRemoveFor(type, id);
+    self.removeOnMouseEnterFor(type, id);
+    self.removeOnMouseLeaveFor(type, id);
     self.pruneTypedOnClicks();
     self.pruneTypedOnRemoves();
+    self.pruneTypedOnMouseEnters();
+    self.pruneTypedOnMouseLeaves();
     const mergedNode = self.mergeWithAdjacentTypedMarks();
     if (mergedNode.hasNoIDsForEveryType() && mergedNode.getParent() !== null)
       $unwrapTypedMarkNode(mergedNode);
@@ -401,8 +517,12 @@ export class TypedMarkNode extends ElementNode {
 
     typedOnClickRegistry.delete(self.getKey());
     typedOnRemoveRegistry.delete(self.getKey());
+    typedOnMouseEnterRegistry.delete(self.getKey());
+    typedOnMouseLeaveRegistry.delete(self.getKey());
     self.__typedOnClicks = undefined;
     self.__typedOnRemoves = undefined;
+    self.__typedOnMouseEnters = undefined;
+    self.__typedOnMouseLeaves = undefined;
 
     super.remove.call(self, preserveEmptyParent);
   }
@@ -422,6 +542,62 @@ export class TypedMarkNode extends ElementNode {
 
     const callbacks: [TypedMarkOnClick, string, string][] = [];
     for (const [type, callbacksById] of Object.entries(typedOnClicks)) {
+      for (const [id, callback] of Object.entries(callbacksById)) {
+        if (callback) callbacks.push([callback, type, id]);
+      }
+    }
+
+    if (callbacks.length === 0) return;
+
+    const textContent = editor.read(() => this.getTextContent());
+    for (const [callback, type, id] of callbacks) {
+      callback(event, type, id, textContent);
+    }
+  }
+
+  private getOrCreateDOMMouseEnterListener(editor: LexicalEditor): (event: DomMouseEvent) => void {
+    if (!this.__domOnMouseEnterListener) {
+      this.__domOnMouseEnterListener = (event: DomMouseEvent) => {
+        this.handleDOMMouseEnter(event, editor);
+      };
+    }
+    return this.__domOnMouseEnterListener;
+  }
+
+  private handleDOMMouseEnter(event: DomMouseEvent, editor: LexicalEditor): void {
+    const typedOnMouseEnters = typedOnMouseEnterRegistry.get(this.getKey());
+    if (!typedOnMouseEnters) return;
+
+    const callbacks: [TypedMarkOnMouseEnter, string, string][] = [];
+    for (const [type, callbacksById] of Object.entries(typedOnMouseEnters)) {
+      for (const [id, callback] of Object.entries(callbacksById)) {
+        if (callback) callbacks.push([callback, type, id]);
+      }
+    }
+
+    if (callbacks.length === 0) return;
+
+    const textContent = editor.read(() => this.getTextContent());
+    for (const [callback, type, id] of callbacks) {
+      callback(event, type, id, textContent);
+    }
+  }
+
+  private getOrCreateDOMMouseLeaveListener(editor: LexicalEditor): (event: DomMouseEvent) => void {
+    if (!this.__domOnMouseLeaveListener) {
+      this.__domOnMouseLeaveListener = (event: DomMouseEvent) => {
+        this.handleDOMMouseLeave(event, editor);
+      };
+    }
+    return this.__domOnMouseLeaveListener;
+  }
+
+  private handleDOMMouseLeave(event: DomMouseEvent, editor: LexicalEditor): void {
+    const typedOnMouseLeaves = typedOnMouseLeaveRegistry.get(this.getKey());
+    if (!typedOnMouseLeaves) return;
+
+    const callbacks: [TypedMarkOnMouseLeave, string, string][] = [];
+    for (const [type, callbacksById] of Object.entries(typedOnMouseLeaves)) {
       for (const [id, callback] of Object.entries(callbacksById)) {
         if (callback) callbacks.push([callback, type, id]);
       }
@@ -594,6 +770,176 @@ export class TypedMarkNode extends ElementNode {
     this.syncTypedOnRemovesToRegistry();
   }
 
+  private ensureOnMouseEnterMapMutable(): TypedOnMouseEnters {
+    if (
+      this.__typedOnMouseEnters === undefined ||
+      this.__typedOnMouseEnters === NO_ON_MOUSE_ENTERS
+    ) {
+      const existing = typedOnMouseEnterRegistry.get(this.getKey());
+      this.__typedOnMouseEnters = existing ?? {};
+    }
+    return this.__typedOnMouseEnters;
+  }
+
+  private syncTypedOnMouseEntersToRegistry(): void {
+    if (!this.__typedOnMouseEnters || Object.keys(this.__typedOnMouseEnters).length === 0) {
+      typedOnMouseEnterRegistry.delete(this.getKey());
+      if (this.__typedOnMouseEnters && Object.keys(this.__typedOnMouseEnters).length === 0) {
+        this.__typedOnMouseEnters = undefined;
+      }
+      return;
+    }
+    typedOnMouseEnterRegistry.set(this.getKey(), this.__typedOnMouseEnters);
+  }
+
+  private setOnMouseEnterFor(type: string, id: string, onMouseEnter: TypedMarkOnMouseEnter): void {
+    assertSafeKey(type);
+    assertSafeKey(id);
+
+    const callbacks = this.ensureOnMouseEnterMapMutable();
+    const typeCallbacks = callbacks[type] ?? (callbacks[type] = {});
+    typeCallbacks[id] = onMouseEnter;
+    this.syncTypedOnMouseEntersToRegistry();
+  }
+
+  private removeOnMouseEnterFor(type: string, id: string): void {
+    if (!this.__typedOnMouseEnters) return;
+    const typeCallbacks = this.__typedOnMouseEnters[type];
+    if (!typeCallbacks) return;
+
+    const updatedTypeCallbacks = omitRecordKey(typeCallbacks, id);
+    const hasRemainingCallbacks = Object.keys(updatedTypeCallbacks).length > 0;
+
+    if (hasRemainingCallbacks) {
+      this.__typedOnMouseEnters = {
+        ...this.__typedOnMouseEnters,
+        [type]: updatedTypeCallbacks,
+      };
+    } else {
+      const remainingCallbacks = omitRecordKey(this.__typedOnMouseEnters, type);
+      this.__typedOnMouseEnters =
+        Object.keys(remainingCallbacks).length > 0 ? remainingCallbacks : undefined;
+    }
+
+    this.syncTypedOnMouseEntersToRegistry();
+  }
+
+  private pruneTypedOnMouseEnters(): void {
+    if (!this.__typedOnMouseEnters || this.__typedOnMouseEnters === NO_ON_MOUSE_ENTERS) {
+      this.__typedOnMouseEnters = undefined;
+      this.syncTypedOnMouseEntersToRegistry();
+      return;
+    }
+
+    const nextTypedOnMouseEnters: TypedOnMouseEnters = {};
+
+    for (const [type, callbacks] of Object.entries(this.__typedOnMouseEnters)) {
+      const ids = this.__typedIDs[type];
+      if (!ids || ids.length === 0) {
+        continue;
+      }
+      const idSet = new Set(ids);
+      const filteredCallbacks: { [id: string]: TypedMarkOnMouseEnter } = {};
+      for (const [id, callback] of Object.entries(callbacks)) {
+        if (idSet.has(id)) {
+          filteredCallbacks[id] = callback;
+        }
+      }
+      if (Object.keys(filteredCallbacks).length > 0) {
+        nextTypedOnMouseEnters[type] = filteredCallbacks;
+      }
+    }
+
+    this.__typedOnMouseEnters =
+      Object.keys(nextTypedOnMouseEnters).length > 0 ? nextTypedOnMouseEnters : undefined;
+    this.syncTypedOnMouseEntersToRegistry();
+  }
+
+  private ensureOnMouseLeaveMapMutable(): TypedOnMouseLeaves {
+    if (
+      this.__typedOnMouseLeaves === undefined ||
+      this.__typedOnMouseLeaves === NO_ON_MOUSE_LEAVES
+    ) {
+      const existing = typedOnMouseLeaveRegistry.get(this.getKey());
+      this.__typedOnMouseLeaves = existing ?? {};
+    }
+    return this.__typedOnMouseLeaves;
+  }
+
+  private syncTypedOnMouseLeavesToRegistry(): void {
+    if (!this.__typedOnMouseLeaves || Object.keys(this.__typedOnMouseLeaves).length === 0) {
+      typedOnMouseLeaveRegistry.delete(this.getKey());
+      if (this.__typedOnMouseLeaves && Object.keys(this.__typedOnMouseLeaves).length === 0) {
+        this.__typedOnMouseLeaves = undefined;
+      }
+      return;
+    }
+    typedOnMouseLeaveRegistry.set(this.getKey(), this.__typedOnMouseLeaves);
+  }
+
+  private setOnMouseLeaveFor(type: string, id: string, onMouseLeave: TypedMarkOnMouseLeave): void {
+    assertSafeKey(type);
+    assertSafeKey(id);
+
+    const callbacks = this.ensureOnMouseLeaveMapMutable();
+    const typeCallbacks = callbacks[type] ?? (callbacks[type] = {});
+    typeCallbacks[id] = onMouseLeave;
+    this.syncTypedOnMouseLeavesToRegistry();
+  }
+
+  private removeOnMouseLeaveFor(type: string, id: string): void {
+    if (!this.__typedOnMouseLeaves) return;
+    const typeCallbacks = this.__typedOnMouseLeaves[type];
+    if (!typeCallbacks) return;
+
+    const updatedTypeCallbacks = omitRecordKey(typeCallbacks, id);
+    const hasRemainingCallbacks = Object.keys(updatedTypeCallbacks).length > 0;
+
+    if (hasRemainingCallbacks) {
+      this.__typedOnMouseLeaves = {
+        ...this.__typedOnMouseLeaves,
+        [type]: updatedTypeCallbacks,
+      };
+    } else {
+      const remainingCallbacks = omitRecordKey(this.__typedOnMouseLeaves, type);
+      this.__typedOnMouseLeaves =
+        Object.keys(remainingCallbacks).length > 0 ? remainingCallbacks : undefined;
+    }
+
+    this.syncTypedOnMouseLeavesToRegistry();
+  }
+
+  private pruneTypedOnMouseLeaves(): void {
+    if (!this.__typedOnMouseLeaves || this.__typedOnMouseLeaves === NO_ON_MOUSE_LEAVES) {
+      this.__typedOnMouseLeaves = undefined;
+      this.syncTypedOnMouseLeavesToRegistry();
+      return;
+    }
+
+    const nextTypedOnMouseLeaves: TypedOnMouseLeaves = {};
+
+    for (const [type, callbacks] of Object.entries(this.__typedOnMouseLeaves)) {
+      const ids = this.__typedIDs[type];
+      if (!ids || ids.length === 0) {
+        continue;
+      }
+      const idSet = new Set(ids);
+      const filteredCallbacks: { [id: string]: TypedMarkOnMouseLeave } = {};
+      for (const [id, callback] of Object.entries(callbacks)) {
+        if (idSet.has(id)) {
+          filteredCallbacks[id] = callback;
+        }
+      }
+      if (Object.keys(filteredCallbacks).length > 0) {
+        nextTypedOnMouseLeaves[type] = filteredCallbacks;
+      }
+    }
+
+    this.__typedOnMouseLeaves =
+      Object.keys(nextTypedOnMouseLeaves).length > 0 ? nextTypedOnMouseLeaves : undefined;
+    this.syncTypedOnMouseLeavesToRegistry();
+  }
+
   private invokeOnRemove(type: string, id: string, cause: TypedMarkRemovalCause): void {
     const callbacks = this.getTypedOnRemoves();
     const callback = callbacks[type]?.[id];
@@ -649,14 +995,14 @@ export class TypedMarkNode extends ElementNode {
   private mergeWithPreviousTypedMark(previous: TypedMarkNode): void {
     this.mergeOnClicksFrom(previous.getTypedOnClicks());
     this.mergeOnRemovesFrom(previous.getTypedOnRemoves());
+    this.mergeOnMouseEntersFrom(previous.getTypedOnMouseEnters());
+    this.mergeOnMouseLeavesFrom(previous.getTypedOnMouseLeaves());
 
     const previousChildren = previous.getChildren();
     if (previousChildren.length > 0) {
       this.splice(0, 0, previousChildren);
     }
 
-    typedOnClickRegistry.delete(previous.getKey());
-    typedOnRemoveRegistry.delete(previous.getKey());
     previous.getWritable().__suppressOnRemoveCallbacks = true;
     previous.remove();
   }
@@ -664,14 +1010,14 @@ export class TypedMarkNode extends ElementNode {
   private mergeWithNextTypedMark(next: TypedMarkNode): void {
     this.mergeOnClicksFrom(next.getTypedOnClicks());
     this.mergeOnRemovesFrom(next.getTypedOnRemoves());
+    this.mergeOnMouseEntersFrom(next.getTypedOnMouseEnters());
+    this.mergeOnMouseLeavesFrom(next.getTypedOnMouseLeaves());
 
     const nextChildren = next.getChildren();
     if (nextChildren.length > 0) {
       this.append(...nextChildren);
     }
 
-    typedOnClickRegistry.delete(next.getKey());
-    typedOnRemoveRegistry.delete(next.getKey());
     next.getWritable().__suppressOnRemoveCallbacks = true;
     next.remove();
   }
@@ -690,6 +1036,22 @@ export class TypedMarkNode extends ElementNode {
     if (Object.keys(merged).length === 0) return;
 
     this.setTypedOnRemoves(merged);
+  }
+
+  private mergeOnMouseEntersFrom(additional: TypedOnMouseEnters): void {
+    if (!additional || Object.keys(additional).length === 0) return;
+    const merged = mergeTypedOnMouseEnterMaps(this.getTypedOnMouseEnters(), additional);
+    if (Object.keys(merged).length === 0) return;
+
+    this.setTypedOnMouseEnters(merged);
+  }
+
+  private mergeOnMouseLeavesFrom(additional: TypedOnMouseLeaves): void {
+    if (!additional || Object.keys(additional).length === 0) return;
+    const merged = mergeTypedOnMouseLeaveMaps(this.getTypedOnMouseLeaves(), additional);
+    if (Object.keys(merged).length === 0) return;
+
+    this.setTypedOnMouseLeaves(merged);
   }
 }
 
@@ -737,6 +1099,44 @@ function cloneTypedOnRemoves(typedOnRemoves?: TypedOnRemoves): TypedOnRemoves | 
   for (const [type, callbacks] of Object.entries(typedOnRemoves)) {
     assertSafeKey(type);
     const clonedCallbacks: { [id: string]: TypedMarkOnRemove } = {};
+    for (const [id, callback] of Object.entries(callbacks)) {
+      assertSafeKey(id);
+      clonedCallbacks[id] = callback;
+    }
+    if (Object.keys(clonedCallbacks).length > 0) clone[type] = clonedCallbacks;
+  }
+
+  return Object.keys(clone).length > 0 ? clone : undefined;
+}
+
+function cloneTypedOnMouseEnters(
+  typedOnMouseEnters?: TypedOnMouseEnters,
+): TypedOnMouseEnters | undefined {
+  if (!typedOnMouseEnters || typedOnMouseEnters === NO_ON_MOUSE_ENTERS) return undefined;
+
+  const clone: TypedOnMouseEnters = {};
+  for (const [type, callbacks] of Object.entries(typedOnMouseEnters)) {
+    assertSafeKey(type);
+    const clonedCallbacks: { [id: string]: TypedMarkOnMouseEnter } = {};
+    for (const [id, callback] of Object.entries(callbacks)) {
+      assertSafeKey(id);
+      clonedCallbacks[id] = callback;
+    }
+    if (Object.keys(clonedCallbacks).length > 0) clone[type] = clonedCallbacks;
+  }
+
+  return Object.keys(clone).length > 0 ? clone : undefined;
+}
+
+function cloneTypedOnMouseLeaves(
+  typedOnMouseLeaves?: TypedOnMouseLeaves,
+): TypedOnMouseLeaves | undefined {
+  if (!typedOnMouseLeaves || typedOnMouseLeaves === NO_ON_MOUSE_LEAVES) return undefined;
+
+  const clone: TypedOnMouseLeaves = {};
+  for (const [type, callbacks] of Object.entries(typedOnMouseLeaves)) {
+    assertSafeKey(type);
+    const clonedCallbacks: { [id: string]: TypedMarkOnMouseLeave } = {};
     for (const [id, callback] of Object.entries(callbacks)) {
       assertSafeKey(id);
       clonedCallbacks[id] = callback;
@@ -845,6 +1245,54 @@ function mergeTypedOnRemoveMaps(
   return merged;
 }
 
+function mergeTypedOnMouseEnterMaps(
+  primary: TypedOnMouseEnters,
+  secondary: TypedOnMouseEnters,
+): TypedOnMouseEnters {
+  const merged: TypedOnMouseEnters = {};
+  const types = new Set([...Object.keys(primary), ...Object.keys(secondary)]);
+
+  for (const type of types) {
+    const primaryCallbacks = primary[type] ?? {};
+    const secondaryCallbacks = secondary[type] ?? {};
+    const ids = new Set([...Object.keys(primaryCallbacks), ...Object.keys(secondaryCallbacks)]);
+
+    const mergedCallbacks: { [id: string]: TypedMarkOnMouseEnter } = {};
+    for (const id of ids) {
+      const callback = primaryCallbacks[id] ?? secondaryCallbacks[id];
+      if (callback) mergedCallbacks[id] = callback;
+    }
+
+    if (Object.keys(mergedCallbacks).length > 0) merged[type] = mergedCallbacks;
+  }
+
+  return merged;
+}
+
+function mergeTypedOnMouseLeaveMaps(
+  primary: TypedOnMouseLeaves,
+  secondary: TypedOnMouseLeaves,
+): TypedOnMouseLeaves {
+  const merged: TypedOnMouseLeaves = {};
+  const types = new Set([...Object.keys(primary), ...Object.keys(secondary)]);
+
+  for (const type of types) {
+    const primaryCallbacks = primary[type] ?? {};
+    const secondaryCallbacks = secondary[type] ?? {};
+    const ids = new Set([...Object.keys(primaryCallbacks), ...Object.keys(secondaryCallbacks)]);
+
+    const mergedCallbacks: { [id: string]: TypedMarkOnMouseLeave } = {};
+    for (const id of ids) {
+      const callback = primaryCallbacks[id] ?? secondaryCallbacks[id];
+      if (callback) mergedCallbacks[id] = callback;
+    }
+
+    if (Object.keys(mergedCallbacks).length > 0) merged[type] = mergedCallbacks;
+  }
+
+  return merged;
+}
+
 function getTypedClassName(className: string, type: string): string {
   return `${className}-${type}`;
 }
@@ -864,8 +1312,18 @@ export function $createTypedMarkNode(
   typedIds?: TypedIDs,
   typedOnClicks?: TypedOnClicks,
   typedOnRemoves?: TypedOnRemoves,
+  typedOnMouseEnters?: TypedOnMouseEnters,
+  typedOnMouseLeaves?: TypedOnMouseLeaves,
 ): TypedMarkNode {
-  return $applyNodeReplacement(new TypedMarkNode(typedIds, typedOnClicks, typedOnRemoves));
+  return $applyNodeReplacement(
+    new TypedMarkNode(
+      typedIds,
+      typedOnClicks,
+      typedOnRemoves,
+      typedOnMouseEnters,
+      typedOnMouseLeaves,
+    ),
+  );
 }
 
 export function $isTypedMarkNode(node: LexicalNode | null | undefined): node is TypedMarkNode {
@@ -892,7 +1350,6 @@ export function $unwrapTypedMarkNode(node: TypedMarkNode): void {
     target = child;
   }
   node.remove();
-  typedOnClickRegistry.delete(node.getKey());
 }
 
 export function $wrapSelectionInTypedMarkNode(
@@ -901,6 +1358,8 @@ export function $wrapSelectionInTypedMarkNode(
   id: string,
   onClick?: TypedMarkOnClick,
   onRemove?: TypedMarkOnRemove,
+  onMouseEnter?: TypedMarkOnMouseEnter,
+  onMouseLeave?: TypedMarkOnMouseLeave,
 ): void {
   const nodes = selection.getNodes();
   const anchorOffset = selection.anchor.offset;
@@ -971,7 +1430,7 @@ export function $wrapSelectionInTypedMarkNode(
 
       if (lastCreatedMarkNode === undefined) {
         lastCreatedMarkNode = $createTypedMarkNode();
-        lastCreatedMarkNode.addID(type, id, onClick, onRemove);
+        lastCreatedMarkNode.addID(type, id, onClick, onRemove, onMouseEnter, onMouseLeave);
         targetNode.insertBefore(lastCreatedMarkNode);
       }
 

--- a/libs/shared/src/nodes/usj/CharNode.test.ts
+++ b/libs/shared/src/nodes/usj/CharNode.test.ts
@@ -1,0 +1,58 @@
+import { createEditor } from "lexical";
+import { describe, expect, it } from "vitest";
+import { $createCharNode, CharNode } from "./CharNode.js";
+
+interface ThemeOverrides {
+  [key: string]: unknown;
+}
+
+function createTestEditor(themeOverrides?: ThemeOverrides) {
+  return createEditor({
+    namespace: "char-node-test",
+    nodes: [CharNode],
+    onError: (error) => {
+      throw error;
+    },
+    theme: { ...themeOverrides },
+  });
+}
+
+function createDomFor(editor: ReturnType<typeof createTestEditor>, marker: string): HTMLElement {
+  let element: HTMLElement | undefined;
+  editor.update(() => {
+    const node = $createCharNode(marker);
+    element = node.createDOM({
+      theme: editor._config.theme,
+      namespace: editor._config.namespace,
+    });
+  });
+  if (!element) throw new Error("CharNode.createDOM did not produce an element");
+  return element;
+}
+
+describe("CharNode createDOM title attribute", () => {
+  it("sets title=__marker by default", () => {
+    const editor = createTestEditor();
+    const element = createDomFor(editor, "wg");
+    expect(element.getAttribute("title")).toBe("wg");
+  });
+
+  it("sets title=__marker when showCharMarkerTitles is true", () => {
+    const editor = createTestEditor({ showCharMarkerTitles: true });
+    const element = createDomFor(editor, "wg");
+    expect(element.getAttribute("title")).toBe("wg");
+  });
+
+  it("omits the title attribute when showCharMarkerTitles is false", () => {
+    const editor = createTestEditor({ showCharMarkerTitles: false });
+    const element = createDomFor(editor, "wg");
+    expect(element.hasAttribute("title")).toBe(false);
+  });
+
+  it("preserves data-marker and usfm_* class regardless of showCharMarkerTitles", () => {
+    const editor = createTestEditor({ showCharMarkerTitles: false });
+    const element = createDomFor(editor, "wj");
+    expect(element.getAttribute("data-marker")).toBe("wj");
+    expect(element.classList.contains("usfm_wj")).toBe(true);
+  });
+});

--- a/libs/shared/src/nodes/usj/CharNode.ts
+++ b/libs/shared/src/nodes/usj/CharNode.ts
@@ -7,6 +7,7 @@ import {
   DOMConversionMap,
   DOMConversionOutput,
   DOMExportOutput,
+  EditorConfig,
   ElementNode,
   LexicalEditor,
   LexicalNode,
@@ -201,10 +202,16 @@ export class CharNode extends ElementNode {
     return self.__unknownAttributes;
   }
 
-  override createDOM(): HTMLElement {
+  override createDOM(config: EditorConfig): HTMLElement {
     const dom = document.createElement("span");
     dom.setAttribute("data-marker", this.__marker);
-    dom.setAttribute("title", this.__marker);
+    // Consumers can suppress the per-char marker tooltip via
+    // `ViewOptions.showCharMarkerTitles = false` - useful when the marker name shouldn't
+    // surface as a browser tooltip on every char span. Default (undefined or true) preserves
+    // the marker hint for consumers that want it while authoring USFM.
+    if (config.theme?.showCharMarkerTitles !== false) {
+      dom.setAttribute("title", this.__marker);
+    }
     dom.classList.add(this.__type, `usfm_${this.__marker}`);
     return dom;
   }

--- a/packages/platform/etc/platform-editor.api.md
+++ b/packages/platform/etc/platform-editor.api.md
@@ -111,6 +111,13 @@ export interface EditorRef {
     removeAnnotation(type: string, id: string): void;
     replaceEmbedUpdate(embedNodeKey: string, insertEmbedOps: DeltaOp[]): void;
     selectNote(noteKeyOrIndex: string | number): void;
+    setAnnotation(selection: AnnotationRange, type: string, id: string, callbacks?: {
+        onClick?: TypedMarkOnClick;
+        onRemove?: TypedMarkOnRemove;
+        onMouseEnter?: TypedMarkOnMouseEnter;
+        onMouseLeave?: TypedMarkOnMouseLeave;
+    }): void;
+    // @deprecated
     setAnnotation(selection: AnnotationRange, type: string, id: string, onClick?: TypedMarkOnClick, onRemove?: TypedMarkOnRemove): void;
     setSelection(selection: SelectionRange): void;
     setUsj(usj: Usj): void;
@@ -288,6 +295,12 @@ export interface Thread {
 export type TypedMarkOnClick = (event: DomMouseEvent, type: string, id: string, textContent: string) => void;
 
 // @public
+export type TypedMarkOnMouseEnter = (event: DomMouseEvent, type: string, id: string, textContent: string) => void;
+
+// @public
+export type TypedMarkOnMouseLeave = (event: DomMouseEvent, type: string, id: string, textContent: string) => void;
+
+// @public
 export type TypedMarkOnRemove = (type: string, id: string, cause: TypedMarkRemovalCause, textContent: string) => void;
 
 // @public
@@ -322,6 +335,7 @@ export interface ViewOptions {
     isFormattedFont: boolean;
     markerMode: MarkerMode;
     noteMode?: NoteMode;
+    showCharMarkerTitles?: boolean;
 }
 
 ```

--- a/packages/platform/src/editor/Editor.test.tsx
+++ b/packages/platform/src/editor/Editor.test.tsx
@@ -1,0 +1,135 @@
+import Editor from "./Editor";
+import { EditorRef } from "./editor.model";
+import { ContentJsonPath, Usj } from "@eten-tech-foundation/scripture-utilities";
+import { act, render } from "@testing-library/react";
+import { createRef, RefObject } from "react";
+import { vi } from "vitest";
+
+const sampleUsj: Usj = {
+  type: "USJ",
+  version: "3.1",
+  content: [
+    {
+      type: "book",
+      marker: "id",
+      code: "GEN",
+      content: ["Test Book"],
+    },
+    {
+      type: "chapter",
+      marker: "c",
+      number: "1",
+    },
+    {
+      type: "para",
+      marker: "p",
+      content: [
+        {
+          type: "verse",
+          marker: "v",
+          number: "1",
+        },
+        "first verse text",
+      ],
+    },
+  ],
+};
+
+const versePath: ContentJsonPath = "$.content[2].content[1]";
+const verseTextLength = "first verse text".length;
+const testRange = {
+  start: { jsonPath: versePath, offset: 0 },
+  end: { jsonPath: versePath, offset: verseTextLength },
+};
+
+async function createEditorRefForTesting(): Promise<RefObject<EditorRef | null>> {
+  const ref = createRef<EditorRef>();
+  await act(async () => {
+    render(<Editor ref={ref} defaultUsj={sampleUsj} />);
+  });
+  if (!ref.current) throw new Error("EditorRef did not mount");
+  return ref;
+}
+
+function getMarkElement(): HTMLElement {
+  // Find the rendered <mark> element on the document. The editor renders the contenteditable to
+  // the DOM, so any annotation will produce a <mark> we can dispatch events on.
+  const mark = document.querySelector("mark");
+  if (!(mark instanceof HTMLElement))
+    throw new Error("Expected a <mark> element in the editor DOM");
+  return mark;
+}
+
+function triggerClickOnMark(): void {
+  const element = getMarkElement();
+  act(() => {
+    element.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+  });
+}
+
+function triggerMouseEnterOnMark(): void {
+  const element = getMarkElement();
+  act(() => {
+    element.dispatchEvent(new window.MouseEvent("mouseenter"));
+  });
+}
+
+describe("setAnnotation overload", () => {
+  it("accepts the deprecated positional form (onClick, onRemove)", async () => {
+    const ref = await createEditorRefForTesting();
+    const editor = ref.current;
+    if (!editor) throw new Error("Editor not mounted");
+    const onClick = vi.fn();
+
+    await act(async () => {
+      editor.setAnnotation(testRange, "highlight", "id-1", onClick);
+    });
+
+    triggerClickOnMark();
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("accepts the new options-object form with onClick", async () => {
+    const ref = await createEditorRefForTesting();
+    const editor = ref.current;
+    if (!editor) throw new Error("Editor not mounted");
+    const onClick = vi.fn();
+
+    await act(async () => {
+      editor.setAnnotation(testRange, "highlight", "id-1", { onClick });
+    });
+
+    triggerClickOnMark();
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("accepts the new options-object form with onMouseEnter", async () => {
+    const ref = await createEditorRefForTesting();
+    const editor = ref.current;
+    if (!editor) throw new Error("Editor not mounted");
+    const onMouseEnter = vi.fn();
+
+    await act(async () => {
+      editor.setAnnotation(testRange, "highlight", "id-1", { onMouseEnter });
+    });
+
+    triggerMouseEnterOnMark();
+    expect(onMouseEnter).toHaveBeenCalled();
+  });
+
+  it("accepts the no-callback form (4th arg omitted) and dispatches click harmlessly", async () => {
+    // Exercises the `fourth === undefined` branch of the discriminator. Both forms - omitted
+    // 4th arg and an empty options-object - should leave the mark functional but produce no
+    // callback invocations (and no thrown errors when the user clicks/hovers it).
+    const ref = await createEditorRefForTesting();
+    const editor = ref.current;
+    if (!editor) throw new Error("Editor not mounted");
+
+    await act(async () => {
+      editor.setAnnotation(testRange, "highlight", "id-1");
+    });
+
+    expect(() => triggerClickOnMark()).not.toThrow();
+    expect(() => triggerMouseEnterOnMark()).not.toThrow();
+  });
+});

--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -34,6 +34,7 @@ import {
   ReactElement,
   useCallback,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -45,6 +46,10 @@ import {
   LoggerBasic,
   SELECTION_CHANGE_TAG,
   TypedMarkNode,
+  TypedMarkOnClick,
+  TypedMarkOnMouseEnter,
+  TypedMarkOnMouseLeave,
+  TypedMarkOnRemove,
 } from "shared";
 import {
   $applyUpdate,
@@ -56,6 +61,7 @@ import {
   $insertNote,
   $selectNote,
   AnnotationPlugin,
+  AnnotationRange,
   AnnotationRef,
   ArrowNavigationPlugin,
   CharNodePlugin,
@@ -83,22 +89,6 @@ import {
   UsjNodesMenuPlugin,
   usjReactNodes,
 } from "shared-react";
-
-type Mutable<T> = {
-  -readonly [P in keyof T]: T[P];
-};
-
-const editorConfig: Mutable<InitialConfigType> = {
-  namespace: "platformEditor",
-  theme: editorTheme,
-  editable: true,
-  editorState: undefined,
-  // Handling of errors during update
-  onError(error) {
-    throw error;
-  },
-  nodes: [TypedMarkNode, ...usjReactNodes],
-};
 
 const defaultViewOptions = getDefaultViewOptions();
 const defaultNodeOptions: UsjNodeOptions = {};
@@ -152,13 +142,38 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
     hasSpellCheck = false,
     textDirection = "ltr",
     markerMenuTrigger = "\\",
-    view: viewOptions = defaultViewOptions,
-    nodes: nodeOptions = defaultNodeOptions,
+    view,
+    nodes,
     debug = false,
-    contextMenu: contextMenuOptions,
+    contextMenu,
   } = options ?? defaultOptions;
 
-  editorConfig.editable = !isReadonly;
+  // Stabilize the destructured option objects so plugin props don't churn when the parent passes
+  // a fresh `options` object every render. Pairs with the per-instance `initialConfig` below -
+  // any state derived from `options` should follow the same pattern to avoid cross-instance
+  // surprises with multiple Editor instances in one WebView.
+  const viewOptions = useMemo(() => view ?? defaultViewOptions, [view]);
+  const nodeOptions = useMemo(() => nodes ?? defaultNodeOptions, [nodes]);
+  const contextMenuOptions = useMemo(() => contextMenu, [contextMenu]);
+
+  // `showCharMarkerTitles` rides on the Lexical theme so `CharNode.createDOM` can read it via
+  // `EditorConfig.theme`. Theme is the channel because its map permits arbitrary keys and is the
+  // lowest-friction way to thread a node-rendering flag through `EditorConfig` without
+  // introducing a new option object.
+  const initialConfig = useMemo<InitialConfigType>(
+    () => ({
+      namespace: "platformEditor",
+      theme: { ...editorTheme, showCharMarkerTitles: viewOptions.showCharMarkerTitles },
+      editable: !isReadonly,
+      editorState: undefined,
+      // Handling of errors during update
+      onError(error) {
+        throw error;
+      },
+      nodes: [TypedMarkNode, ...usjReactNodes],
+    }),
+    [isReadonly, viewOptions.showCharMarkerTitles],
+  );
   editorUsjAdaptor.initialize(logger);
 
   useImperativeHandle(ref, () => ({
@@ -232,13 +247,45 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
         }
       });
     },
-    setAnnotation(selection, type, id, onClick, onRemove) {
+    setAnnotation(
+      selection: AnnotationRange,
+      type: string,
+      id: string,
+      fourth?:
+        | TypedMarkOnClick
+        | {
+            onClick?: TypedMarkOnClick;
+            onRemove?: TypedMarkOnRemove;
+            onMouseEnter?: TypedMarkOnMouseEnter;
+            onMouseLeave?: TypedMarkOnMouseLeave;
+          },
+      fifth?: TypedMarkOnRemove,
+    ) {
+      let onClick: TypedMarkOnClick | undefined;
+      let onRemove: TypedMarkOnRemove | undefined;
+      let onMouseEnter: TypedMarkOnMouseEnter | undefined;
+      let onMouseLeave: TypedMarkOnMouseLeave | undefined;
+
+      if (typeof fourth === "function" || fourth === undefined) {
+        // Legacy positional form: (selection, type, id, onClick?, onRemove?)
+        onClick = fourth;
+        onRemove = fifth;
+      } else {
+        // New options-object form: (selection, type, id, callbacks?)
+        onClick = fourth.onClick;
+        onRemove = fourth.onRemove;
+        onMouseEnter = fourth.onMouseEnter;
+        onMouseLeave = fourth.onMouseLeave;
+      }
+
       annotationRef.current?.setAnnotation(
         selection,
         externalTypedMarkType(type),
         id,
         onClick,
         onRemove,
+        onMouseEnter,
+        onMouseLeave,
       );
     },
     removeAnnotation(type, id) {
@@ -336,7 +383,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
   );
 
   return (
-    <LexicalComposer initialConfig={editorConfig}>
+    <LexicalComposer initialConfig={initialConfig}>
       <EditablePlugin isEditable={!isReadonly} />
       <div className="editor-container">
         {hasExternalUI ? (

--- a/packages/platform/src/editor/editor.model.ts
+++ b/packages/platform/src/editor/editor.model.ts
@@ -1,7 +1,13 @@
 import { Usj } from "@eten-tech-foundation/scripture-utilities";
 import { SerializedVerseRef } from "@sillsdev/scripture";
 import { RefObject } from "react";
-import { LoggerBasic, TypedMarkOnClick, TypedMarkOnRemove } from "shared";
+import {
+  LoggerBasic,
+  TypedMarkOnClick,
+  TypedMarkOnMouseEnter,
+  TypedMarkOnMouseLeave,
+  TypedMarkOnRemove,
+} from "shared";
 import {
   AnnotationRange,
   ContextMenuOptionConfig,
@@ -63,9 +69,33 @@ export interface EditorRef {
    */
   setSelection(selection: SelectionRange): void;
   /**
-   * Set an ephemeral annotation.
-   * @param selection - An annotation range containing the start and end location. The json-path in
-   *   an annotation location assumes no comment Milestone nodes are present in the USJ.
+   * Set an ephemeral annotation with optional event callbacks.
+   *
+   * @param selection - An annotation range containing the start and end location. The json-path
+   *   in an annotation location assumes no comment Milestone nodes are present in the USJ.
+   * @param type - Type of the annotation.
+   * @param id - ID of the annotation.
+   * @param callbacks - Optional click / removal / hover handlers. Each is independently
+   *   optional. Omit the argument entirely to register an annotation with no callbacks.
+   */
+  setAnnotation(
+    selection: AnnotationRange,
+    type: string,
+    id: string,
+    callbacks?: {
+      onClick?: TypedMarkOnClick;
+      onRemove?: TypedMarkOnRemove;
+      onMouseEnter?: TypedMarkOnMouseEnter;
+      onMouseLeave?: TypedMarkOnMouseLeave;
+    },
+  ): void;
+  /**
+   * Set an ephemeral annotation with positional click / remove handlers.
+   *
+   * @deprecated Pass a callbacks object instead. This positional form is preserved for backward
+   *   compatibility and will be removed in a future release.
+   *
+   * @param selection - An annotation range containing the start and end location.
    * @param type - Type of the annotation.
    * @param id - ID of the annotation.
    * @param onClick - Optional onClick handler.

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -54,6 +54,8 @@ export type {
   LoggerBasic,
   NodeOptions,
   TypedMarkOnClick,
+  TypedMarkOnMouseEnter,
+  TypedMarkOnMouseLeave,
   TypedMarkOnRemove,
   TypedMarkRemovalCause,
 } from "shared";

--- a/packages/platform/src/marginal/Marginal.tsx
+++ b/packages/platform/src/marginal/Marginal.tsx
@@ -18,8 +18,14 @@ import {
   useRef,
   useState,
 } from "react";
-import { DeltaOp, DeltaSource } from "shared-react";
-import { LoggerBasic } from "shared";
+import { AnnotationRange, DeltaOp, DeltaSource } from "shared-react";
+import {
+  LoggerBasic,
+  TypedMarkOnClick,
+  TypedMarkOnMouseEnter,
+  TypedMarkOnMouseLeave,
+  TypedMarkOnRemove,
+} from "shared";
 
 /**
  * Forward reference for the editor.
@@ -145,8 +151,28 @@ const Marginal = forwardRef(function Marginal<TLogger extends LoggerBasic>(
     setSelection(selection) {
       editorRef.current?.setSelection(selection);
     },
-    setAnnotation(selection, type, id, onClick, onRemove) {
-      editorRef.current?.setAnnotation(selection, type, id, onClick, onRemove);
+    setAnnotation(
+      selection: AnnotationRange,
+      type: string,
+      id: string,
+      fourth?:
+        | TypedMarkOnClick
+        | {
+            onClick?: TypedMarkOnClick;
+            onRemove?: TypedMarkOnRemove;
+            onMouseEnter?: TypedMarkOnMouseEnter;
+            onMouseLeave?: TypedMarkOnMouseLeave;
+          },
+      fifth?: TypedMarkOnRemove,
+    ) {
+      // Discriminate so the delegated call binds to the matching overload (legacy positional vs
+      // new options-object). Forwarding `(fourth, fifth)` together would fail typecheck since
+      // neither overload accepts both shapes.
+      if (typeof fourth === "function" || fourth === undefined) {
+        editorRef.current?.setAnnotation(selection, type, id, fourth, fifth);
+      } else {
+        editorRef.current?.setAnnotation(selection, type, id, fourth);
+      }
     },
     removeAnnotation(type, id) {
       editorRef.current?.removeAnnotation(type, id);


### PR DESCRIPTION
Adds `onMouseEnter` / `onMouseLeave` callbacks to typed-mark annotations. Mirrors the existing `onClick` registry infrastructure 1:1 in `TypedMarkNode` - new types, registries, instance fields, DOM listeners, `addID` extension, merge plumbing, and `removeAnnotation` cleanup. Hover callbacks survive node merging identically to click callbacks.

Native `mouseenter` / `mouseleave` semantics are used (no bubbling, no re-fire across inner text-node boundaries), so a hover stays "sticky" to the outer mark element regardless of internal text-node structure.

`EditorRef.setAnnotation` evolves via overload:

- The positional 5-arg form `(selection, type, id, onClick?, onRemove?)` is preserved and JSDoc-deprecated for backward compatibility.
- A new 4-arg options-object form takes a callbacks object accepting `onClick` / `onRemove` / `onMouseEnter` / `onMouseLeave` - each independently optional.

The implementation in `Editor.tsx` discriminates on whether the 4th argument is a function (legacy) or an object (new) and routes through to `$wrapSelectionInTypedMarkNode` either way.

Adds `showCharMarkerTitles?: boolean` to `ViewOptions` (default `true` to preserve current behavior). When `false`, `CharNode.createDOM` skips the `dom.setAttribute("title", this.__marker)` call - eliminating the per-char `"wg"` / `"wj"` browser-native tooltips that fire on every char node. The other DOM hooks (`data-marker`, `usfm_*` class) are unchanged so existing SCSS bundles still apply.

The flag threads through the existing view-options merge in `Editorial`/`Editor.tsx` with no other public API changes.

- `TypedMarkNode.test.ts` extends the click-callback suite with enter/leave equivalents (fire on cursor crossing, multiple type/id pairs, survive node merge, cleanup on `removeAnnotation` and `remove()`).
- `CharNode.test.ts` (new) asserts `createDOM` produces no `title` attribute when `showCharMarkerTitles: false` and preserves `title=__marker` otherwise.
- `Editor.test.tsx` (new) covers the `setAnnotation` overload: positional onClick form still works (deprecated path), options-object form works, and an options-object containing `onMouseEnter` registers
  + fires the callback.
- `AnnotationPlugin.test.tsx` extended for the new params on the inner `setAnnotation` API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/474)
<!-- Reviewable:end -->
