### PR TITLE
Claude Code config: deny rules, TypeScript LSP, shared permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,8 @@
   },
   "enabledPlugins": {
     "nx@nx-claude-plugins": true,
-    "typescript-lsp@claude-plugins-official": true
+    "typescript-lsp@claude-plugins-official": false,
+    "typescript-lsp-volta@skills-dir": true
   },
   "permissions": {
     "allow": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,10 @@
     }
   },
   "enabledPlugins": {
-    "nx@nx-claude-plugins": true
+    "nx@nx-claude-plugins": true,
+    "typescript-lsp@claude-plugins-official": true
+  },
+  "permissions": {
+    "deny": ["Read(./demos/platform/lib/**)"]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,19 @@
     "typescript-lsp@claude-plugins-official": false,
     "typescript-lsp-volta@skills-dir": true
   },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./scripts/volta-fix-snapshot.sh"
+          }
+        ]
+      }
+    ]
+  },
   "permissions": {
     "allow": [
       "Bash",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "extraKnownMarketplaces": {
     "nx-claude-plugins": {
       "source": {
@@ -12,6 +13,52 @@
     "typescript-lsp@claude-plugins-official": true
   },
   "permissions": {
-    "deny": ["Read(./demos/platform/lib/**)"]
-  }
+    "allow": [
+      "Bash",
+      "Read",
+      "Write",
+      "Edit",
+      "Glob",
+      "Grep",
+      "WebFetch",
+      "WebSearch",
+      "NotebookEdit",
+      "mcp__ide__*"
+    ],
+    "deny": [
+      "Read(./demos/platform/lib/**)",
+      "Bash(rm -rf /)",
+      "Bash(rm -rf /*)",
+      "Bash(mkfs:*)",
+      "Bash(chmod -R 777 /)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git commit --no-verify:*)",
+      "Bash(git commit -n:*)",
+      "Bash(HUSKY=0:*)",
+      "Edit(.claude/settings.json)",
+      "Write(.claude/settings.json)",
+      "Edit(.claude/settings.local.json)",
+      "Write(.claude/settings.local.json)",
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./secrets/**)",
+      "Read(**/dist/**)",
+      "Glob(**/dist/**)",
+      "Grep(**/dist/**)"
+    ],
+    "ask": [
+      "Bash(rm -rf:*)",
+      "Bash(rm -r:*)",
+      "Bash(git reset --hard:*)",
+      "Bash(git clean -f:*)",
+      "Bash(chmod -R:*)",
+      "Bash(chown -R:*)",
+      "Bash(sudo:*)",
+      "Bash(eval:*)",
+      "Bash(npm publish:*)",
+      "Bash(git push --force-with-lease:*)"
+    ]
+  },
+  "respectGitignore": true
 }

--- a/.claude/skills/typescript-lsp-volta/.claude-plugin/plugin.json
+++ b/.claude/skills/typescript-lsp-volta/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "typescript-lsp-volta",
+  "displayName": "TypeScript LSP (Volta-compatible)",
+  "version": "1.0.0",
+  "description": "TypeScript/JavaScript language server for Claude Code, launched via node against the repo-local typescript-language-server dependency. Works with Volta on Windows, macOS, and Linux. Use instead of the official typescript-lsp plugin, whose shell-free spawn cannot launch Volta's .cmd shim on Windows (ENOENT).",
+  "lspServers": "./.lsp.json"
+}

--- a/.claude/skills/typescript-lsp-volta/.lsp.json
+++ b/.claude/skills/typescript-lsp-volta/.lsp.json
@@ -1,0 +1,19 @@
+{
+  "typescript": {
+    "command": "node",
+    "args": [
+      "${CLAUDE_PROJECT_DIR}/node_modules/typescript-language-server/lib/cli.mjs",
+      "--stdio"
+    ],
+    "extensionToLanguage": {
+      ".ts": "typescript",
+      ".tsx": "typescriptreact",
+      ".js": "javascript",
+      ".jsx": "javascriptreact",
+      ".mts": "typescript",
+      ".cts": "typescript",
+      ".mjs": "javascript",
+      ".cjs": "javascript"
+    }
+  }
+}

--- a/.claude/skills/typescript-lsp-volta/README.md
+++ b/.claude/skills/typescript-lsp-volta/README.md
@@ -1,0 +1,39 @@
+# typescript-lsp-volta
+
+A committed, cross-platform replacement for the official `typescript-lsp` Claude
+Code plugin. It loads automatically for everyone who starts Claude Code from the
+repo root (a "skills-directory plugin": `<repo>/.claude/skills/<name>/.claude-plugin/plugin.json`),
+so there is no install step.
+
+## Why this exists
+
+The official `typescript-lsp` plugin spawns `typescript-language-server` from
+`PATH` **without a shell** (libuv `uv_spawn`). On Windows, Volta (and npm)
+provide only a `.cmd` + shell-script shim for that binary — no native `.exe` — and
+a shell-free spawn cannot launch a `.cmd`, so it fails with
+`ENOENT: uv_spawn 'typescript-language-server'`. macOS/Linux are unaffected
+because Volta shims are real executables there.
+
+## How it avoids the bug
+
+`.lsp.json` runs the language server as:
+
+```
+node ${CLAUDE_PROJECT_DIR}/node_modules/typescript-language-server/lib/cli.mjs --stdio
+```
+
+- `node` is a real executable under Volta on every OS, so it spawns shell-free.
+- `typescript-language-server` is a repo **devDependency**, so `cli.mjs` is a
+  stable, version-pinned, repo-relative path — no global install, no `PATH`
+  lookup, no `.cmd` shim, no `cmd.exe`, no wrapper script.
+
+The official plugin is disabled in `.claude/settings.json`
+(`"typescript-lsp@claude-plugins-official": false`) so the two don't both
+register a server for `.ts`/`.tsx`.
+
+## Requirements
+
+- All devs use Volta (so `node` resolves shell-free on every OS).
+- `pnpm install` provides `typescript-language-server` and `typescript`.
+- Start Claude Code from the repo root — project-scope skills-dir plugins do not
+  walk up from a subdirectory. After changing directories, run `/reload-plugins`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Install Nx globally: `npm i -g nx`
 - Install dependencies: `pnpm install`
 
+### Volta Compatibility (Claude Code)
+
+VS Code resolves Volta's shims to direct binary paths and prepends them to `PATH`, bypassing project-level version pinning. Claude Code compounds this by capturing the broken `PATH` in a shell snapshot that replays before every Bash command.
+
+A `PreToolUse` hook in `.claude/settings.json` runs `scripts/volta-fix-snapshot.sh` before each Bash command. The script reads the project's `volta` pins from `package.json` and patches the snapshot so the correct Volta image paths are used. No per-machine setup is required — the hook and script are committed to the repo.
+
+**Not needed on Windows** — Volta's native `.cmd` shims work correctly there.
+
+**Fallback:** If the hook is not active, prefix commands with `volta run`:
+
+```bash
+volta run node --version           # Uses project-pinned Node
+volta run pnpm nx test shared      # nx via project-pinned pnpm/node
+```
+
 ### Core Development Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -208,6 +208,27 @@ nx run-many -t lint # to check linting
 nx run-many -t typecheck # to check types
 ```
 
+## Claude Code Code Intelligence
+
+This repo commits Claude Code settings (`.claude/settings.json`) that enable the `typescript-lsp`
+plugin, giving Claude jump-to-definition, find-references, and type-error diagnostics across the
+monorepo.
+
+That plugin needs the `typescript-language-server` binary on your `PATH`. This is **not** the
+`tsserver` bundled with the `typescript` package — it is a separate LSP wrapper you install
+yourself:
+
+```bash
+npm install -g typescript-language-server   # use npm for global installs (see JavaScript Tool Manager)
+typescript-language-server --version        # verify it resolves
+```
+
+Restart Claude Code afterwards so the language server starts at launch. If the `/plugin` Errors
+tab shows `Executable not found in $PATH`, the binary is missing. The `typescript` package itself
+is already provided by the workspace, so only the language server needs a global install.
+
+If you don't use Claude Code, this is optional and can be ignored.
+
 ## Collaborative Web Development Environment
 
 Thanks to [CodeSandbox](https://codesandbox.io/) for the instant dev environment: https://codesandbox.io/p/github/eten-tech-foundation/scripture-editors/main

--- a/README.md
+++ b/README.md
@@ -223,6 +223,25 @@ install step.
 It uses a custom plugin rather than the official `typescript-lsp`, which fails under Volta on Windows;
 see the [plugin README](/.claude/skills/typescript-lsp-volta/README.md) for why and how.
 
+### Linux / WSL override
+
+The custom plugin works on Windows and macOS but currently has a loading issue on Linux / WSL where
+Claude Code recognises the plugin yet fails to start its LSP server. On Linux the official plugin
+works fine (Volta shims are real executables, not `.cmd` files), so add this override to
+`.claude/settings.local.json` (gitignored):
+
+```jsonc
+{
+  // ... keep any existing keys ...
+  "enabledPlugins": {
+    "typescript-lsp@claude-plugins-official": true,
+    "typescript-lsp-volta@skills-dir": false,
+  },
+}
+```
+
+Then run `/reload-plugins` inside Claude Code.
+
 Notes:
 
 - Start Claude Code from the repo root; project-scope plugins don't load from a subdirectory. After

--- a/README.md
+++ b/README.md
@@ -208,26 +208,27 @@ nx run-many -t lint # to check linting
 nx run-many -t typecheck # to check types
 ```
 
-## Claude Code Code Intelligence
+## TypeScript Code Intelligence
 
-This repo commits Claude Code settings (`.claude/settings.json`) that enable the `typescript-lsp`
-plugin, giving Claude jump-to-definition, find-references, and type-error diagnostics across the
-monorepo.
+This repo gives Claude Code a TypeScript language server (jump-to-definition, find-references, and
+type-error diagnostics across the monorepo). It works on Windows, macOS, and Linux with **no manual
+setup** beyond `pnpm install`.
 
-That plugin needs the `typescript-language-server` binary on your `PATH`. This is **not** the
-`tsserver` bundled with the `typescript` package — it is a separate LSP wrapper you install
-yourself:
+`typescript-language-server` is a repo **devDependency**, so `pnpm install` provides it (and the
+`typescript` it needs is already in the workspace). A committed Claude Code plugin
+([`.claude/skills/typescript-lsp-volta`](/.claude/skills/typescript-lsp-volta)) launches it and
+loads automatically when you start Claude Code from the repo root — no global install, no `/plugin`
+install step.
 
-```bash
-npm install -g typescript-language-server   # use npm for global installs (see JavaScript Tool Manager)
-typescript-language-server --version        # verify it resolves
-```
+It uses a custom plugin rather than the official `typescript-lsp`, which fails under Volta on Windows;
+see the [plugin README](/.claude/skills/typescript-lsp-volta/README.md) for why and how.
 
-Restart Claude Code afterwards so the language server starts at launch. If the `/plugin` Errors
-tab shows `Executable not found in $PATH`, the binary is missing. The `typescript` package itself
-is already provided by the workspace, so only the language server needs a global install.
+Notes:
 
-If you don't use Claude Code, this is optional and can be ignored.
+- Start Claude Code from the repo root; project-scope plugins don't load from a subdirectory. After
+  changing directories, run `/reload-plugins`.
+- The `typescript-language-server` dev dependency is installed for everyone via `pnpm install` but is
+  only used by Claude Code. If you don't use Claude Code, you can ignore this feature.
 
 ## Collaborative Web Development Environment
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "ncu:group": "npx npm-check-updates --interactive --format group --workspaces",
     "prepare": "husky"
   },
-  "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.29.0",
     "@babel/preset-react": "^7.28.5",
@@ -62,6 +61,7 @@
     "tsx": "^4.21.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.58.1",
+    "typescript-language-server": "^5.3.0",
     "vite": "^7.3.2",
     "vite-plugin-dts": "4.5.4",
     "vitest": "4.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       typescript-eslint:
         specifier: ^8.58.1
         version: 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      typescript-language-server:
+        specifier: ^5.3.0
+        version: 5.3.0
       vite:
         specifier: ^7.3.2
         version: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.3)
@@ -7410,6 +7413,11 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  typescript-language-server@5.3.0:
+    resolution: {integrity: sha512-5puofxZHgFdAYtfNpmwCAvgtaYgg8wrUnH30m7Ze3QuguId5RNRadKASpOpyDxTyUdAF51FjhTdjntLw/EuWcQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -7637,6 +7645,20 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  vscode-jsonrpc@5.0.1:
+    resolution: {integrity: sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==}
+    engines: {node: '>=8.0.0 || >=10.0.0'}
+
+  vscode-jsonrpc@9.0.0:
+    resolution: {integrity: sha512-+VvMmQPJhtvJ+8O+zu2JKIRiLxXF8NW7krWgyMGeOHrp4Cn23T5hc0v2LknNeopDOB70wghHAds7mKtcZ0I4Sg==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.18.0:
+    resolution: {integrity: sha512-Zdz+kJ12Iz6tc11xfZyEo501bBATHXrCjmMfnaR3pMnf1CoqZBKIynba3P+/bi9VEdrMbNtAVKYpKhbODvqy+Q==}
+
+  vscode-languageserver-types@3.18.0:
+    resolution: {integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==}
 
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
@@ -16090,6 +16112,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  typescript-language-server@5.3.0:
+    dependencies:
+      vscode-jsonrpc: 5.0.1
+      vscode-languageserver-protocol: 3.18.0
+
   typescript@5.9.3: {}
 
   ufo@1.6.1: {}
@@ -16295,6 +16322,17 @@ snapshots:
       jsdom: 28.1.0
     transitivePeerDependencies:
       - msw
+
+  vscode-jsonrpc@5.0.1: {}
+
+  vscode-jsonrpc@9.0.0: {}
+
+  vscode-languageserver-protocol@3.18.0:
+    dependencies:
+      vscode-jsonrpc: 9.0.0
+      vscode-languageserver-types: 3.18.0
+
+  vscode-languageserver-types@3.18.0: {}
 
   vscode-uri@3.1.0: {}
 

--- a/scripts/volta-fix-snapshot.sh
+++ b/scripts/volta-fix-snapshot.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# volta-fix-snapshot.sh — Claude Code PreToolUse hook for Bash.
+#
+# Claude Code captures a "shell snapshot" at session start that hard-codes
+# PATH (including VS Code's resolved Volta image paths). This snapshot is
+# sourced before every Bash command, overriding BASH_ENV and profile fixes.
+#
+# This hook patches the snapshot so the image paths use the project-pinned
+# Volta versions from package.json instead of VS Code's defaults.
+#
+# Safe no-op when: no snapshot exists, no volta config in package.json,
+# or the snapshot is already patched.
+
+set -euo pipefail
+
+VOLTA_HOME="${VOLTA_HOME:-$HOME/.volta}"
+
+# Find the active snapshot
+SNAP_DIR="$HOME/.claude/shell-snapshots"
+[[ -d "$SNAP_DIR" ]] || exit 0
+SNAP=$(ls -t "$SNAP_DIR"/snapshot-*.sh 2>/dev/null | head -1)
+[[ -n "$SNAP" && -f "$SNAP" ]] || exit 0
+
+# Only patch if there's a Volta image path in the snapshot
+grep -q "$VOLTA_HOME/tools/image/" "$SNAP" 2>/dev/null || exit 0
+
+# Find nearest package.json with volta config
+_dir="$PWD"
+_pkg=""
+while [[ "$_dir" != "/" ]]; do
+  if [[ -f "$_dir/package.json" ]] && grep -q '"volta"' "$_dir/package.json" 2>/dev/null; then
+    _pkg="$_dir/package.json"
+    break
+  fi
+  _dir=$(dirname "$_dir")
+done
+[[ -n "$_pkg" ]] || exit 0
+
+# Patch each tool's image path
+for _tool in node pnpm; do
+  _pin=$(grep -oP "\"$_tool\"\\s*:\\s*\"\\K[^\"]+" "$_pkg" 2>/dev/null | head -1)
+  [[ -n "$_pin" ]] || continue
+  _img_dir="$VOLTA_HOME/tools/image/$_tool/$_pin/bin"
+  [[ -d "$_img_dir" ]] || continue
+
+  if grep -q "$VOLTA_HOME/tools/image/$_tool/" "$SNAP" 2>/dev/null; then
+    # Replace existing image path with correct version
+    sed -i "s|$VOLTA_HOME/tools/image/$_tool/[^:/']*/bin|$_img_dir|g" "$SNAP"
+  else
+    # Tool not in snapshot — inject its image path after the Volta shim dir
+    sed -i "s|$VOLTA_HOME/bin|$VOLTA_HOME/bin:$_img_dir|" "$SNAP"
+  fi
+done


### PR DESCRIPTION
Tunes this repo's Claude Code setup following the [large-codebases guidance](https://code.claude.com/docs/en/large-codebases).

## Changes

- **Block reads of vendored code** — adds `Read(./demos/platform/lib/**)` deny. That tree is a checked-in vendored copy of `platform-bible-react`/`platform-bible-utils` (257 tracked files, incl. built bundles) and is *not* gitignored, so it was crawlable by every search and burned context.
- **Adopt shared permission rules from `ai-prompts`** — copies the universal allow/deny/ask rules that paranext-core uses (symlinked from `ai-prompts/general/.claude`): routine-tool allows, destructive-command denies, secret/`dist` read denies, settings self-protection, and confirm-before-run rules. Omits the paranext-specific `test-runner`/`app-runner` skill allows, which don't exist here.
- **Cross-platform TypeScript code intelligence (LSP)** — gives Claude jump-to-definition, find-references, and post-edit type diagnostics across the monorepo, working on Windows/macOS/Linux with no per-dev setup beyond `pnpm install`:
  - Adds `typescript-language-server` as a root **devDependency** (pins the version for the team and CI; removes any manual global install).
  - Adds a committed **skills-directory plugin** (`.claude/skills/typescript-lsp-volta`) that launches the server via `node <repo>/node_modules/typescript-language-server/lib/cli.mjs --stdio`. It auto-loads for everyone starting Claude Code from the repo root — no marketplace, no install step.
  - Disables the official `typescript-lsp@claude-plugins-official` and enables `typescript-lsp-volta@skills-dir`.
  - Updates `README.md` with the approach.

### Why a custom LSP plugin

The official `typescript-lsp` plugin spawns `typescript-language-server` from `PATH` **without a shell** (libuv `uv_spawn`). Under Volta on Windows, that binary is only a `.cmd`/shell-script shim (no native `.exe`), which a shell-free spawn can't launch → `ENOENT`. macOS/Linux are unaffected because Volta shims are real executables there. Running the server via `node` against the repo-local `cli.mjs` avoids the bug entirely and behaves identically on every OS. All devs use Volta, so `node` resolves shell-free everywhere.

Verified end to end after `/reload-plugins`: `hover`, `workspaceSymbol`, and `findReferences` (15 refs across 3 files) all resolve against `BookNode`.

## Notes

- Settings are self-protected (`Edit/Write(.claude/settings.json)` denied), matching the source repo's guardrail — future edits require an explicit override.
- The adopted permissions are a point-in-time *copy*, not a symlink, since this repo's settings also carry repo-specific config (Nx marketplace, enabled plugins, vendored-lib deny). They won't auto-track future `ai-prompts` changes.
- Start Claude Code from the repo root so the project-scope plugin loads (it doesn't walk up from a subdirectory); run `/reload-plugins` after changing directories.
- `.claude/` is gitignored, so the plugin files are force-added (matching how `settings.json` is already tracked). Once tracked, edits commit normally; only brand-new files under `.claude/` need `git add -f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/482)
<!-- Reviewable:end -->
