### PR TITLE
perf(shared-react): skip delta diff for ignored-tag updates

### DIFF
--- a/libs/shared-react/src/plugins/usj/collab/DeltaOnChangePlugin.test.tsx
+++ b/libs/shared-react/src/plugins/usj/collab/DeltaOnChangePlugin.test.tsx
@@ -28,7 +28,9 @@ import {
   $createImpliedParaNode,
   $isImmutableChapterNode,
   $isImpliedParaNode,
+  blackListedChangeTags,
   charIdState,
+  EXTERNAL_USJ_MUTATION_TAG,
   ImmutableChapterNode,
   ImpliedParaNode,
   segmentState,
@@ -314,6 +316,47 @@ describe("OnChangePlugin", () => {
         if (!$isTextNode(t2)) throw new Error("Expected TextNode");
         expect(t2.getTextContent()).toBe("and all the brethren who are with me");
       });
+    });
+  });
+
+  describe("Blacklisted change tags (ignoreTags)", () => {
+    async function setup() {
+      const calls: DeltaOp[][] = [];
+      const { editor } = await baseTestEnvironment(
+        () => {
+          $getRoot().append($createImpliedParaNode().append($createTextNode("hello")));
+        },
+        <DeltaOnChangePlugin
+          onChange={(_editorState, _editor, _tags, ops) => calls.push(ops)}
+          ignoreSelectionChange
+          ignoreHistoryMergeTagChange
+          ignoreTags={blackListedChangeTags}
+        />,
+      );
+      return { editor, calls };
+    }
+
+    // A multi-node change forces the expensive full-document diff branch in $getUpdateOps.
+    function $makeMultiNodeChange() {
+      const root = $getRoot();
+      const para = root.getFirstChild();
+      if ($isImpliedParaNode(para)) {
+        const firstText = para.getFirstChild();
+        if ($isTextNode(firstText)) firstText.setTextContent("changed");
+      }
+      root.append($createImpliedParaNode().append($createTextNode("added")));
+    }
+
+    it("emits a delta for an untagged change (sanity)", async () => {
+      const { editor, calls } = await setup();
+      await sutUpdate(editor, $makeMultiNodeChange);
+      expect(calls).toHaveLength(1);
+    });
+
+    it("skips the delta when the update carries a blacklisted tag (e.g. chapter load)", async () => {
+      const { editor, calls } = await setup();
+      await sutUpdate(editor, $makeMultiNodeChange, { tag: EXTERNAL_USJ_MUTATION_TAG });
+      expect(calls).toHaveLength(0);
     });
   });
 });

--- a/libs/shared-react/src/plugins/usj/collab/DeltaOnChangePlugin.tsx
+++ b/libs/shared-react/src/plugins/usj/collab/DeltaOnChangePlugin.tsx
@@ -10,14 +10,27 @@ import { $getNodeByKey, $isTextNode, HISTORY_MERGE_TAG } from "lexical";
 import Delta from "quill-delta";
 import { useLayoutEffect } from "react";
 
+/** Stable default for {@link DeltaOnChangePlugin}'s `ignoreTags` so the effect deps stay stable. */
+const EMPTY_TAGS: readonly string[] = [];
+
 /** Adapted from the LexicalOnChangePlugin to include collaborative editing operations. */
 export function DeltaOnChangePlugin({
   ignoreHistoryMergeTagChange = true,
   ignoreSelectionChange = false,
+  ignoreTags = EMPTY_TAGS,
   onChange,
 }: {
   ignoreHistoryMergeTagChange?: boolean;
   ignoreSelectionChange?: boolean;
+  /**
+   * Update tags for which no delta should be computed or emitted. Updates carrying any of these
+   * tags are skipped before `$getUpdateOps` runs. Use this for programmatic, non-collaborative
+   * mutations (e.g. loading a new chapter via `EXTERNAL_USJ_MUTATION_TAG`): computing a delta for
+   * a full-document replacement diffs the entire old text against the entire new text, which is
+   * O(n×d) and can take minutes for large documents - and the result is discarded by consumers
+   * that already filter these tags anyway.
+   */
+  ignoreTags?: readonly string[];
   onChange: (
     editorState: EditorState,
     editor: LexicalEditor,
@@ -35,6 +48,7 @@ export function DeltaOnChangePlugin({
       if (
         (ignoreSelectionChange && dirtyElements.size === 0 && dirtyLeaves.size === 0) ||
         (ignoreHistoryMergeTagChange && tags.has(HISTORY_MERGE_TAG)) ||
+        ignoreTags.some((tag) => tags.has(tag)) ||
         prevEditorState.isEmpty()
       ) {
         return;
@@ -47,7 +61,7 @@ export function DeltaOnChangePlugin({
 
       onChange(editorState, editor, tags, ops);
     });
-  }, [editor, ignoreHistoryMergeTagChange, ignoreSelectionChange, onChange]);
+  }, [editor, ignoreHistoryMergeTagChange, ignoreSelectionChange, ignoreTags, onChange]);
 
   return null;
 }

--- a/libs/shared-react/src/plugins/usj/react-test.utils.tsx
+++ b/libs/shared-react/src/plugins/usj/react-test.utils.tsx
@@ -20,6 +20,7 @@ import {
   $isElementNode,
   $setSelection,
   $setState,
+  EditorUpdateOptions,
   KEY_DOWN_COMMAND,
   KEY_ENTER_COMMAND,
   LexicalEditor,
@@ -325,12 +326,17 @@ export async function deleteTextAtSelection(
  * Run generic test update logic in the LexicalEditor for the SUT (Software Under Test).
  * @param editor - The LexicalEditor instance where the update will occur.
  * @param $updateFn - The function containing the update logic.
+ * @param options - Optional Lexical update options, e.g. `{ tag: EXTERNAL_USJ_MUTATION_TAG }`.
  */
-export async function sutUpdate(editor: LexicalEditor, $updateFn: () => void) {
+export async function sutUpdate(
+  editor: LexicalEditor,
+  $updateFn: () => void,
+  options?: EditorUpdateOptions,
+) {
   await act(async () => {
     editor.update(() => {
       $updateFn();
-    });
+    }, options);
   });
 }
 

--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -440,6 +440,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
             onChange={handleChange}
             ignoreSelectionChange
             ignoreHistoryMergeTagChange
+            ignoreTags={blackListedChangeTags}
           />
           <ActiveTextPlugin viewOptions={viewOptions} />
           <AnnotationPlugin ref={annotationRef} logger={logger} />


### PR DESCRIPTION
DeltaOnChangePlugin computed a quill-delta diff on every editor update, including programmatic full-document loads (e.g. chapter navigation tagged EXTERNAL_USJ_MUTATION_TAG). For large documents the else-branch diffs the entire old text against the entire new text via fast-diff (diff-match-patch), which is O(n×d) and can take minutes - and the result was discarded by consumers that already filter blackListedChangeTags.

Add an `ignoreTags` prop to DeltaOnChangePlugin that short-circuits the update listener before `$getUpdateOps` runs, and pass `blackListedChangeTags` from the platform Editor. User edits are unaffected (they carry no blacklisted tag).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/483)
<!-- Reviewable:end -->
