### PR TITLE
Polish paragraph-structure view: empty-verse placeholder, outline, gutter, RTL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,7 +220,11 @@ When working with scripture data:
 # Code Style
 
 - Prefer `undefined` over `null` when representing missing values unless an API explicitly requires `null`.
-- Prefer chaining Lexical `append` calls inside the final `$getRoot().append(...)` when setting up document structure in tests so the hierarchy is readable at a glance.
+- When building Lexical structures in tests, chain `.append(...)` calls inside `$getRoot().append(...)` so the code shape mirrors the resulting tree. Even when you need a local reference to a node, hoist only the bare `$createXNode(...)` to the variable and put the children inside the root chain — `para = $createParaNode("p"); $getRoot().append(para.append(...children));` — rather than the half-flat `para = $createParaNode("p").append(...); $getRoot().append(para);` shape.
+- Construct Lexical nodes via `$create<X>Node` / `$create<X>Nodes` helpers (singular for one node, plural for an array), matching Lexical's own naming convention. Test helpers follow the same pattern.
+- When a named type alias exists for a union (e.g., `SomeVerseNode` for `VerseNode | ImmutableVerseNode`), use the alias rather than re-spelling the union inline. Aliases live alongside their `$is*` guards.
+- Don't call `editor.update(...)` from inside a listener (event handler, update listener, etc.) — nested updates risk infinite cascade loops. Lexical's command system (`editor.registerCommand`) is the canonical entry point for mutating state in response to user interactions.
+- Order `<*Plugin />` children in `packages/platform/src/editor/Editor.tsx` alphabetically by component name. The alphabetical block starts partway through — initial plugins in the setup section (`OnSelectionChangePlugin`, `DeltaOnChangePlugin`, `ActiveTextPlugin`, …) intentionally precede it.
 
 # Context 7 Library Documentation
 

