### PR TITLE
remove mermaid extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "bierner.markdown-mermaid",
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",


### PR DESCRIPTION
- VS Code now previews mermaid graphs - remove mermaid extension since it interferes with preview

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/478)
<!-- Reviewable:end -->
