### PR TITLE
refactor(platform): drop dead remote-source branch in handleChange

### DIFF
--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -358,17 +358,20 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
   }));
 
   const handleChange = useCallback(
-    (editorState: EditorState, _editor: LexicalEditor, tags: Set<string>, ops: DeltaOp[]) => {
-      if (blackListedChangeTags.some((tag) => tags.has(tag))) return;
-
+    (editorState: EditorState, _editor: LexicalEditor, _tags: Set<string>, ops: DeltaOp[]) => {
+      // No blacklisted-tag guard is needed here: `DeltaOnChangePlugin` is given
+      // `ignoreTags={blackListedChangeTags}` and short-circuits before calling this handler, so
+      // only local user edits (which carry no blacklisted tag) ever reach this point.
       const newUsj = editorUsjAdaptor.deserializeEditorState(editorState);
       if (newUsj) {
         const isEdited = !deepEqual(editedUsjRef.current, newUsj);
         if (isEdited) editedUsjRef.current = newUsj;
         if (isEdited || !deepEqual(usj, newUsj)) {
-          const source = tags.has(DELTA_CHANGE_TAG) ? "remote" : "local";
+          // `handleChange` only runs for local edits: `DeltaOnChangePlugin` ignores
+          // `blackListedChangeTags` (which includes `DELTA_CHANGE_TAG`), so updates from
+          // `applyUpdate` never reach here - they emit `onUsjChange` with source "remote" directly.
           const insertedNodeKey = getInsertedNodeKey(ops, editorState);
-          onUsjChange?.(newUsj, ops, source, insertedNodeKey);
+          onUsjChange?.(newUsj, ops, "local", insertedNodeKey);
         }
       }
     },


### PR DESCRIPTION
## Summary

Cleanup following #483 (`perf(shared-react): skip delta diff for ignored-tag updates`), which moved blacklisted-tag filtering up into `DeltaOnChangePlugin` via `ignoreTags`.

In `packages/platform/src/editor/Editor.tsx`, `handleChange` is wired to exactly one plugin: `DeltaOnChangePlugin`, which is given `ignoreTags={blackListedChangeTags}` and short-circuits **before** invoking the handler. As a result:

- The in-handler guard `if (blackListedChangeTags.some((tag) => tags.has(tag))) return;` could never fire — redundant.
- The ternary `tags.has(DELTA_CHANGE_TAG) ? "remote" : "local"` always resolved to `"local"`, since `DELTA_CHANGE_TAG` is one of the blacklisted tags. Remote updates are emitted directly by `applyUpdate` with source `"remote"`, never through this path — so the `"remote"` branch was dead.

This PR removes both and hardcodes the source to `"local"`, with comments recording the invariant. `tags` is renamed to `_tags` as it is no longer read.

`DELTA_CHANGE_TAG` (used by `applyUpdate`) and `blackListedChangeTags` (used by the plugin) imports are unchanged — both still needed.

## Verification

- ✅ `nx lint platform` passes
- ✅ Direct `tsc --build` on the platform lib passes (no type errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/484)
<!-- Reviewable:end -->