--- a/libs/shared/src/nodes/usj/BookNode.ts
+++ b/libs/shared/src/nodes/usj/BookNode.ts
@@ -104,6 +104,9 @@ export class BookNode extends ElementNode {
   }
 
   override createDOM(): HTMLElement {
+    // The `.book` class is targeted by platform gutter-positioning rules in usj-nodes.css
+    // alongside `.para` (paragraph-like layout). Changes here that affect the first-child marker
+    // node, the data-code attribute, or the element tag may require corresponding CSS updates.
     const dom = document.createElement("p");
     dom.setAttribute("data-marker", this.__marker);
     dom.classList.add(this.__type, `usfm_${this.__marker}`);

--- a/libs/shared/src/nodes/usj/ParaNode.ts
+++ b/libs/shared/src/nodes/usj/ParaNode.ts
@@ -7,6 +7,7 @@ import {
   DOMConversionMap,
   DOMConversionOutput,
   DOMExportOutput,
+  EditorConfig,
   ElementFormatType,
   LexicalEditor,
   LexicalNode,
@@ -241,6 +242,16 @@ export class ParaNode extends ParagraphNode {
     dom.setAttribute("data-marker", this.__marker);
     dom.classList.add(this.__type, `usfm_${this.__marker}`);
     return dom;
+  }
+
+  override updateDOM(prevNode: this, dom: HTMLElement, config: EditorConfig): boolean {
+    const recreate = super.updateDOM(prevNode, dom, config);
+    if (!recreate && prevNode.__marker !== this.__marker) {
+      dom.setAttribute("data-marker", this.__marker);
+      dom.classList.remove(`usfm_${prevNode.__marker}`);
+      dom.classList.add(`usfm_${this.__marker}`);
+    }
+    return recreate;
   }
 
   override exportDOM(editor: LexicalEditor): DOMExportOutput {

--- a/libs/shared/src/nodes/usj/node.utils.ts
+++ b/libs/shared/src/nodes/usj/node.utils.ts
@@ -532,6 +532,19 @@ export function $isVisibleMarkerNode(
 }
 
 /**
+ * True for either flavor of paragraph-marker node: a `MarkerNode` (markerMode "editable") or an
+ * `ImmutableTypedTextNode` with `textType: "marker"` (markerMode "visible" or gutter views).
+ * These are the two node shapes used to render a paragraph's USFM marker (e.g. `\p`, `\s2`,
+ * `\q1`) as the visible first child of its paragraph.
+ *
+ * @param node - The node to check.
+ * @returns `true` if the node is a `MarkerNode` or a visible marker node.
+ */
+export function $isParaMarkerPrefix(node: LexicalNode | null | undefined): boolean {
+  return $isMarkerNode(node) || $isVisibleMarkerNode(node);
+}
+
+/**
  * Remove all known properties of the `markerObject`.
  * @param markerObject - Scripture marker and its contents.
  * @param markerObjectProps - List of known properties to remove. Defaults to `MARKER_OBJECT_PROPS`.

--- a/packages/platform/src/editor/ActiveTextPlugin.test.tsx
+++ b/packages/platform/src/editor/ActiveTextPlugin.test.tsx
@@ -12,11 +12,15 @@ import {
   ParaNode,
   VerseNode,
 } from "shared";
-import { $createImmutableVerseNode, ImmutableVerseNode } from "shared-react";
+import { $createImmutableVerseNode, ImmutableVerseNode, SomeVerseNode } from "shared-react";
 // Reaching inside only for tests.
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { createBasicTestEnvironment } from "../../../../libs/shared/src/nodes/usj/test.utils";
-import { $getEmptyVerseStatus, $getParaFromSelection } from "./ActiveTextPlugin";
+import {
+  $getActiveVerseKey,
+  $getEmptyVerseStatus,
+  $getParaFromSelection,
+} from "./ActiveTextPlugin";
 
 const nodes = [
   ParaNode,
@@ -43,7 +47,7 @@ const nodes = [
 type ParaShape = "editable" | "gutter-hidden" | "plain-hidden";
 
 /** Builds the leading paragraph-marker children for the given shape, or [] if the shape has none. */
-function $paraMarkerPrefix(shape: ParaShape, marker: string): LexicalNode[] {
+function $createParaMarkerPrefixNodes(shape: ParaShape, marker: string): LexicalNode[] {
   if (shape === "editable") return [$createMarkerNode(marker), $createTextNode(NBSP)];
   if (shape === "gutter-hidden")
     return [$createImmutableTypedTextNode("marker", `\\${marker}${NBSP}`)];
@@ -61,10 +65,10 @@ describe("$getEmptyVerseStatus", () => {
   describe.each(shapes)("%s shape", (shape) => {
     it("marks the verse empty when it has no body text", () => {
       let para: ParaNode;
-      let v1: VerseNode | ImmutableVerseNode;
+      let v1: SomeVerseNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         v1 = $verseFor(shape, "1");
-        para = $createParaNode("p").append(...$paraMarkerPrefix(shape, "p"), v1);
+        para = $createParaNode("p").append(...$createParaMarkerPrefixNodes(shape, "p"), v1);
         $getRoot().append(para);
       });
 
@@ -78,11 +82,11 @@ describe("$getEmptyVerseStatus", () => {
 
     it("marks the verse non-empty when it has body text", () => {
       let para: ParaNode;
-      let v1: VerseNode | ImmutableVerseNode;
+      let v1: SomeVerseNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         v1 = $verseFor(shape, "1");
         para = $createParaNode("p").append(
-          ...$paraMarkerPrefix(shape, "p"),
+          ...$createParaMarkerPrefixNodes(shape, "p"),
           v1,
           $createTextNode("In the beginning"),
         );
@@ -99,11 +103,11 @@ describe("$getEmptyVerseStatus", () => {
 
     it("marks the verse empty when it is followed by whitespace only", () => {
       let para: ParaNode;
-      let v1: VerseNode | ImmutableVerseNode;
+      let v1: SomeVerseNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         v1 = $verseFor(shape, "1");
         para = $createParaNode("p").append(
-          ...$paraMarkerPrefix(shape, "p"),
+          ...$createParaMarkerPrefixNodes(shape, "p"),
           v1,
           $createTextNode("   "),
         );
@@ -120,13 +124,13 @@ describe("$getEmptyVerseStatus", () => {
 
     it("marks only the empty verse when one of two verses in the paragraph has no body", () => {
       let para: ParaNode;
-      let v1: VerseNode | ImmutableVerseNode;
-      let v2: VerseNode | ImmutableVerseNode;
+      let v1: SomeVerseNode;
+      let v2: SomeVerseNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         v1 = $verseFor(shape, "1");
         v2 = $verseFor(shape, "2");
         para = $createParaNode("p").append(
-          ...$paraMarkerPrefix(shape, "p"),
+          ...$createParaMarkerPrefixNodes(shape, "p"),
           v1,
           v2,
           $createTextNode("In the beginning"),
@@ -144,13 +148,13 @@ describe("$getEmptyVerseStatus", () => {
 
     it("marks the trailing verse empty when it has no body after a non-empty preceding verse", () => {
       let para: ParaNode;
-      let v1: VerseNode | ImmutableVerseNode;
-      let v2: VerseNode | ImmutableVerseNode;
+      let v1: SomeVerseNode;
+      let v2: SomeVerseNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         v1 = $verseFor(shape, "1");
         v2 = $verseFor(shape, "2");
         para = $createParaNode("p").append(
-          ...$paraMarkerPrefix(shape, "p"),
+          ...$createParaMarkerPrefixNodes(shape, "p"),
           v1,
           $createTextNode("text one"),
           v2,
@@ -170,7 +174,7 @@ describe("$getEmptyVerseStatus", () => {
       let para: ParaNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         para = $createParaNode("q2").append(
-          ...$paraMarkerPrefix(shape, "q2"),
+          ...$createParaMarkerPrefixNodes(shape, "q2"),
           $createTextNode("continuation"),
         );
         $getRoot().append(para);
@@ -186,11 +190,11 @@ describe("$getEmptyVerseStatus", () => {
 
     it("ignores text before the first verse (intro text does not affect classification)", () => {
       let para: ParaNode;
-      let v1: VerseNode | ImmutableVerseNode;
+      let v1: SomeVerseNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         v1 = $verseFor(shape, "1");
         para = $createParaNode("p").append(
-          ...$paraMarkerPrefix(shape, "p"),
+          ...$createParaMarkerPrefixNodes(shape, "p"),
           $createTextNode("pre-verse intro"),
           v1,
         );
@@ -207,6 +211,124 @@ describe("$getEmptyVerseStatus", () => {
   });
 });
 
+describe("$getActiveVerseKey", () => {
+  const shapes: ParaShape[] = ["editable", "gutter-hidden", "plain-hidden"];
+
+  it("returns undefined when there is no range selection", () => {
+    const { editor } = createBasicTestEnvironment(nodes, () => {
+      $getRoot().append(
+        $createParaNode("p").append(
+          ...$createParaMarkerPrefixNodes("gutter-hidden", "p"),
+          $verseFor("gutter-hidden", "1"),
+        ),
+      );
+    });
+
+    editor.getEditorState().read(() => {
+      const result = $getActiveVerseKey();
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  it("returns undefined when cursor is in a non-verse paragraph (e.g. \\s heading)", () => {
+    const { editor } = createBasicTestEnvironment(nodes, () => {
+      const heading = $createTextNode("Heading");
+      $getRoot().append(
+        $createParaNode("s").append(...$createParaMarkerPrefixNodes("gutter-hidden", "s"), heading),
+      );
+      heading.select();
+    });
+
+    editor.getEditorState().read(() => {
+      const result = $getActiveVerseKey();
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe.each(shapes)("%s shape", (shape) => {
+    it("returns undefined when cursor sits before the first verse marker", () => {
+      let para: ParaNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        para = $createParaNode("p").append(
+          ...$createParaMarkerPrefixNodes(shape, "p"),
+          $verseFor(shape, "1"),
+        );
+        $getRoot().append(para);
+        para.select(0, 0);
+      });
+
+      editor.getEditorState().read(() => {
+        const result = $getActiveVerseKey();
+
+        expect(result).toBeUndefined();
+      });
+    });
+
+    it("returns the verse key when an element selection sits immediately after its marker", () => {
+      let v1: SomeVerseNode;
+      let para: ParaNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        v1 = $verseFor(shape, "1");
+        para = $createParaNode("p").append(...$createParaMarkerPrefixNodes(shape, "p"), v1);
+        $getRoot().append(para);
+        // Mimic placeCursorAfterEmptyVerse: drop the caret immediately after the verse marker.
+        const after = v1.getIndexWithinParent() + 1;
+        para.select(after, after);
+      });
+
+      editor.getEditorState().read(() => {
+        const result = $getActiveVerseKey();
+
+        expect(result).toBe(v1.getKey());
+      });
+    });
+
+    it("returns the verse key when the cursor sits in body text after the verse", () => {
+      let v1: SomeVerseNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        v1 = $verseFor(shape, "1");
+        const body = $createTextNode("In the beginning");
+        $getRoot().append(
+          $createParaNode("p").append(...$createParaMarkerPrefixNodes(shape, "p"), v1, body),
+        );
+        body.select();
+      });
+
+      editor.getEditorState().read(() => {
+        const result = $getActiveVerseKey();
+
+        expect(result).toBe(v1.getKey());
+      });
+    });
+
+    it("returns the second verse's key when the cursor sits in its section", () => {
+      let v2: SomeVerseNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        v2 = $verseFor(shape, "2");
+        const body2 = $createTextNode("body two");
+        $getRoot().append(
+          $createParaNode("p").append(
+            ...$createParaMarkerPrefixNodes(shape, "p"),
+            $verseFor(shape, "1"),
+            $createTextNode("body one"),
+            v2,
+            body2,
+          ),
+        );
+        body2.select();
+      });
+
+      editor.getEditorState().read(() => {
+        const result = $getActiveVerseKey();
+
+        expect(result).toBe(v2.getKey());
+      });
+    });
+  });
+});
+
 describe("$getParaFromSelection", () => {
   it("returns undefined for an undefined selection", () => {
     expect($getParaFromSelection(undefined)).toBeUndefined();
@@ -217,7 +339,7 @@ describe("$getParaFromSelection", () => {
     const { editor } = createBasicTestEnvironment(nodes, () => {
       const textNode = $createTextNode("Hello world");
       para = $createParaNode("p").append(
-        ...$paraMarkerPrefix("gutter-hidden", "p"),
+        ...$createParaMarkerPrefixNodes("gutter-hidden", "p"),
         $verseFor("gutter-hidden", "1"),
         textNode,
       );
@@ -236,7 +358,10 @@ describe("$getParaFromSelection", () => {
     let para: ParaNode;
     const { editor } = createBasicTestEnvironment(nodes, () => {
       const textNode = $createTextNode("Heading");
-      para = $createParaNode("s").append(...$paraMarkerPrefix("gutter-hidden", "s"), textNode);
+      para = $createParaNode("s").append(
+        ...$createParaMarkerPrefixNodes("gutter-hidden", "s"),
+        textNode,
+      );
       $getRoot().append(para);
       textNode.select();
     });

--- a/packages/platform/src/editor/ActiveTextPlugin.test.tsx
+++ b/packages/platform/src/editor/ActiveTextPlugin.test.tsx
@@ -68,8 +68,8 @@ describe("$getEmptyVerseStatus", () => {
       let v1: SomeVerseNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         v1 = $verseFor(shape, "1");
-        para = $createParaNode("p").append(...$createParaMarkerPrefixNodes(shape, "p"), v1);
-        $getRoot().append(para);
+        para = $createParaNode("p");
+        $getRoot().append(para.append(...$createParaMarkerPrefixNodes(shape, "p"), v1));
       });
 
       editor.getEditorState().read(() => {
@@ -85,12 +85,14 @@ describe("$getEmptyVerseStatus", () => {
       let v1: SomeVerseNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         v1 = $verseFor(shape, "1");
-        para = $createParaNode("p").append(
-          ...$createParaMarkerPrefixNodes(shape, "p"),
-          v1,
-          $createTextNode("In the beginning"),
+        para = $createParaNode("p");
+        $getRoot().append(
+          para.append(
+            ...$createParaMarkerPrefixNodes(shape, "p"),
+            v1,
+            $createTextNode("In the beginning"),
+          ),
         );
-        $getRoot().append(para);
       });
 
       editor.getEditorState().read(() => {
@@ -106,12 +108,10 @@ describe("$getEmptyVerseStatus", () => {
       let v1: SomeVerseNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         v1 = $verseFor(shape, "1");
-        para = $createParaNode("p").append(
-          ...$createParaMarkerPrefixNodes(shape, "p"),
-          v1,
-          $createTextNode("   "),
+        para = $createParaNode("p");
+        $getRoot().append(
+          para.append(...$createParaMarkerPrefixNodes(shape, "p"), v1, $createTextNode("   ")),
         );
-        $getRoot().append(para);
       });
 
       editor.getEditorState().read(() => {
@@ -129,13 +129,15 @@ describe("$getEmptyVerseStatus", () => {
       const { editor } = createBasicTestEnvironment(nodes, () => {
         v1 = $verseFor(shape, "1");
         v2 = $verseFor(shape, "2");
-        para = $createParaNode("p").append(
-          ...$createParaMarkerPrefixNodes(shape, "p"),
-          v1,
-          v2,
-          $createTextNode("In the beginning"),
+        para = $createParaNode("p");
+        $getRoot().append(
+          para.append(
+            ...$createParaMarkerPrefixNodes(shape, "p"),
+            v1,
+            v2,
+            $createTextNode("In the beginning"),
+          ),
         );
-        $getRoot().append(para);
       });
 
       editor.getEditorState().read(() => {
@@ -153,13 +155,15 @@ describe("$getEmptyVerseStatus", () => {
       const { editor } = createBasicTestEnvironment(nodes, () => {
         v1 = $verseFor(shape, "1");
         v2 = $verseFor(shape, "2");
-        para = $createParaNode("p").append(
-          ...$createParaMarkerPrefixNodes(shape, "p"),
-          v1,
-          $createTextNode("text one"),
-          v2,
+        para = $createParaNode("p");
+        $getRoot().append(
+          para.append(
+            ...$createParaMarkerPrefixNodes(shape, "p"),
+            v1,
+            $createTextNode("text one"),
+            v2,
+          ),
         );
-        $getRoot().append(para);
       });
 
       editor.getEditorState().read(() => {
@@ -173,11 +177,13 @@ describe("$getEmptyVerseStatus", () => {
     it("returns no keys for a paragraph with no verses", () => {
       let para: ParaNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
-        para = $createParaNode("q2").append(
-          ...$createParaMarkerPrefixNodes(shape, "q2"),
-          $createTextNode("continuation"),
+        para = $createParaNode("q2");
+        $getRoot().append(
+          para.append(
+            ...$createParaMarkerPrefixNodes(shape, "q2"),
+            $createTextNode("continuation"),
+          ),
         );
-        $getRoot().append(para);
       });
 
       editor.getEditorState().read(() => {
@@ -193,12 +199,14 @@ describe("$getEmptyVerseStatus", () => {
       let v1: SomeVerseNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         v1 = $verseFor(shape, "1");
-        para = $createParaNode("p").append(
-          ...$createParaMarkerPrefixNodes(shape, "p"),
-          $createTextNode("pre-verse intro"),
-          v1,
+        para = $createParaNode("p");
+        $getRoot().append(
+          para.append(
+            ...$createParaMarkerPrefixNodes(shape, "p"),
+            $createTextNode("pre-verse intro"),
+            v1,
+          ),
         );
-        $getRoot().append(para);
       });
 
       editor.getEditorState().read(() => {
@@ -251,11 +259,10 @@ describe("$getActiveVerseKey", () => {
     it("returns undefined when cursor sits before the first verse marker", () => {
       let para: ParaNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
-        para = $createParaNode("p").append(
-          ...$createParaMarkerPrefixNodes(shape, "p"),
-          $verseFor(shape, "1"),
+        para = $createParaNode("p");
+        $getRoot().append(
+          para.append(...$createParaMarkerPrefixNodes(shape, "p"), $verseFor(shape, "1")),
         );
-        $getRoot().append(para);
         para.select(0, 0);
       });
 
@@ -271,8 +278,8 @@ describe("$getActiveVerseKey", () => {
       let para: ParaNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         v1 = $verseFor(shape, "1");
-        para = $createParaNode("p").append(...$createParaMarkerPrefixNodes(shape, "p"), v1);
-        $getRoot().append(para);
+        para = $createParaNode("p");
+        $getRoot().append(para.append(...$createParaMarkerPrefixNodes(shape, "p"), v1));
         // Mimic placeCursorAfterEmptyVerse: drop the caret immediately after the verse marker.
         const after = v1.getIndexWithinParent() + 1;
         para.select(after, after);
@@ -338,12 +345,14 @@ describe("$getParaFromSelection", () => {
     let para: ParaNode;
     const { editor } = createBasicTestEnvironment(nodes, () => {
       const textNode = $createTextNode("Hello world");
-      para = $createParaNode("p").append(
-        ...$createParaMarkerPrefixNodes("gutter-hidden", "p"),
-        $verseFor("gutter-hidden", "1"),
-        textNode,
+      para = $createParaNode("p");
+      $getRoot().append(
+        para.append(
+          ...$createParaMarkerPrefixNodes("gutter-hidden", "p"),
+          $verseFor("gutter-hidden", "1"),
+          textNode,
+        ),
       );
-      $getRoot().append(para);
       textNode.select();
     });
 
@@ -358,11 +367,10 @@ describe("$getParaFromSelection", () => {
     let para: ParaNode;
     const { editor } = createBasicTestEnvironment(nodes, () => {
       const textNode = $createTextNode("Heading");
-      para = $createParaNode("s").append(
-        ...$createParaMarkerPrefixNodes("gutter-hidden", "s"),
-        textNode,
+      para = $createParaNode("s");
+      $getRoot().append(
+        para.append(...$createParaMarkerPrefixNodes("gutter-hidden", "s"), textNode),
       );
-      $getRoot().append(para);
       textNode.select();
     });
 

--- a/packages/platform/src/editor/ActiveTextPlugin.test.tsx
+++ b/packages/platform/src/editor/ActiveTextPlugin.test.tsx
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { $getRoot, $createTextNode, $getSelection, LexicalNode } from "lexical";
 import {
-  $createCharNode,
   $createImmutableTypedTextNode,
   $createMarkerNode,
   $createParaNode,
@@ -17,11 +16,7 @@ import { $createImmutableVerseNode, ImmutableVerseNode } from "shared-react";
 // Reaching inside only for tests.
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { createBasicTestEnvironment } from "../../../../libs/shared/src/nodes/usj/test.utils";
-import {
-  $isParaBodyEmpty,
-  $getVerseParaFromSelection,
-  $getActiveVerseSiblings,
-} from "./ActiveTextPlugin";
+import { $getEmptyVerseStatus, $getParaFromSelection } from "./ActiveTextPlugin";
 
 const nodes = [
   ParaNode,
@@ -60,286 +55,196 @@ function $verseFor(shape: ParaShape, number: string) {
   return shape === "editable" ? $createVerseNode(number) : $createImmutableVerseNode(number);
 }
 
-describe("$isParaBodyEmpty", () => {
+describe("$getEmptyVerseStatus", () => {
   const shapes: ParaShape[] = ["editable", "gutter-hidden", "plain-hidden"];
 
   describe.each(shapes)("%s shape", (shape) => {
-    it("is true for a verse with no body text", () => {
+    it("marks the verse empty when it has no body text", () => {
       let para: ParaNode;
+      let v1: VerseNode | ImmutableVerseNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
-        para = $createParaNode("p");
-        $getRoot().append(para.append(...$paraMarkerPrefix(shape, "p"), $verseFor(shape, "1")));
+        v1 = $verseFor(shape, "1");
+        para = $createParaNode("p").append(...$paraMarkerPrefix(shape, "p"), v1);
+        $getRoot().append(para);
       });
 
       editor.getEditorState().read(() => {
-        expect($isParaBodyEmpty(para)).toBe(true);
+        const result = $getEmptyVerseStatus(para);
+
+        expect(result.emptyKeys).toEqual([v1.getKey()]);
+        expect(result.nonEmptyKeys).toEqual([]);
       });
     });
 
-    it("is false when the verse has body text", () => {
+    it("marks the verse non-empty when it has body text", () => {
       let para: ParaNode;
+      let v1: VerseNode | ImmutableVerseNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
+        v1 = $verseFor(shape, "1");
         para = $createParaNode("p").append(
           ...$paraMarkerPrefix(shape, "p"),
-          $verseFor(shape, "1"),
+          v1,
           $createTextNode("In the beginning"),
         );
         $getRoot().append(para);
       });
 
       editor.getEditorState().read(() => {
-        expect($isParaBodyEmpty(para)).toBe(false);
+        const result = $getEmptyVerseStatus(para);
+
+        expect(result.emptyKeys).toEqual([]);
+        expect(result.nonEmptyKeys).toEqual([v1.getKey()]);
       });
     });
 
-    it("is true when the verse is followed by whitespace only", () => {
+    it("marks the verse empty when it is followed by whitespace only", () => {
       let para: ParaNode;
+      let v1: VerseNode | ImmutableVerseNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
+        v1 = $verseFor(shape, "1");
         para = $createParaNode("p").append(
           ...$paraMarkerPrefix(shape, "p"),
-          $verseFor(shape, "1"),
+          v1,
           $createTextNode("   "),
         );
         $getRoot().append(para);
       });
 
       editor.getEditorState().read(() => {
-        expect($isParaBodyEmpty(para)).toBe(true);
+        const result = $getEmptyVerseStatus(para);
+
+        expect(result.emptyKeys).toEqual([v1.getKey()]);
+        expect(result.nonEmptyKeys).toEqual([]);
+      });
+    });
+
+    it("marks only the empty verse when one of two verses in the paragraph has no body", () => {
+      let para: ParaNode;
+      let v1: VerseNode | ImmutableVerseNode;
+      let v2: VerseNode | ImmutableVerseNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        v1 = $verseFor(shape, "1");
+        v2 = $verseFor(shape, "2");
+        para = $createParaNode("p").append(
+          ...$paraMarkerPrefix(shape, "p"),
+          v1,
+          v2,
+          $createTextNode("In the beginning"),
+        );
+        $getRoot().append(para);
+      });
+
+      editor.getEditorState().read(() => {
+        const result = $getEmptyVerseStatus(para);
+
+        expect(result.emptyKeys).toEqual([v1.getKey()]);
+        expect(result.nonEmptyKeys).toEqual([v2.getKey()]);
+      });
+    });
+
+    it("marks the trailing verse empty when it has no body after a non-empty preceding verse", () => {
+      let para: ParaNode;
+      let v1: VerseNode | ImmutableVerseNode;
+      let v2: VerseNode | ImmutableVerseNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        v1 = $verseFor(shape, "1");
+        v2 = $verseFor(shape, "2");
+        para = $createParaNode("p").append(
+          ...$paraMarkerPrefix(shape, "p"),
+          v1,
+          $createTextNode("text one"),
+          v2,
+        );
+        $getRoot().append(para);
+      });
+
+      editor.getEditorState().read(() => {
+        const result = $getEmptyVerseStatus(para);
+
+        expect(result.emptyKeys).toEqual([v2.getKey()]);
+        expect(result.nonEmptyKeys).toEqual([v1.getKey()]);
+      });
+    });
+
+    it("returns no keys for a paragraph with no verses", () => {
+      let para: ParaNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        para = $createParaNode("q2").append(
+          ...$paraMarkerPrefix(shape, "q2"),
+          $createTextNode("continuation"),
+        );
+        $getRoot().append(para);
+      });
+
+      editor.getEditorState().read(() => {
+        const result = $getEmptyVerseStatus(para);
+
+        expect(result.emptyKeys).toEqual([]);
+        expect(result.nonEmptyKeys).toEqual([]);
+      });
+    });
+
+    it("ignores text before the first verse (intro text does not affect classification)", () => {
+      let para: ParaNode;
+      let v1: VerseNode | ImmutableVerseNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        v1 = $verseFor(shape, "1");
+        para = $createParaNode("p").append(
+          ...$paraMarkerPrefix(shape, "p"),
+          $createTextNode("pre-verse intro"),
+          v1,
+        );
+        $getRoot().append(para);
+      });
+
+      editor.getEditorState().read(() => {
+        const result = $getEmptyVerseStatus(para);
+
+        expect(result.emptyKeys).toEqual([v1.getKey()]);
+        expect(result.nonEmptyKeys).toEqual([]);
       });
     });
   });
 });
 
-describe("$getVerseParaFromSelection", () => {
+describe("$getParaFromSelection", () => {
   it("returns undefined for an undefined selection", () => {
-    expect($getVerseParaFromSelection(undefined)).toBeUndefined();
+    expect($getParaFromSelection(undefined)).toBeUndefined();
   });
 
   it("returns the paragraph when cursor is in a verse paragraph (gutter-hidden shape)", () => {
+    let para: ParaNode;
     const { editor } = createBasicTestEnvironment(nodes, () => {
       const textNode = $createTextNode("Hello world");
-      $getRoot().append(
-        $createParaNode("p").append(
-          ...$paraMarkerPrefix("gutter-hidden", "p"),
-          $verseFor("gutter-hidden", "1"),
-          textNode,
-        ),
+      para = $createParaNode("p").append(
+        ...$paraMarkerPrefix("gutter-hidden", "p"),
+        $verseFor("gutter-hidden", "1"),
+        textNode,
       );
+      $getRoot().append(para);
       textNode.select();
     });
 
     editor.getEditorState().read(() => {
-      const result = $getVerseParaFromSelection($getSelection() ?? undefined);
+      const result = $getParaFromSelection($getSelection() ?? undefined);
 
-      expect(result).toBeDefined();
+      expect(result?.getKey()).toBe(para.getKey());
     });
   });
 
   it("returns the paragraph when cursor is in a non-verse para (e.g. \\s heading)", () => {
+    let para: ParaNode;
     const { editor } = createBasicTestEnvironment(nodes, () => {
       const textNode = $createTextNode("Heading");
-      $getRoot().append(
-        $createParaNode("s").append(...$paraMarkerPrefix("gutter-hidden", "s"), textNode),
-      );
+      para = $createParaNode("s").append(...$paraMarkerPrefix("gutter-hidden", "s"), textNode);
+      $getRoot().append(para);
       textNode.select();
     });
 
     editor.getEditorState().read(() => {
-      const result = $getVerseParaFromSelection($getSelection() ?? undefined);
+      const result = $getParaFromSelection($getSelection() ?? undefined);
 
-      expect(result).not.toBeNull();
-    });
-  });
-});
-
-describe("$getActiveVerseSiblings", () => {
-  it("returns (undefined, undefined) for an undefined selection", () => {
-    let para: ParaNode;
-    const { editor } = createBasicTestEnvironment(nodes, () => {
-      para = $createParaNode("p").append(
-        ...$paraMarkerPrefix("gutter-hidden", "p"),
-        $verseFor("gutter-hidden", "1"),
-        $createTextNode("text"),
-      );
-      $getRoot().append(para);
-    });
-
-    editor.getEditorState().read(() => {
-      const result = $getActiveVerseSiblings(para, undefined);
-
-      expect(result.activeVerseKey).toBeUndefined();
-      expect(result.nextVerseKey).toBeUndefined();
-    });
-  });
-
-  const shapes: ParaShape[] = ["editable", "gutter-hidden", "plain-hidden"];
-
-  describe.each(shapes)("%s shape", (shape) => {
-    it("returns the verse key and undefined for a single-verse paragraph", () => {
-      let para: ParaNode;
-      let verse: VerseNode | ImmutableVerseNode;
-      const { editor } = createBasicTestEnvironment(nodes, () => {
-        verse = $verseFor(shape, "1");
-        const text = $createTextNode("In the beginning");
-        para = $createParaNode("p").append(...$paraMarkerPrefix(shape, "p"), verse, text);
-        $getRoot().append(para);
-        text.select();
-      });
-
-      editor.getEditorState().read(() => {
-        const result = $getActiveVerseSiblings(para, $getSelection() ?? undefined);
-
-        expect(result.activeVerseKey).toBe(verse.getKey());
-        expect(result.nextVerseKey).toBeUndefined();
-      });
-    });
-
-    it("returns (verse1Key, verse2Key) when cursor is in the first verse section", () => {
-      let para: ParaNode;
-      let v1: VerseNode | ImmutableVerseNode;
-      let v2: VerseNode | ImmutableVerseNode;
-      const { editor } = createBasicTestEnvironment(nodes, () => {
-        v1 = $verseFor(shape, "1");
-        const t1 = $createTextNode("text one");
-        v2 = $verseFor(shape, "2");
-        para = $createParaNode("p").append(
-          ...$paraMarkerPrefix(shape, "p"),
-          v1,
-          t1,
-          v2,
-          $createTextNode("text two"),
-        );
-        $getRoot().append(para);
-        t1.select();
-      });
-
-      editor.getEditorState().read(() => {
-        const result = $getActiveVerseSiblings(para, $getSelection() ?? undefined);
-
-        expect(result.activeVerseKey).toBe(v1.getKey());
-        expect(result.nextVerseKey).toBe(v2.getKey());
-      });
-    });
-
-    it("returns (verse2Key, verse3Key) when cursor is in the middle verse section", () => {
-      let para: ParaNode;
-      let v2: VerseNode | ImmutableVerseNode;
-      let v3: VerseNode | ImmutableVerseNode;
-      const { editor } = createBasicTestEnvironment(nodes, () => {
-        v2 = $verseFor(shape, "2");
-        v3 = $verseFor(shape, "3");
-        const t2 = $createTextNode("text two");
-        para = $createParaNode("p").append(
-          ...$paraMarkerPrefix(shape, "p"),
-          $verseFor(shape, "1"),
-          $createTextNode("text one"),
-          v2,
-          t2,
-          v3,
-          $createTextNode("text three"),
-        );
-        $getRoot().append(para);
-        t2.select();
-      });
-
-      editor.getEditorState().read(() => {
-        const result = $getActiveVerseSiblings(para, $getSelection() ?? undefined);
-
-        expect(result.activeVerseKey).toBe(v2.getKey());
-        expect(result.nextVerseKey).toBe(v3.getKey());
-      });
-    });
-
-    it("returns (lastVerseKey, undefined) when cursor is in the last verse section", () => {
-      let para: ParaNode;
-      let v2: VerseNode | ImmutableVerseNode;
-      const { editor } = createBasicTestEnvironment(nodes, () => {
-        v2 = $verseFor(shape, "2");
-        const t2 = $createTextNode("text two");
-        para = $createParaNode("p").append(
-          ...$paraMarkerPrefix(shape, "p"),
-          $verseFor(shape, "1"),
-          $createTextNode("text one"),
-          v2,
-          t2,
-        );
-        $getRoot().append(para);
-        t2.select();
-      });
-
-      editor.getEditorState().read(() => {
-        const result = $getActiveVerseSiblings(para, $getSelection() ?? undefined);
-
-        expect(result.activeVerseKey).toBe(v2.getKey());
-        expect(result.nextVerseKey).toBeUndefined();
-      });
-    });
-
-    it("returns (undefined, firstVerseKey) when cursor is in pre-verse intro text", () => {
-      let para: ParaNode;
-      let v1: VerseNode | ImmutableVerseNode;
-      const { editor } = createBasicTestEnvironment(nodes, () => {
-        const intro = $createTextNode("intro");
-        v1 = $verseFor(shape, "1");
-        para = $createParaNode("p").append(
-          ...$paraMarkerPrefix(shape, "p"),
-          intro,
-          v1,
-          $createTextNode("text one"),
-        );
-        $getRoot().append(para);
-        intro.select();
-      });
-
-      editor.getEditorState().read(() => {
-        const result = $getActiveVerseSiblings(para, $getSelection() ?? undefined);
-
-        expect(result.activeVerseKey).toBeUndefined();
-        expect(result.nextVerseKey).toBe(v1.getKey());
-      });
-    });
-
-    it("returns the verse key when the cursor is inside a CharNode within the verse section", () => {
-      let para: ParaNode;
-      let v1: VerseNode | ImmutableVerseNode;
-      const { editor } = createBasicTestEnvironment(nodes, () => {
-        v1 = $verseFor(shape, "1");
-        const charText = $createTextNode("Lord");
-        const charNode = $createCharNode("nd").append(charText);
-        para = $createParaNode("p").append(
-          ...$paraMarkerPrefix(shape, "p"),
-          v1,
-          $createTextNode("The "),
-          charNode,
-          $createTextNode(" said"),
-        );
-        $getRoot().append(para);
-        charText.select();
-      });
-
-      editor.getEditorState().read(() => {
-        const result = $getActiveVerseSiblings(para, $getSelection() ?? undefined);
-
-        expect(result.activeVerseKey).toBe(v1.getKey());
-        expect(result.nextVerseKey).toBeUndefined();
-      });
-    });
-  });
-
-  it("returns (undefined, undefined) for a paragraph with no verse nodes (e.g. \\q2 continuation)", () => {
-    let para: ParaNode;
-    const { editor } = createBasicTestEnvironment(nodes, () => {
-      const text = $createTextNode("continuation line");
-      para = $createParaNode("q2").append(...$paraMarkerPrefix("gutter-hidden", "q2"), text);
-      $getRoot().append(para);
-      text.select();
-    });
-
-    editor.getEditorState().read(() => {
-      const result = $getActiveVerseSiblings(para, $getSelection() ?? undefined);
-
-      expect(result.activeVerseKey).toBeUndefined();
-      expect(result.nextVerseKey).toBeUndefined();
+      expect(result?.getKey()).toBe(para.getKey());
     });
   });
 });

--- a/packages/platform/src/editor/ActiveTextPlugin.tsx
+++ b/packages/platform/src/editor/ActiveTextPlugin.tsx
@@ -1,6 +1,7 @@
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { mergeRegister } from "@lexical/utils";
 import {
+  $getNearestNodeFromDOMNode,
   $getRoot,
   $getSelection,
   $isElementNode,
@@ -10,8 +11,6 @@ import {
   COMMAND_PRIORITY_LOW,
   ElementNode,
   FOCUS_COMMAND,
-  LexicalEditor,
-  LexicalNode,
 } from "lexical";
 import { useEffect, useRef } from "react";
 import { $isImmutableTypedTextNode, $isMarkerNode, ZWSP } from "shared";
@@ -21,97 +20,68 @@ const ACTIVE_CLASS = "psc-active-text";
 const EMPTY_CLASS = "psc-empty-text";
 
 /**
- * Plugin that shows an outline box around the active text section (the verse range under the
- * cursor) and marks paragraphs with no body content as empty. No-op unless
- * `viewOptions.hasActiveTextFocusBox` is true.
- *
- * @public
+ * Plugin that outlines the paragraph under the cursor and marks individual verses with no
+ * body content as empty. No-op unless `viewOptions.hasActiveTextFocusBox` is true.
  */
 export function ActiveTextPlugin({ viewOptions }: { viewOptions: ViewOptions | undefined }): null {
   const [editor] = useLexicalComposerContext();
   const activeKeyRef = useRef<string>(undefined);
-  const activeVerseKeyRef = useRef<string>(undefined);
-  const nextVerseKeyRef = useRef<string>(undefined);
   const isEnabled = viewOptions?.hasActiveTextFocusBox ?? false;
 
   useEffect(() => {
     if (!isEnabled) return;
 
-    // Re-measures verse section bounds when the active paragraph's height changes due to
-    // text reflow (window resize, content edits that change line count, etc.).
-    const resizeObserver = new ResizeObserver(() => {
+    function setActivePara(key: string | undefined): void {
       if (activeKeyRef.current) {
-        updateTextOutlineBounds(
-          editor,
-          activeKeyRef.current,
-          activeVerseKeyRef.current,
-          nextVerseKeyRef.current,
-        );
-      }
-    });
-
-    function setActivePara(
-      key: string | undefined,
-      verseKey: string | undefined,
-      nextVerseKey: string | undefined,
-    ): void {
-      if (activeKeyRef.current) {
-        const oldEl = editor.getElementByKey(activeKeyRef.current);
-        if (oldEl) {
-          oldEl.classList.remove(ACTIVE_CLASS);
-          oldEl.style.removeProperty("--active-verse-top");
-          oldEl.style.removeProperty("--active-verse-bottom");
-          resizeObserver.unobserve(oldEl);
-        }
+        editor.getElementByKey(activeKeyRef.current)?.classList.remove(ACTIVE_CLASS);
       }
       activeKeyRef.current = key;
-      activeVerseKeyRef.current = verseKey;
-      nextVerseKeyRef.current = nextVerseKey;
       if (key) {
-        const el = editor.getElementByKey(key);
-        if (el) {
-          el.classList.add(ACTIVE_CLASS);
-          updateTextOutlineBounds(editor, key, verseKey, nextVerseKey);
-          resizeObserver.observe(el);
-        }
+        editor.getElementByKey(key)?.classList.add(ACTIVE_CLASS);
       }
     }
 
-    return mergeRegister(
+    // Clicking the ellipsis placeholder (rendered as ::after on the empty verse span) hits the
+    // verse element itself, which is a decorator node — Lexical's default cursor placement leaves
+    // the user with no obvious caret inside the empty verse's section. Move the caret to the slot
+    // immediately after the verse in its paragraph so typing extends the empty verse.
+    function placeCursorAfterEmptyVerse(event: MouseEvent): void {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      const verseEl = target.closest(`.${EMPTY_CLASS}`);
+      if (!verseEl) return;
+      editor.update(() => {
+        const node = $getNearestNodeFromDOMNode(verseEl);
+        if (!$isSomeVerseNode(node)) return;
+        const para = node.getParent();
+        if (!$isElementNode(para)) return;
+        const after = node.getIndexWithinParent() + 1;
+        para.select(after, after);
+      });
+    }
+
+    const unsubscribers = [
+      editor.registerRootListener((rootElement, prevRootElement) => {
+        prevRootElement?.removeEventListener("click", placeCursorAfterEmptyVerse);
+        rootElement?.addEventListener("click", placeCursorAfterEmptyVerse);
+      }),
       editor.registerUpdateListener(({ editorState }) => {
-        const { newActiveKey, newActiveVerseKey, newNextVerseKey, emptyKeys, nonEmptyKeys } =
-          editorState.read(() => {
-            const { newActiveKey, newActiveVerseKey, newNextVerseKey } = $readActiveState();
+        const { newActiveKey, emptyKeys, nonEmptyKeys } = editorState.read(() => {
+          const newActiveKey = $getActiveParaKey();
+          const emptyKeys: string[] = [];
+          const nonEmptyKeys: string[] = [];
+          $getRoot()
+            .getChildren()
+            .forEach((child) => {
+              if (!$isElementNode(child)) return;
+              const { emptyKeys: e, nonEmptyKeys: n } = $getEmptyVerseStatus(child);
+              emptyKeys.push(...e);
+              nonEmptyKeys.push(...n);
+            });
+          return { newActiveKey, emptyKeys, nonEmptyKeys };
+        });
 
-            const emptyKeys: string[] = [];
-            const nonEmptyKeys: string[] = [];
-            $getRoot()
-              .getChildren()
-              .forEach((child) => {
-                if (!$isElementNode(child)) return;
-                if (!$paraHasVerse(child)) return;
-                if ($isParaBodyEmpty(child)) {
-                  emptyKeys.push(child.getKey());
-                } else {
-                  nonEmptyKeys.push(child.getKey());
-                }
-              });
-
-            return { newActiveKey, newActiveVerseKey, newNextVerseKey, emptyKeys, nonEmptyKeys };
-          });
-
-        if (newActiveKey !== activeKeyRef.current) {
-          setActivePara(newActiveKey, newActiveVerseKey, newNextVerseKey);
-        } else if (
-          newActiveVerseKey !== activeVerseKeyRef.current ||
-          newNextVerseKey !== nextVerseKeyRef.current
-        ) {
-          // Same paragraph, cursor moved to a different verse section — re-measure bounds only.
-          activeVerseKeyRef.current = newActiveVerseKey;
-          nextVerseKeyRef.current = newNextVerseKey;
-          if (newActiveKey)
-            updateTextOutlineBounds(editor, newActiveKey, newActiveVerseKey, newNextVerseKey);
-        }
+        if (newActiveKey !== activeKeyRef.current) setActivePara(newActiveKey);
 
         emptyKeys.forEach((key) => editor.getElementByKey(key)?.classList.add(EMPTY_CLASS));
         nonEmptyKeys.forEach((key) => editor.getElementByKey(key)?.classList.remove(EMPTY_CLASS));
@@ -119,7 +89,7 @@ export function ActiveTextPlugin({ viewOptions }: { viewOptions: ViewOptions | u
       editor.registerCommand(
         BLUR_COMMAND,
         () => {
-          setActivePara(undefined, undefined, undefined);
+          setActivePara(undefined);
           return false;
         },
         COMMAND_PRIORITY_LOW,
@@ -127,50 +97,36 @@ export function ActiveTextPlugin({ viewOptions }: { viewOptions: ViewOptions | u
       editor.registerCommand(
         FOCUS_COMMAND,
         () => {
-          const { newActiveKey, newActiveVerseKey, newNextVerseKey } = editor
-            .getEditorState()
-            .read($readActiveState);
-          if (
-            newActiveKey !== activeKeyRef.current ||
-            newActiveVerseKey !== activeVerseKeyRef.current
-          ) {
-            setActivePara(newActiveKey, newActiveVerseKey, newNextVerseKey);
-          }
+          const newActiveKey = editor.getEditorState().read($getActiveParaKey);
+          if (newActiveKey !== activeKeyRef.current) setActivePara(newActiveKey);
           return false;
         },
         COMMAND_PRIORITY_LOW,
       ),
-      () => resizeObserver.disconnect(),
-    );
+    ];
+
+    // Initial sync: registerUpdateListener does not fire on registration, so a mount with an
+    // already-focused editor (route reload, focus restored by browser) would otherwise leave the
+    // active outline missing until the user moves the cursor.
+    setActivePara(editor.getEditorState().read($getActiveParaKey));
+
+    return mergeRegister(...unsubscribers);
   }, [editor, isEnabled]);
 
   return null;
 }
 
-/**
- * Reads the active paragraph and surrounding verse siblings from the current selection.
- * Must be called inside an editor state read.
- */
-export function $readActiveState(): {
-  newActiveKey: string | undefined;
-  newActiveVerseKey: string | undefined;
-  newNextVerseKey: string | undefined;
-} {
-  const selection = $getSelection() ?? undefined;
-  const activePara = $getVerseParaFromSelection(selection);
-  const newActiveKey = activePara?.getKey();
-  let newActiveVerseKey: string | undefined;
-  let newNextVerseKey: string | undefined;
-  if (activePara) {
-    const siblings = $getActiveVerseSiblings(activePara, selection);
-    newActiveVerseKey = siblings.activeVerseKey;
-    newNextVerseKey = siblings.nextVerseKey;
-  }
-  return { newActiveKey, newActiveVerseKey, newNextVerseKey };
+/** Reads the active paragraph's key from the current selection. Must run inside an editor read. */
+function $getActiveParaKey(): string | undefined {
+  return $getParaFromSelection($getSelection() ?? undefined)?.getKey();
 }
 
-/** Returns the top-level paragraph for the cursor, or undefined if no range selection. */
-export function $getVerseParaFromSelection(
+/**
+ * Returns the top-level paragraph for the cursor, or undefined if no range selection. This is any
+ * paragraph the cursor lands in — verse-bearing paragraphs, section headings, book code paragraph,
+ * empty paragraphs, etc.
+ */
+export function $getParaFromSelection(
   selection: BaseSelection | undefined,
 ): ElementNode | undefined {
   if (!$isRangeSelection(selection)) return undefined;
@@ -178,107 +134,33 @@ export function $getVerseParaFromSelection(
 }
 
 /**
- * Returns the key of the verse node (VerseNode or ImmutableVerseNode) immediately before
- * the cursor within `para`, plus the key of the verse node that follows it.
- *
- * Used to restrict the active-text outline box to a single verse section within paragraphs
- * that contain multiple \v markers (e.g. Matthew 1's \p paragraphs).
- *
- * - `activeVerseKey`: the last verse node at or before the cursor; undefined if no verse precedes
- *   the cursor position.
- * - `nextVerseKey`: the first verse node after the active one; when `activeVerseKey` is undefined
- *   (cursor before any verse), the first verse in the paragraph so the pre-verse intro section
- *   is bounded correctly; undefined when no subsequent verse exists in the paragraph.
+ * Classifies each verse in the paragraph by whether its "section" — the children between this
+ * verse marker and the next verse marker (or end of paragraph) — has any non-whitespace body text.
+ * Marker-prefix nodes (the paragraph's leading `\p` marker / immutable typed text) and ZWSPs are
+ * ignored. Used to apply `psc-empty-text` per verse so the ellipsis placeholder renders next to
+ * every empty verse number, not just verses that occupy their own paragraph.
  */
-export function $getActiveVerseSiblings(
-  para: ElementNode,
-  selection: BaseSelection | undefined,
-): { activeVerseKey: string | undefined; nextVerseKey: string | undefined } {
-  if (!$isRangeSelection(selection)) return { activeVerseKey: undefined, nextVerseKey: undefined };
-
-  const anchorNode = selection.anchor.getNode();
-
-  // Walk up from the anchor to find its direct child of `para` (handles CharNode nesting etc.).
-  let directChild: LexicalNode = anchorNode;
-  for (;;) {
-    const parent = directChild.getParent();
-    if (!parent || parent.is(para)) break;
-    directChild = parent;
-  }
-
+export function $getEmptyVerseStatus(para: ElementNode): {
+  emptyKeys: string[];
+  nonEmptyKeys: string[];
+} {
   const children = para.getChildren();
-  const directChildIndex = children.findIndex((c) => c.is(directChild));
-  if (directChildIndex === -1) return { activeVerseKey: undefined, nextVerseKey: undefined };
-
-  // Last verse node AT OR BEFORE the cursor position (inclusive of the cursor's own node).
-  let activeVerseIndex = -1;
-  let activeVerseKey: string | undefined;
-  for (let i = directChildIndex; i >= 0; i--) {
-    if ($isSomeVerseNode(children[i])) {
-      activeVerseKey = children[i].getKey();
-      activeVerseIndex = i;
-      break;
+  const emptyKeys: string[] = [];
+  const nonEmptyKeys: string[] = [];
+  for (let i = 0; i < children.length; i++) {
+    const verse = children[i];
+    if (!$isSomeVerseNode(verse)) continue;
+    let sectionHasBody = false;
+    for (let j = i + 1; j < children.length; j++) {
+      const sibling = children[j];
+      if ($isSomeVerseNode(sibling)) break;
+      if ($isImmutableTypedTextNode(sibling) || $isMarkerNode(sibling)) continue;
+      if (sibling.getTextContent().replaceAll(ZWSP, "").trim() !== "") {
+        sectionHasBody = true;
+        break;
+      }
     }
+    (sectionHasBody ? nonEmptyKeys : emptyKeys).push(verse.getKey());
   }
-
-  // First verse node AFTER the active verse.  When there is no active verse (cursor before any
-  // \v), scan from the start so pre-verse intro content is bounded by the first verse.
-  const searchFrom = activeVerseIndex === -1 ? 0 : activeVerseIndex + 1;
-  let nextVerseKey: string | undefined;
-  for (let i = searchFrom; i < children.length; i++) {
-    if ($isSomeVerseNode(children[i])) {
-      nextVerseKey = children[i].getKey();
-      break;
-    }
-  }
-
-  return { activeVerseKey, nextVerseKey };
-}
-
-/** Returns true if the paragraph's only content beyond verse and marker-prefix nodes is whitespace. */
-export function $isParaBodyEmpty(para: ElementNode): boolean {
-  const nonVerseText = para
-    .getChildren()
-    .filter(
-      (child) =>
-        !$isSomeVerseNode(child) && !$isImmutableTypedTextNode(child) && !$isMarkerNode(child),
-    )
-    .map((child) => child.getTextContent())
-    .join("");
-  return nonVerseText.replaceAll(ZWSP, "").trim() === "";
-}
-
-function $paraHasVerse(para: ElementNode): boolean {
-  return para.getChildren().some((c) => $isSomeVerseNode(c));
-}
-
-/**
- * Sets `--active-verse-top` and `--active-verse-bottom` on the paragraph element so the
- * CSS `::before` outline covers only the active text section, not the whole paragraph.
- *
- * When `activeVerseKey` is undefined (paragraph with no verse node, e.g. a \q2 continuation),
- * both properties default to -2px, which produces the same full-paragraph box as before.
- */
-function updateTextOutlineBounds(
-  editor: LexicalEditor,
-  paraKey: string,
-  activeVerseKey: string | undefined,
-  nextVerseKey: string | undefined,
-): void {
-  const paraEl = editor.getElementByKey(paraKey);
-  if (!paraEl) return;
-
-  const verseEl = activeVerseKey ? editor.getElementByKey(activeVerseKey) : undefined;
-  const nextVerseEl = nextVerseKey ? editor.getElementByKey(nextVerseKey) : undefined;
-
-  // top: 2px above the first line of the active verse span (or 2px above the paragraph top).
-  const topOffset = verseEl ? verseEl.offsetTop - 2 : -2;
-
-  // bottom: expressed as CSS `bottom: Xpx` (distance from the paragraph's bottom edge).
-  // We want the box to extend 2px below the top edge of the next verse span.
-  const paraHeight = paraEl.clientHeight;
-  const bottomCSS = nextVerseEl ? Math.max(0, paraHeight - nextVerseEl.offsetTop - 2) : -2;
-
-  paraEl.style.setProperty("--active-verse-top", `${topOffset}px`);
-  paraEl.style.setProperty("--active-verse-bottom", `${bottomCSS}px`);
+  return { emptyKeys, nonEmptyKeys };
 }

--- a/packages/platform/src/editor/ActiveTextPlugin.tsx
+++ b/packages/platform/src/editor/ActiveTextPlugin.tsx
@@ -8,9 +8,11 @@ import {
   $isRangeSelection,
   BaseSelection,
   BLUR_COMMAND,
+  CLICK_COMMAND,
   COMMAND_PRIORITY_LOW,
   ElementNode,
   FOCUS_COMMAND,
+  LexicalNode,
 } from "lexical";
 import { useEffect, useRef } from "react";
 import { $isImmutableTypedTextNode, $isMarkerNode, ZWSP } from "shared";
@@ -41,33 +43,34 @@ export function ActiveTextPlugin({ viewOptions }: { viewOptions: ViewOptions | u
       }
     }
 
-    // Clicking the ellipsis placeholder (rendered as ::after on the empty verse span) hits the
-    // verse element itself, which is a decorator node — Lexical's default cursor placement leaves
-    // the user with no obvious caret inside the empty verse's section. Move the caret to the slot
-    // immediately after the verse in its paragraph so typing extends the empty verse.
-    function placeCursorAfterEmptyVerse(event: MouseEvent): void {
-      const target = event.target;
-      if (!(target instanceof Element)) return;
-      const verseEl = target.closest(`.${EMPTY_CLASS}`);
-      if (!verseEl) return;
-      editor.update(() => {
-        const node = $getNearestNodeFromDOMNode(verseEl);
-        if (!$isSomeVerseNode(node)) return;
-        const para = node.getParent();
-        if (!$isElementNode(para)) return;
-        const after = node.getIndexWithinParent() + 1;
-        para.select(after, after);
-      });
-    }
-
     const unsubscribers = [
-      editor.registerRootListener((rootElement, prevRootElement) => {
-        prevRootElement?.removeEventListener("click", placeCursorAfterEmptyVerse);
-        rootElement?.addEventListener("click", placeCursorAfterEmptyVerse);
-      }),
+      // Clicking the ellipsis placeholder (rendered as ::after on the empty verse span) hits the
+      // verse element itself, which is a decorator node — Lexical's default cursor placement leaves
+      // the user with no obvious caret inside the empty verse's section. Move the caret to the slot
+      // immediately after the verse in its paragraph so typing extends the empty verse. CLICK_COMMAND
+      // handlers already run inside an editor update, so we set selection directly here rather than
+      // calling editor.update() from a DOM listener.
+      editor.registerCommand(
+        CLICK_COMMAND,
+        (event) => {
+          const target = event.target;
+          if (!(target instanceof Element)) return false;
+          const verseEl = target.closest(`.${EMPTY_CLASS}`);
+          if (!verseEl) return false;
+          const node = $getNearestNodeFromDOMNode(verseEl);
+          if (!$isSomeVerseNode(node)) return false;
+          const para = node.getParent();
+          if (!$isElementNode(para)) return false;
+          const after = node.getIndexWithinParent() + 1;
+          para.select(after, after);
+          return false;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
       editor.registerUpdateListener(({ editorState }) => {
-        const { newActiveKey, emptyKeys, nonEmptyKeys } = editorState.read(() => {
+        const { newActiveKey, activeVerseKey, emptyKeys, nonEmptyKeys } = editorState.read(() => {
           const newActiveKey = $getActiveParaKey();
+          const activeVerseKey = $getActiveVerseKey();
           const emptyKeys: string[] = [];
           const nonEmptyKeys: string[] = [];
           $getRoot()
@@ -78,12 +81,21 @@ export function ActiveTextPlugin({ viewOptions }: { viewOptions: ViewOptions | u
               emptyKeys.push(...e);
               nonEmptyKeys.push(...n);
             });
-          return { newActiveKey, emptyKeys, nonEmptyKeys };
+          return { newActiveKey, activeVerseKey, emptyKeys, nonEmptyKeys };
         });
 
         if (newActiveKey !== activeKeyRef.current) setActivePara(newActiveKey);
 
-        emptyKeys.forEach((key) => editor.getElementByKey(key)?.classList.add(EMPTY_CLASS));
+        // The active verse (the one whose section currently contains the cursor) is treated as
+        // non-empty: the ellipsis placeholder hides while the user is positioned to type there,
+        // and reappears on the next update when the cursor moves to a different verse.
+        emptyKeys.forEach((key) => {
+          if (key === activeVerseKey) {
+            editor.getElementByKey(key)?.classList.remove(EMPTY_CLASS);
+          } else {
+            editor.getElementByKey(key)?.classList.add(EMPTY_CLASS);
+          }
+        });
         nonEmptyKeys.forEach((key) => editor.getElementByKey(key)?.classList.remove(EMPTY_CLASS));
       }),
       editor.registerCommand(
@@ -119,6 +131,47 @@ export function ActiveTextPlugin({ viewOptions }: { viewOptions: ViewOptions | u
 /** Reads the active paragraph's key from the current selection. Must run inside an editor read. */
 function $getActiveParaKey(): string | undefined {
   return $getParaFromSelection($getSelection() ?? undefined)?.getKey();
+}
+
+/**
+ * Returns the key of the verse whose section currently contains the cursor — that is, the most
+ * recent verse marker at or before the cursor's position within its paragraph. Returns undefined
+ * when there is no range selection, the cursor sits in a non-verse paragraph, or the cursor is
+ * before the first verse marker. Must run inside an editor read.
+ */
+export function $getActiveVerseKey(): string | undefined {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection)) return undefined;
+
+  const anchor = selection.anchor;
+  const anchorNode = anchor.getNode();
+  const para = anchorNode.getTopLevelElement();
+  if (!$isElementNode(para)) return undefined;
+
+  // Translate the cursor into a boundary index within the paragraph's children. Verse markers at
+  // index < boundary sit at or before the cursor; the latest one is the active verse.
+  let boundary: number;
+  if (anchorNode.is(para)) {
+    // Element selection on the para itself — offset is a child index, e.g. set by
+    // placeCursorAfterEmptyVerse via `para.select(verseIndex + 1, verseIndex + 1)`.
+    boundary = anchor.offset;
+  } else {
+    // Selection inside a descendant — walk up to the direct paragraph child and treat the
+    // cursor as positioned just past that child's start (so the child itself counts).
+    let topChild: LexicalNode | undefined = anchorNode;
+    while (topChild && !topChild.getParent()?.is(para)) {
+      topChild = topChild.getParent() ?? undefined;
+    }
+    if (!topChild) return undefined;
+    boundary = topChild.getIndexWithinParent() + 1;
+  }
+
+  const children = para.getChildren();
+  let activeKey: string | undefined;
+  for (let i = 0; i < boundary && i < children.length; i++) {
+    if ($isSomeVerseNode(children[i])) activeKey = children[i].getKey();
+  }
+  return activeKey;
 }
 
 /**

--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -447,7 +447,6 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
             ignoreTags={blackListedChangeTags}
           />
           <ActiveTextPlugin viewOptions={viewOptions} />
-          <ParaMarkerPrefixGuardPlugin viewOptions={viewOptions} logger={logger} />
           <AnnotationPlugin ref={annotationRef} logger={logger} />
           <ArrowNavigationPlugin viewOptions={viewOptions} />
           <CharNodePlugin />
@@ -460,6 +459,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
             viewOptions={viewOptions}
             logger={logger}
           />
+          <ParaMarkerPrefixGuardPlugin viewOptions={viewOptions} logger={logger} />
           <ParaNodePlugin />
           <TextDirectionPlugin textDirection={textDirection} />
           <TextSpacingPlugin />

--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -4,6 +4,7 @@ import { getUsjMarkerAction, isUsjMarkerSupported } from "./adaptors/usj-marker-
 import { EditorOptions, EditorProps, EditorRef } from "./editor.model";
 import editorTheme from "./editor.theme";
 import { ActiveTextPlugin } from "./ActiveTextPlugin";
+import { ParaMarkerPrefixGuardPlugin } from "./ParaMarkerPrefixGuardPlugin";
 import ScriptureReferencePlugin from "./ScriptureReferencePlugin";
 import TreeViewPlugin from "./TreeViewPlugin";
 import { ToolbarPlugin } from "./toolbar/ToolbarPlugin";
@@ -446,6 +447,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
             ignoreTags={blackListedChangeTags}
           />
           <ActiveTextPlugin viewOptions={viewOptions} />
+          <ParaMarkerPrefixGuardPlugin viewOptions={viewOptions} logger={logger} />
           <AnnotationPlugin ref={annotationRef} logger={logger} />
           <ArrowNavigationPlugin viewOptions={viewOptions} />
           <CharNodePlugin />

--- a/packages/platform/src/editor/ParaMarkerPrefixGuardPlugin.test.tsx
+++ b/packages/platform/src/editor/ParaMarkerPrefixGuardPlugin.test.tsx
@@ -37,7 +37,7 @@ const nodes = [
  */
 type PrefixShape = "editable" | "gutter-hidden";
 
-function $paraMarkerPrefix(shape: PrefixShape, marker: string): LexicalNode[] {
+function $createParaMarkerPrefixNodes(shape: PrefixShape, marker: string): LexicalNode[] {
   if (shape === "editable") return [$createMarkerNode(marker), $createTextNode(NBSP)];
   return [$createImmutableTypedTextNode("marker", `\\${marker}${NBSP}`)];
 }
@@ -49,8 +49,8 @@ describe("$resetMarkerIfPrefixDeleted", () => {
     it("resets a non-default paragraph's marker when the prefix has been removed", () => {
       let para: ParaNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
-        para = $createParaNode("q1").append($createTextNode("a poetry line"));
-        $getRoot().append(para);
+        para = $createParaNode("q1");
+        $getRoot().append(para.append($createTextNode("a poetry line")));
       });
 
       editor.update(() => $resetMarkerIfPrefixDeleted(para), { discrete: true });
@@ -63,11 +63,13 @@ describe("$resetMarkerIfPrefixDeleted", () => {
     it("does not reset when the prefix is still the first child", () => {
       let para: ParaNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
-        para = $createParaNode("q1").append(
-          ...$paraMarkerPrefix(shape, "q1"),
-          $createTextNode("a poetry line"),
+        para = $createParaNode("q1");
+        $getRoot().append(
+          para.append(
+            ...$createParaMarkerPrefixNodes(shape, "q1"),
+            $createTextNode("a poetry line"),
+          ),
         );
-        $getRoot().append(para);
       });
 
       editor.update(() => $resetMarkerIfPrefixDeleted(para), { discrete: true });
@@ -94,8 +96,8 @@ describe("$resetMarkerIfPrefixDeleted", () => {
     it("does not reset a paragraph already at the default marker", () => {
       let para: ParaNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
-        para = $createParaNode("p").append($createTextNode("plain text"));
-        $getRoot().append(para);
+        para = $createParaNode("p");
+        $getRoot().append(para.append($createTextNode("plain text")));
       });
 
       editor.update(() => $resetMarkerIfPrefixDeleted(para), { discrete: true });

--- a/packages/platform/src/editor/ParaMarkerPrefixGuardPlugin.test.tsx
+++ b/packages/platform/src/editor/ParaMarkerPrefixGuardPlugin.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { $createTextNode, $getRoot, LexicalNode } from "lexical";
+import {
+  $createImmutableTypedTextNode,
+  $createMarkerNode,
+  $createParaNode,
+  CharNode,
+  ImmutableTypedTextNode,
+  MarkerNode,
+  NBSP,
+  ParaNode,
+  VerseNode,
+} from "shared";
+import { ImmutableVerseNode } from "shared-react";
+// Reaching inside only for tests.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { createBasicTestEnvironment } from "../../../../libs/shared/src/nodes/usj/test.utils";
+import { $resetMarkerIfPrefixDeleted } from "./ParaMarkerPrefixGuardPlugin";
+
+const nodes = [
+  ParaNode,
+  VerseNode,
+  ImmutableVerseNode,
+  MarkerNode,
+  ImmutableTypedTextNode,
+  CharNode,
+];
+
+/**
+ * The marker-prefix shapes the adaptor injects in markerPrefix views. The transform must reset
+ * markers regardless of which shape the prefix took.
+ *
+ * - `editable`: `markerMode: "editable"` — prefix is a mutable `MarkerNode("\\p")` followed by a
+ *   `TextNode(NBSP)` (the "marker-trailing-space").
+ * - `gutter-hidden`: `markerMode: "hidden"` + `hasGutterParaMarkers: true` — prefix is an
+ *   `ImmutableTypedTextNode("marker", "\\p\\u00A0")`.
+ */
+type PrefixShape = "editable" | "gutter-hidden";
+
+function $paraMarkerPrefix(shape: PrefixShape, marker: string): LexicalNode[] {
+  if (shape === "editable") return [$createMarkerNode(marker), $createTextNode(NBSP)];
+  return [$createImmutableTypedTextNode("marker", `\\${marker}${NBSP}`)];
+}
+
+describe("$resetMarkerIfPrefixDeleted", () => {
+  const shapes: PrefixShape[] = ["editable", "gutter-hidden"];
+
+  describe.each(shapes)("%s shape", (shape) => {
+    it("resets a non-default paragraph's marker when the prefix has been removed", () => {
+      let para: ParaNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        para = $createParaNode("q1").append($createTextNode("a poetry line"));
+        $getRoot().append(para);
+      });
+
+      editor.update(() => $resetMarkerIfPrefixDeleted(para), { discrete: true });
+
+      editor.getEditorState().read(() => {
+        expect(para.getMarker()).toBe("p");
+      });
+    });
+
+    it("does not reset when the prefix is still the first child", () => {
+      let para: ParaNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        para = $createParaNode("q1").append(
+          ...$paraMarkerPrefix(shape, "q1"),
+          $createTextNode("a poetry line"),
+        );
+        $getRoot().append(para);
+      });
+
+      editor.update(() => $resetMarkerIfPrefixDeleted(para), { discrete: true });
+
+      editor.getEditorState().read(() => {
+        expect(para.getMarker()).toBe("q1");
+      });
+    });
+
+    it("does not reset an empty paragraph (transient mid-edit state)", () => {
+      let para: ParaNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        para = $createParaNode("q1");
+        $getRoot().append(para);
+      });
+
+      editor.update(() => $resetMarkerIfPrefixDeleted(para), { discrete: true });
+
+      editor.getEditorState().read(() => {
+        expect(para.getMarker()).toBe("q1");
+      });
+    });
+
+    it("does not reset a paragraph already at the default marker", () => {
+      let para: ParaNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        para = $createParaNode("p").append($createTextNode("plain text"));
+        $getRoot().append(para);
+      });
+
+      editor.update(() => $resetMarkerIfPrefixDeleted(para), { discrete: true });
+
+      editor.getEditorState().read(() => {
+        expect(para.getMarker()).toBe("p");
+      });
+    });
+  });
+});

--- a/packages/platform/src/editor/ParaMarkerPrefixGuardPlugin.tsx
+++ b/packages/platform/src/editor/ParaMarkerPrefixGuardPlugin.tsx
@@ -1,21 +1,19 @@
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import { LexicalNode } from "lexical";
 import { useEffect } from "react";
-import {
-  $isImmutableTypedTextNode,
-  $isMarkerNode,
-  LoggerBasic,
-  ParaNode,
-  PARA_MARKER_DEFAULT,
-} from "shared";
+import { $isParaMarkerPrefix, LoggerBasic, ParaNode, PARA_MARKER_DEFAULT } from "shared";
 import { ViewOptions } from "shared-react";
 
 /**
- * Resets a paragraph's marker to default when the user deletes its leading marker-prefix child.
+ * Reverts a paragraph back to the default `\p` marker when the user deletes the visible
+ * USFM-marker label (e.g. `\s2`, `\q1`) at the start of the paragraph.
  *
- * Only mounted in views that render a marker-prefix child (markerMode "editable"/"visible" or
- * `hasGutterParaMarkers`). In those views the prefix is the user's handle for the paragraph's
- * type, so removing it should revert the paragraph to a default `\p`.
+ * In views that render a paragraph's marker as a visible node — either inline (markerMode
+ * "editable"/"visible") or in the gutter (`hasGutterParaMarkers`) — the adaptor injects that
+ * marker as the first child of every non-`\p` paragraph. That visible marker is the only
+ * thing the user can directly select and delete to act on the paragraph's type, so when it
+ * disappears we read that as "make this a plain paragraph" and rewrite the paragraph's
+ * marker to `\p`. The plugin is a no-op in views that don't render the marker (markerMode
+ * "hidden" without a gutter), since the user never has the affordance to delete one.
  */
 export function ParaMarkerPrefixGuardPlugin({
   viewOptions,
@@ -41,38 +39,28 @@ export function ParaMarkerPrefixGuardPlugin({
 }
 
 /**
- * Resets the paragraph's marker to default when the marker-prefix child has been removed.
+ * Resets `para`'s marker to `\p` if it's a non-default paragraph whose first child is no
+ * longer the visible USFM-marker node the adaptor injected.
  *
- * Relies on the invariant that `createPara` (usj-editor.adaptor.ts) always injects a marker-prefix
- * child as the first child of every paragraph in markerPrefix views. Given that invariant, a
- * non-default paragraph that has content but no prefix as first child must have had its prefix
- * deleted by the user — the prefix is the user's handle for changing paragraph type. Empty
- * paragraphs are skipped because they're a transient state during edits (e.g. select-all-then-type
- * before the new content lands) where the prefix is also missing without user intent to retype.
+ * `createPara` (usj-editor.adaptor.ts) always injects that visible marker as the first
+ * child of every paragraph in views that render one, so a non-default paragraph that has
+ * content but no marker as its first child must have had it deleted by the user — and the
+ * marker is the only direct affordance the user has for the paragraph's type, so deleting
+ * it reads as "revert to default." Empty paragraphs are skipped because they're a transient
+ * state during edits (e.g. select-all-then-type before the new content lands) where the
+ * marker is also missing without user intent to demote the paragraph.
  *
- * The optional logger is used to surface invariant violations: in normal use this fires when the
- * user deletes a marker prefix on purpose, so the debug line is informational. If it fires on
- * initial document load (before the user has typed anything), the adaptor failed to inject a
- * prefix for this paragraph type — that's the bug to chase.
+ * The optional logger surfaces this: in normal use it fires when the user deletes a marker
+ * on purpose, so the debug line is just informational. If it fires on initial document
+ * load (before any typing), the adaptor failed to inject a marker for this paragraph type
+ * — that is the bug to chase.
  */
 export function $resetMarkerIfPrefixDeleted(para: ParaNode, logger?: LoggerBasic): void {
   if (para.getMarker() === PARA_MARKER_DEFAULT) return;
   if (para.isEmpty()) return;
-  const firstChild = para.getFirstChild();
-  if (firstChild && $isParaMarkerPrefix(firstChild)) return;
+  if ($isParaMarkerPrefix(para.getFirstChild())) return;
   logger?.debug(
     `[ParaMarkerPrefixGuard] Resetting paragraph "${para.getMarker()}" → "${PARA_MARKER_DEFAULT}" (key ${para.getKey()})`,
   );
   para.setMarker(PARA_MARKER_DEFAULT);
-}
-
-/**
- * True for the paragraph-marker-prefix nodes the adaptor injects as the first child of a
- * `\p`-style paragraph: an `ImmutableTypedTextNode` with `textType: "marker"` in gutter /
- * markerMode "visible" views, or a `MarkerNode` in markerMode "editable" view.
- */
-function $isParaMarkerPrefix(node: LexicalNode): boolean {
-  if ($isMarkerNode(node)) return true;
-  if ($isImmutableTypedTextNode(node)) return node.getTextType() === "marker";
-  return false;
 }

--- a/packages/platform/src/editor/ParaMarkerPrefixGuardPlugin.tsx
+++ b/packages/platform/src/editor/ParaMarkerPrefixGuardPlugin.tsx
@@ -1,0 +1,78 @@
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { LexicalNode } from "lexical";
+import { useEffect } from "react";
+import {
+  $isImmutableTypedTextNode,
+  $isMarkerNode,
+  LoggerBasic,
+  ParaNode,
+  PARA_MARKER_DEFAULT,
+} from "shared";
+import { ViewOptions } from "shared-react";
+
+/**
+ * Resets a paragraph's marker to default when the user deletes its leading marker-prefix child.
+ *
+ * Only mounted in views that render a marker-prefix child (markerMode "editable"/"visible" or
+ * `hasGutterParaMarkers`). In those views the prefix is the user's handle for the paragraph's
+ * type, so removing it should revert the paragraph to a default `\p`.
+ */
+export function ParaMarkerPrefixGuardPlugin({
+  viewOptions,
+  logger,
+}: {
+  viewOptions: ViewOptions | undefined;
+  logger?: LoggerBasic;
+}): null {
+  const [editor] = useLexicalComposerContext();
+  const isEnabled =
+    viewOptions?.markerMode === "editable" ||
+    viewOptions?.markerMode === "visible" ||
+    (viewOptions?.hasGutterParaMarkers ?? false);
+
+  useEffect(() => {
+    if (!isEnabled) return;
+    return editor.registerNodeTransform(ParaNode, (para) =>
+      $resetMarkerIfPrefixDeleted(para, logger),
+    );
+  }, [editor, isEnabled, logger]);
+
+  return null;
+}
+
+/**
+ * Resets the paragraph's marker to default when the marker-prefix child has been removed.
+ *
+ * Relies on the invariant that `createPara` (usj-editor.adaptor.ts) always injects a marker-prefix
+ * child as the first child of every paragraph in markerPrefix views. Given that invariant, a
+ * non-default paragraph that has content but no prefix as first child must have had its prefix
+ * deleted by the user — the prefix is the user's handle for changing paragraph type. Empty
+ * paragraphs are skipped because they're a transient state during edits (e.g. select-all-then-type
+ * before the new content lands) where the prefix is also missing without user intent to retype.
+ *
+ * The optional logger is used to surface invariant violations: in normal use this fires when the
+ * user deletes a marker prefix on purpose, so the debug line is informational. If it fires on
+ * initial document load (before the user has typed anything), the adaptor failed to inject a
+ * prefix for this paragraph type — that's the bug to chase.
+ */
+export function $resetMarkerIfPrefixDeleted(para: ParaNode, logger?: LoggerBasic): void {
+  if (para.getMarker() === PARA_MARKER_DEFAULT) return;
+  if (para.isEmpty()) return;
+  const firstChild = para.getFirstChild();
+  if (firstChild && $isParaMarkerPrefix(firstChild)) return;
+  logger?.debug(
+    `[ParaMarkerPrefixGuard] Resetting paragraph "${para.getMarker()}" → "${PARA_MARKER_DEFAULT}" (key ${para.getKey()})`,
+  );
+  para.setMarker(PARA_MARKER_DEFAULT);
+}
+
+/**
+ * True for the paragraph-marker-prefix nodes the adaptor injects as the first child of a
+ * `\p`-style paragraph: an `ImmutableTypedTextNode` with `textType: "marker"` in gutter /
+ * markerMode "visible" views, or a `MarkerNode` in markerMode "editable" view.
+ */
+function $isParaMarkerPrefix(node: LexicalNode): boolean {
+  if ($isMarkerNode(node)) return true;
+  if ($isImmutableTypedTextNode(node)) return node.getTextType() === "marker";
+  return false;
+}

--- a/packages/platform/src/editor/adaptors/usj-editor-adaptor.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-editor-adaptor.test.ts
@@ -202,6 +202,15 @@ describe("USJ Editor Adaptor", () => {
       getViewOptions(PARAGRAPH_STRUCTURE_VIEW_MODE),
     );
 
+    // Book \id begins with a typed-text marker (no book code suffix in gutter mode — the gutter
+    // only shows the opening marker text, not the per-marker arguments).
+    const book = serializedEditorState.root.children[0];
+    if (!isSerializedBookNode(book)) throw new Error("No book node found");
+    const bookMarker = book.children?.[0];
+    if (!isSerializedImmutableTypedTextNode(bookMarker)) throw new Error("No book marker found");
+    expect(bookMarker.textType).toBe("marker");
+    expect(bookMarker.text).toBe(`${openingMarkerText("id")}${NBSP}`);
+
     // Para 'p' begins with a typed-text marker (rendered for the gutter to consume)
     const pPara = serializedEditorState.root.children[VERSE_PARA_INDEX];
     if (!isSerializedParaNode(pPara)) throw new Error("No para node found");

--- a/packages/platform/src/editor/adaptors/usj-editor.adaptor.ts
+++ b/packages/platform/src/editor/adaptors/usj-editor.adaptor.ts
@@ -232,6 +232,10 @@ function createBook(markerObject: MarkerObject): SerializedBookNode {
     children.push(
       createImmutableTypedText("marker", openingMarkerText(marker) + " " + code + NBSP),
     );
+  } else if (_viewOptions?.hasGutterParaMarkers) {
+    // Gutter mode hides inline markers, but the paragraph-structure view still wants the \id
+    // tag visible in the gutter alongside the other paragraph-level markers (\h, \s1, \p, ...).
+    children.push(createImmutableTypedText("marker", openingMarkerText(marker) + NBSP));
   }
   const text = getTextContent(markerObject.content);
   if (text) children.push(createText(text));

--- a/packages/platform/src/usj-nodes.css
+++ b/packages/platform/src/usj-nodes.css
@@ -2437,12 +2437,12 @@ span.read img {
    we attach the ellipsis to `.verse` directly.) */
 .psc-gutter-markers .verse.psc-empty-text::after {
   content: "…";
-  /* Inline-logical margins so the spacing flips correctly in RTL: a hardcoded NBSP inside
-     `content` is a weak bidi character and ends up between the ellipsis and its own verse
-     number when the paragraph is RTL, making the ellipsis look like it belongs to the next
-     verse. Using margin-inline-start/end keeps the gaps on the right sides in both directions. */
-  margin-inline-start: 0.25em;
-  margin-inline-end: 0.25em;
+  cursor: text;
+  /* Padding instead of margin so the I-beam cursor extends across the spacing on either
+     side of the ellipsis, not just the glyph itself. Inline-logical so the gap follows
+     writing direction (flips in RTL) without per-direction overrides. */
+  padding-inline-start: 0.25em;
+  padding-inline-end: 0.25em;
   /* The platform's --muted-foreground holds raw HSL component values, so it has to be wrapped
      in hsl(). The fallback is hsl-formatted too, lighter than the platform default to read as
      a placeholder rather than body text. */

--- a/packages/platform/src/usj-nodes.css
+++ b/packages/platform/src/usj-nodes.css
@@ -2429,10 +2429,26 @@ span.read img {
   color: var(--scripture-accent-chapter);
 }
 
-.psc-gutter-markers .psc-empty-text::after {
+/* Ellipsis placeholder rendered after the verse number whenever a verse has no body text
+   between its marker and the next verse (or end of paragraph). The class is set per-verse by
+   ActiveTextPlugin so the placeholder shows up for every empty verse, not just verses that
+   stand alone in their paragraph. (The `.marker` class is only present in markerMode "visible";
+   in paragraph-structure view the verse number is rendered by ImmutableVerseNode.decorate, so
+   we attach the ellipsis to `.verse` directly.) */
+.psc-gutter-markers .verse.psc-empty-text::after {
   content: "…";
-  color: var(--muted-foreground, #6b7280);
+  /* Inline-logical margins so the spacing flips correctly in RTL: a hardcoded NBSP inside
+     `content` is a weak bidi character and ends up between the ellipsis and its own verse
+     number when the paragraph is RTL, making the ellipsis look like it belongs to the next
+     verse. Using margin-inline-start/end keeps the gaps on the right sides in both directions. */
+  margin-inline-start: 0.25em;
+  margin-inline-end: 0.25em;
+  /* The platform's --muted-foreground holds raw HSL component values, so it has to be wrapped
+     in hsl(). The fallback is hsl-formatted too, lighter than the platform default to read as
+     a placeholder rather than body text. */
+  color: hsl(var(--muted-foreground, 215 16% 65%) / 0.7);
   font-style: italic;
+  font-weight: normal;
 }
 
 .psc-gutter-markers .usfm_s,
@@ -2440,11 +2456,6 @@ span.read img {
 .psc-gutter-markers .usfm_s2,
 .psc-gutter-markers .usfm_s3 {
   text-align: center;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  font-size: 0.8rem;
-  font-weight: 400;
-  color: var(--muted-foreground, #6b7280);
   border-top: none;
   margin-top: 1rem;
 }
@@ -2458,7 +2469,8 @@ span.read img {
 /* position: relative gives absolutely-positioned gutter markers the right
    containing block. --para-indent and --verse-text-start default to 0;
    paragraph-specific overrides follow below. */
-.psc-gutter-markers .para {
+.psc-gutter-markers .para,
+.psc-gutter-markers .book {
   position: relative;
   --para-indent: 0px;
   --verse-text-start: 0px;
@@ -2484,7 +2496,8 @@ span.read img {
    LTR even in RTL documents. Physical left/right are used for positioning (instead of
    inset-inline-*) because forcing direction: ltr on the element makes logical property
    resolution unreliable across browsers. */
-.psc-gutter-markers .para > .marker:not(.verse):not(.chapter):first-child {
+.psc-gutter-markers .para > .marker:not(.verse):not(.chapter):first-child,
+.psc-gutter-markers .book > .marker:first-child {
   display: block;
   position: absolute;
   /* left = -(gutter-width) + 0.5em-gap + para-indent-compensation */
@@ -2509,7 +2522,8 @@ span.read img {
    `text-align: left` here in an RTL containing block triggers a Chrome/Firefox bidi quirk
    where the text glyphs are painted ~57px outside the box to the left (only manifests when
    the box width matches the CSS width — auto-widened boxes like \mt1, \ms1 escape it). */
-.psc-gutter-markers[dir="rtl"] .para > .marker:not(.verse):not(.chapter):first-child {
+.psc-gutter-markers[dir="rtl"] .para > .marker:not(.verse):not(.chapter):first-child,
+.psc-gutter-markers[dir="rtl"] .book > .marker:first-child {
   left: auto;
   right: calc(-1 * (var(--psc-gutter-width) - 0.5em) - var(--para-indent));
 }
@@ -2539,6 +2553,27 @@ span.read img {
    the verse text rather than floating away from it. */
 .psc-gutter-markers[dir="rtl"] .verse.marker {
   direction: ltr;
+  unicode-bidi: isolate;
+}
+
+/* Without isolation, an inline verse number (a weak EN-type character) bidi-merges with
+   adjacent Latin text into a single LTR run, which makes the verse number render before its
+   text in left-to-right visual order instead of at the start of the verse in RTL reading
+   order.
+
+   `unicode-bidi: isolate` alone is not enough though: an isolated element with no explicit
+   `direction` becomes a *neutral* character in the parent's bidi flow. Bidi rule N1 then
+   promotes any neutrals sandwiched between two strong LTR runs (e.g. the verses sitting
+   between two English text fragments) up to the LTR level, merging them all back into one
+   big LTR run. Forcing `direction: rtl` on the verse makes the isolated unit a *strong* RTL
+   atom in the parent's bidi flow, so each verse keeps its RTL level regardless of neighbors
+   and the bidi algorithm places verse + following text in reading order. The digit inside
+   still renders LTR because EN flips to level 2 within the verse's RTL isolation.
+
+   The .verse.marker rule above is preserved (it forces direction: ltr because the visible-
+   marker mode's "\\v N" content needs to stay readable LTR) and wins via higher specificity. */
+.psc-gutter-markers[dir="rtl"] .verse {
+  direction: rtl;
   unicode-bidi: isolate;
 }
 
@@ -2628,28 +2663,43 @@ span.read img {
 
 /* ── Active text focus box ────────────────────────────────────────────────────
    Applied via .psc-active-focus when viewOptions.hasActiveTextFocusBox is true.
-   Shows an outline box around the verse range under the cursor. When used
-   alongside .psc-gutter-markers, the --verse-text-start variable aligns the box
-   with the hanging-indent text start of poetry paragraphs. Without the gutter
-   class that variable defaults to 0px, so poetry alignment is approximate. */
+   Outlines the entire paragraph under the cursor. When used alongside
+   .psc-gutter-markers, the --verse-text-start variable aligns the box with the
+   hanging-indent text start of poetry paragraphs. Without the gutter class that
+   variable defaults to 0px, so poetry alignment is approximate. */
 
 .psc-active-focus {
   --scripture-accent: #c4956a;
 }
 
-/* position: relative on the active paragraph is the containing block for ::before. */
+/* position: relative on the active paragraph is the containing block for the outline pseudo.
+   We use ::after instead of ::before because BookNode paragraphs already use ::before to render
+   the book code via attr(data-code) (see .marker-hidden .book[data-code]::before above), and that
+   rule has higher specificity than the outline's — sharing ::before would let "HAB" bleed into the
+   outline's absolutely-positioned box. */
 .psc-active-focus .psc-active-text {
   position: relative;
 }
 
-.psc-active-focus .psc-active-text::before {
+.psc-active-focus .psc-active-text::after {
   content: "";
   position: absolute;
   inset-inline-start: var(--verse-text-start, 0px);
   inset-inline-end: 0;
-  top: var(--active-verse-top, -2px);
-  bottom: var(--active-verse-bottom, -2px);
+  top: -2px;
+  bottom: -2px;
   border: 2.5px solid var(--scripture-accent);
   border-radius: 4px;
   pointer-events: none;
+}
+
+/* In gutter-marker mode, the paragraph marker (\p, \q1, etc.) is absolutely positioned in the
+   gutter to the inline-start side of the paragraph's content box. Extend the outline's
+   inline-start so the box surrounds the marker too — using min() picks whichever is further
+   into the gutter, the hanging-indent text start (for poetry) or the marker's own column. */
+.psc-active-focus.psc-gutter-markers .psc-active-text::after {
+  inset-inline-start: min(
+    var(--verse-text-start, 0px),
+    calc(-1 * var(--psc-gutter-width) - var(--para-indent))
+  );
 }


### PR DESCRIPTION
## Context

The platform editor's *Paragraph Structure* view (`markerMode: "hidden"` + `hasGutterParaMarkers: true` + `hasActiveTextFocusBox: true`) had a number of rough edges around the active-paragraph outline, the placeholder shown for empty verses, the rendering of paragraph-level markers in the gutter, and the bidi behavior of mixed-direction content. This pass focused on getting that view into a usable state for prose books.

Video Demo
https://github.com/user-attachments/assets/d7bc013e-1a98-42e6-be5d-5d18a16965a8


## Changes

### Empty-verse placeholder
- **Per-verse detection.** Replaced `$isParaBodyEmpty` (paragraph-level) with `$getEmptyVerseStatus` (per-verse): walks each `\v` marker and inspects only the children between it and the next verse marker, so the `…` placeholder now shows next to **every** empty verse — not only verses that happen to occupy their own paragraph.
- **CSS selector fix.** The placeholder rule was originally written against `.verse.marker.psc-empty-text::after`, but the `marker` class is only present in `markerMode: "visible"`. In paragraph-structure view the verse number is rendered by `ImmutableVerseNode.decorate()`, so the selector was relaxed to `.verse.psc-empty-text::after` and the `content` was reduced to just `"…"` (the number isn't duplicated).
- **Color was effectively invisible.** `var(--muted-foreground, #6b7280)` produced an invalid color because the platform's `--muted-foreground` holds raw HSL component values (e.g. `215.4 16.3% 46.9%`), not a color. Wrapped in `hsl()` and used a lighter, opacity-reduced fallback so the ellipsis reads as a clear placeholder.
- **Click-to-position.** Clicking the ellipsis (a CSS `::after` whose target is the verse decorator) wasn't dropping the caret into the empty verse's section. Added a root-level click listener that maps the DOM hit back to the Lexical node and calls `para.select(idx, idx)` with the position immediately after the verse.

### Active-paragraph outline
- **Simplified to paragraph-level.** The earlier per-verse outline machinery (`updateTextOutlineBounds`, `ResizeObserver`, `$getActiveVerseSiblings`, `--active-verse-top` / `--active-verse-bottom`) was producing degenerate (flat) boxes whenever the active verse and next verse landed on the same line. Per-verse boxing is deferred to a follow-up work item; the outline now wraps the entire active paragraph with hardcoded `top: -2px; bottom: -2px;`.
- **Gutter marker no longer clipped.** The outline's `inset-inline-start` defaulted to the paragraph content edge, leaving the absolutely-positioned `\p` / `\s1` / `\q1` gutter markers outside. Added a `psc-gutter-markers`-scoped override that picks the further-inset of `--verse-text-start` (poetry hanging indent) and the gutter column itself.
- **Switched outline pseudo to `::after`.** `BookNode`'s data-code (e.g. `HAB`) is rendered via `.marker-hidden .book[data-code]::before`, which has higher specificity than the outline rule and was therefore winning the `content` cascade — so clicking into the `\id` line painted "HAB" inside the absolutely-positioned outline box and dragged it into the gutter. The outline now uses `::after` to avoid the collision.

### Paragraph-level markers in the gutter
- **`\id` now renders in the gutter.** `createBook` in the USJ→editor adaptor only inserted the marker prefix for `markerMode: "editable"` / `"visible"`; the corresponding `createPara` branch checks `hasGutterParaMarkers` too. Added the same branch to `createBook`, and extended the gutter CSS selectors (`.para`, `.marker:first-child`, and the RTL counterpart) to also target `.book`.
- **Section-heading styling normalized.** Removed `text-transform: uppercase`, `letter-spacing: 0.1em`, `font-size: 0.8rem`, `font-weight: 400`, and the muted color from the general section-heading rule so user-typed headings render in their natural case using the standard bold/body-size `.formatted-font .usfm_s1` styling. (No default placeholder text — that's a future work item.)

### Marker deletion resets paragraph type
- Added `ParaNode.updateDOM` so changes to `__marker` actually refresh the `data-marker` attribute and `usfm_*` class on the live element (`createDOM` was the only place these were set).
- Added a Lexical node transform on `ParaNode` (now its own `ParaMarkerPrefixGuardPlugin`) that resets `__marker` to `"p"` when the marker-prefix child has been deleted. The transform is gated on `markerMode in ("editable", "visible") || hasGutterParaMarkers`, since `ParaNode.__marker` is the sole source of truth in views that don't render a prefix child. `$isParaMarkerPrefix` recognises both the immutable prefix (gutter / visible) and the editable `MarkerNode` prefix.

### RTL bidi for paragraph-structure view
- **Empty-verse placeholder spacing.** The hardcoded NBSP inside the ellipsis `content` is a weak bidi character — in RTL it ended up between the ellipsis and the empty verse's own number, making the ellipsis look like it belonged to the next verse. Replaced with logical `margin-inline-start` / `margin-inline-end` so the gaps stay on the correct sides in both directions.
- **Verse atom isolation.** In RTL paragraphs with mixed Latin/English content, the verse number (Unicode EN, weak LTR) bidi-merged with adjacent Latin text into a single LTR run, rendering verse number → text in LTR order even within an RTL paragraph. The pre-existing `.verse.marker` rule handled the `markerMode: "visible"` shape; added the broader paragraph-structure shape under `.psc-gutter-markers[dir="rtl"] .verse`. `unicode-bidi: isolate` alone wasn't enough — an isolated element with no explicit direction is a *neutral* in the parent's bidi flow, and rule N1 promotes neutrals sandwiched between two strong-LTR runs back to LTR. Setting `direction: rtl` makes the isolated unit a *strong* RTL atom so every verse keeps level 1 regardless of neighbors. The digit inside still renders LTR because EN flips to level 2 inside the verse's RTL isolation.

  Beyond fixing the specific "1 3 2" misordering in mixed Arabic + English content, treating each verse as a bidi atom matters because:
  - **A verse marker is a semantic anchor, not a fragment of text.** Scripture verses are discrete editorial units — readers and editors expect each `\v N` to behave the same way regardless of what characters happen to sit next to it. Without isolation, the visual position of a verse number depends on whether its neighbors are Latin, Arabic, neutral punctuation, or another verse number, and the algorithm can shuffle them under bidi rules (W4/N1) that were designed for inline-text directionality, not for editorial markers.
  - **Adjacent empty verses no longer collide.** When two verses sit back-to-back with no text between (e.g. v2 followed immediately by v3 because v2's section is empty), their digits form a single contiguous EN run. At the level-2 reversal pass the run gets reversed in place — which is what produced the "1 3 2" ordering — *before* the level-1 pass reverses the whole line. Isolating each verse turns `[v2, v3]` into two separate atoms, so they keep their DOM order through every reversal pass.
  - **Editing stays stable.** Without isolation, typing or deleting a character next to a verse can cause the bidi algorithm to re-resolve and visually relocate the verse number. With each verse as a strong-direction atom, the verse's position in the flow is determined by its DOM position alone, so the caret and surrounding text don't jump when an unrelated edit changes the surrounding character mix.
  - **Real scripture is mixed content.** Even an RTL document inevitably contains footnote callers, USFM markers, book codes, embedded numbers, and English glosses. Each is an editorial element that should behave consistently in the bidi flow rather than letting its visual position depend on the directionality of the surrounding text run.

## Out of scope / follow-up

- **Per-verse outline boxes.** The active outline currently wraps the whole paragraph. A future pass will reintroduce per-verse section boxing (including Z-shape rendering for verses that begin mid-line) — the `psc-empty-text` per-verse class and `--verse-text-start` plumbing are still in place to support that.
- **Default placeholder text for empty section headings.** Reverted in this pass; a future work item will define the placeholder content and styling.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/486)
<!-- Reviewable:end -->
