### PR TITLE
PT-4013 Structure protection keyboard input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ vitest.config.*.timestamp*
 .superpowers
 docs/superpowers
 .claude
+.review

--- a/libs/shared-react/src/plugins/usj/StructureProtectionPlugin.test.tsx
+++ b/libs/shared-react/src/plugins/usj/StructureProtectionPlugin.test.tsx
@@ -1,0 +1,252 @@
+// Should only be used on nodes that are initialized in the test environment.
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+// Reaching inside only for tests.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { updateSelection } from "../../../../../libs/shared/src/nodes/usj/test.utils";
+import { $createImmutableVerseNode, ImmutableVerseNode } from "../../nodes/usj";
+import { StructureProtectionPlugin } from "./StructureProtectionPlugin";
+import { baseTestEnvironment, pressKey } from "./react-test.utils";
+import { act } from "@testing-library/react";
+import {
+  $getRoot,
+  $createTextNode,
+  TextNode,
+  COMMAND_PRIORITY_LOW,
+  CONTROLLED_TEXT_INSERTION_COMMAND,
+  CUT_COMMAND,
+  DRAGSTART_COMMAND,
+} from "lexical";
+import { $createParaNode, ParaNode } from "shared";
+
+// NOTE: jsdom cannot drive collapsed mid-text deletes (domSelection.modify) or printable-char
+// insertion via dispatchCommand, and IS_APPLE is false so Alt+Backspace is a no-op. Those cases
+// (mid-text-allowed, Alt/Cmd+Backspace blocked, insertText-allowed, verse removal) are covered as
+// deterministic unit tests in structureProtection.utils.test.ts. Behavior tests here cover only
+// the jsdom-working paths: block-boundary merge and Enter split.
+describe("StructureProtectionPlugin — keyboard", () => {
+  it("blocks Backspace-at-start merge when protected", async () => {
+    let t2: TextNode;
+    const { editor } = await baseTestEnvironment(
+      () => {
+        t2 = $createTextNode("second");
+        $getRoot().append(
+          $createParaNode("p").append($createTextNode("first")),
+          $createParaNode("q").append(t2),
+        );
+      },
+      <StructureProtectionPlugin isProtected={true} />,
+    );
+    updateSelection(editor, t2!, 0);
+
+    await pressKey(editor, "Backspace", 0);
+
+    editor.getEditorState().read(() => {
+      expect($getRoot().getChildrenSize()).toBe(2); // unchanged
+    });
+  });
+
+  it("allows Backspace-at-start merge when NOT protected", async () => {
+    let t2: TextNode;
+    const { editor } = await baseTestEnvironment(
+      () => {
+        t2 = $createTextNode("second");
+        $getRoot().append(
+          $createParaNode("p").append($createTextNode("first")),
+          $createParaNode("q").append(t2),
+        );
+      },
+      <StructureProtectionPlugin isProtected={false} />,
+    );
+    updateSelection(editor, t2!, 0);
+
+    await pressKey(editor, "Backspace", 0);
+
+    editor.getEditorState().read(() => {
+      expect($getRoot().getChildrenSize()).toBe(1); // merged
+    });
+  });
+
+  it("blocks Enter (paragraph split) when protected", async () => {
+    let t1: TextNode;
+    const { editor } = await baseTestEnvironment(
+      () => {
+        t1 = $createTextNode("abcdef");
+        $getRoot().append($createParaNode("p").append(t1));
+      },
+      <StructureProtectionPlugin isProtected={true} />,
+    );
+    updateSelection(editor, t1!, 3);
+
+    await pressKey(editor, "Enter", 0);
+
+    editor.getEditorState().read(() => {
+      expect($getRoot().getChildrenSize()).toBe(1); // not split
+    });
+  });
+});
+
+describe("StructureProtectionPlugin — non-keydown vectors", () => {
+  it("blocks controlled text insertion over a selection spanning a block boundary when protected", async () => {
+    let t1: TextNode;
+    let t2: TextNode;
+    const { editor } = await baseTestEnvironment(
+      () => {
+        t1 = $createTextNode("first");
+        t2 = $createTextNode("second");
+        $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
+      },
+      <StructureProtectionPlugin isProtected={true} />,
+    );
+    updateSelection(editor, t1!, 0, t2!, 6);
+
+    await act(async () => {
+      editor.dispatchCommand(CONTROLLED_TEXT_INSERTION_COMMAND, "x");
+    });
+
+    editor.getEditorState().read(() => {
+      expect($getRoot().getChildrenSize()).toBe(2); // not merged/replaced
+    });
+  });
+
+  it("allows controlled text insertion spanning a boundary when NOT protected", async () => {
+    let t1: TextNode;
+    let t2: TextNode;
+    const { editor } = await baseTestEnvironment(
+      () => {
+        t1 = $createTextNode("first");
+        t2 = $createTextNode("second");
+        $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
+      },
+      <StructureProtectionPlugin isProtected={false} />,
+    );
+    updateSelection(editor, t1!, 0, t2!, 6);
+
+    await act(async () => {
+      editor.dispatchCommand(CONTROLLED_TEXT_INSERTION_COMMAND, "x");
+    });
+
+    editor.getEditorState().read(() => {
+      expect($getRoot().getChildrenSize()).toBe(1); // replaced/merged
+    });
+  });
+
+  it("blocks insertion over a selection containing a verse marker when protected", async () => {
+    let para: ParaNode;
+    let t1: TextNode;
+    const { editor } = await baseTestEnvironment(
+      () => {
+        para = $createParaNode("p");
+        t1 = $createTextNode("text");
+        $getRoot().append(para.append($createImmutableVerseNode("1"), t1));
+      },
+      <StructureProtectionPlugin isProtected={true} />,
+    );
+    updateSelection(editor, para!, 0, t1!, 4);
+
+    await act(async () => {
+      editor.dispatchCommand(CONTROLLED_TEXT_INSERTION_COMMAND, "x");
+    });
+
+    editor.getEditorState().read(() => {
+      const firstBlock = $getRoot().getChildren()[0];
+      const hasVerse =
+        "getChildren" in firstBlock &&
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (firstBlock as any).getChildren().some((n: unknown) => n instanceof ImmutableVerseNode);
+      expect(hasVerse).toBe(true); // verse marker survives
+    });
+  });
+
+  it("consumes CUT over an unsafe selection when protected (low-priority spy not reached)", async () => {
+    let t1: TextNode;
+    let t2: TextNode;
+    const { editor } = await baseTestEnvironment(
+      () => {
+        t1 = $createTextNode("first");
+        t2 = $createTextNode("second");
+        $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
+      },
+      <StructureProtectionPlugin isProtected={true} />,
+    );
+    updateSelection(editor, t1!, 0, t2!, 6);
+
+    const spy = vi.fn(() => false);
+    const unregister = editor.registerCommand(CUT_COMMAND, spy, COMMAND_PRIORITY_LOW);
+    await act(async () => {
+      editor.dispatchCommand(CUT_COMMAND, null);
+    });
+    unregister();
+
+    expect(spy).not.toHaveBeenCalled(); // HIGH handler blocked propagation
+  });
+
+  it("does NOT consume CUT when not protected (low-priority spy reached)", async () => {
+    let t1: TextNode;
+    let t2: TextNode;
+    const { editor } = await baseTestEnvironment(
+      () => {
+        t1 = $createTextNode("first");
+        t2 = $createTextNode("second");
+        $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
+      },
+      <StructureProtectionPlugin isProtected={false} />,
+    );
+    updateSelection(editor, t1!, 0, t2!, 6);
+
+    const spy = vi.fn(() => true); // claim handled so RichText's own cut does nothing
+    const unregister = editor.registerCommand(CUT_COMMAND, spy, COMMAND_PRIORITY_LOW);
+    await act(async () => {
+      editor.dispatchCommand(CUT_COMMAND, null);
+    });
+    unregister();
+
+    expect(spy).toHaveBeenCalled(); // plugin inert; propagation continued
+  });
+
+  it("consumes DRAGSTART over an unsafe selection when protected (low-priority spy not reached)", async () => {
+    let t1: TextNode;
+    let t2: TextNode;
+    const { editor } = await baseTestEnvironment(
+      () => {
+        t1 = $createTextNode("first");
+        t2 = $createTextNode("second");
+        $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
+      },
+      <StructureProtectionPlugin isProtected={true} />,
+    );
+    updateSelection(editor, t1!, 0, t2!, 6);
+
+    const spy = vi.fn(() => false);
+    const unregister = editor.registerCommand(DRAGSTART_COMMAND, spy, COMMAND_PRIORITY_LOW);
+    await act(async () => {
+      editor.dispatchCommand(DRAGSTART_COMMAND, null as unknown as DragEvent);
+    });
+    unregister();
+
+    expect(spy).not.toHaveBeenCalled(); // HIGH handler blocked propagation
+  });
+
+  it("does NOT consume DRAGSTART when not protected (low-priority spy reached)", async () => {
+    let t1: TextNode;
+    let t2: TextNode;
+    const { editor } = await baseTestEnvironment(
+      () => {
+        t1 = $createTextNode("first");
+        t2 = $createTextNode("second");
+        $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
+      },
+      <StructureProtectionPlugin isProtected={false} />,
+    );
+    updateSelection(editor, t1!, 0, t2!, 6);
+
+    const spy = vi.fn(() => true);
+    const unregister = editor.registerCommand(DRAGSTART_COMMAND, spy, COMMAND_PRIORITY_LOW);
+    await act(async () => {
+      editor.dispatchCommand(DRAGSTART_COMMAND, null as unknown as DragEvent);
+    });
+    unregister();
+
+    expect(spy).toHaveBeenCalled(); // plugin inert; propagation continued
+  });
+});

--- a/libs/shared-react/src/plugins/usj/StructureProtectionPlugin.test.tsx
+++ b/libs/shared-react/src/plugins/usj/StructureProtectionPlugin.test.tsx
@@ -221,9 +221,9 @@ describe("StructureProtectionPlugin — non-keydown vectors", () => {
   });
 });
 
-async function testEnvironment(isProtected: boolean, $initialEditorState: () => void) {
+async function testEnvironment(isStructureProtected: boolean, $initialEditorState: () => void) {
   return baseTestEnvironment(
     $initialEditorState,
-    <StructureProtectionPlugin isProtected={isProtected} />,
+    <StructureProtectionPlugin isStructureProtected={isStructureProtected} />,
   );
 }

--- a/libs/shared-react/src/plugins/usj/StructureProtectionPlugin.test.tsx
+++ b/libs/shared-react/src/plugins/usj/StructureProtectionPlugin.test.tsx
@@ -27,7 +27,7 @@ import { $createParaNode, ParaNode } from "shared";
 describe("StructureProtectionPlugin — keyboard", () => {
   it("blocks Backspace-at-start merge when protected", async () => {
     let t2: TextNode;
-    const { editor } = await testEnvironment(true, () => {
+    const { editor } = await testEnvironment(() => {
       t2 = $createTextNode("second");
       $getRoot().append(
         $createParaNode("p").append($createTextNode("first")),
@@ -43,27 +43,9 @@ describe("StructureProtectionPlugin — keyboard", () => {
     });
   });
 
-  it("allows Backspace-at-start merge when NOT protected", async () => {
-    let t2: TextNode;
-    const { editor } = await testEnvironment(false, () => {
-      t2 = $createTextNode("second");
-      $getRoot().append(
-        $createParaNode("p").append($createTextNode("first")),
-        $createParaNode("q").append(t2),
-      );
-    });
-    updateSelection(editor, t2!, 0);
-
-    await pressKey(editor, "Backspace", 0);
-
-    editor.getEditorState().read(() => {
-      expect($getRoot().getChildrenSize()).toBe(1); // merged
-    });
-  });
-
   it("blocks Enter (paragraph split) when protected", async () => {
     let t1: TextNode;
-    const { editor } = await testEnvironment(true, () => {
+    const { editor } = await testEnvironment(() => {
       t1 = $createTextNode("abcdef");
       $getRoot().append($createParaNode("p").append(t1));
     });
@@ -81,7 +63,7 @@ describe("StructureProtectionPlugin — non-keydown vectors", () => {
   it("blocks controlled text insertion over a selection spanning a block boundary when protected", async () => {
     let t1: TextNode;
     let t2: TextNode;
-    const { editor } = await testEnvironment(true, () => {
+    const { editor } = await testEnvironment(() => {
       t1 = $createTextNode("first");
       t2 = $createTextNode("second");
       $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
@@ -97,29 +79,10 @@ describe("StructureProtectionPlugin — non-keydown vectors", () => {
     });
   });
 
-  it("allows controlled text insertion spanning a boundary when NOT protected", async () => {
-    let t1: TextNode;
-    let t2: TextNode;
-    const { editor } = await testEnvironment(false, () => {
-      t1 = $createTextNode("first");
-      t2 = $createTextNode("second");
-      $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
-    });
-    updateSelection(editor, t1!, 0, t2!, 6);
-
-    await act(async () => {
-      editor.dispatchCommand(CONTROLLED_TEXT_INSERTION_COMMAND, "x");
-    });
-
-    editor.getEditorState().read(() => {
-      expect($getRoot().getChildrenSize()).toBe(1); // replaced/merged
-    });
-  });
-
   it("blocks insertion over a selection containing a verse marker when protected", async () => {
     let para: ParaNode;
     let t1: TextNode;
-    const { editor } = await testEnvironment(true, () => {
+    const { editor } = await testEnvironment(() => {
       para = $createParaNode("p");
       t1 = $createTextNode("text");
       $getRoot().append(para.append($createImmutableVerseNode("1"), t1));
@@ -143,7 +106,7 @@ describe("StructureProtectionPlugin — non-keydown vectors", () => {
   it("consumes CUT over an unsafe selection when protected (low-priority spy not reached)", async () => {
     let t1: TextNode;
     let t2: TextNode;
-    const { editor } = await testEnvironment(true, () => {
+    const { editor } = await testEnvironment(() => {
       t1 = $createTextNode("first");
       t2 = $createTextNode("second");
       $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
@@ -158,32 +121,12 @@ describe("StructureProtectionPlugin — non-keydown vectors", () => {
     unregister();
 
     expect(spy).not.toHaveBeenCalled(); // HIGH handler blocked propagation
-  });
-
-  it("does NOT consume CUT when not protected (low-priority spy reached)", async () => {
-    let t1: TextNode;
-    let t2: TextNode;
-    const { editor } = await testEnvironment(false, () => {
-      t1 = $createTextNode("first");
-      t2 = $createTextNode("second");
-      $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
-    });
-    updateSelection(editor, t1!, 0, t2!, 6);
-
-    const spy = vi.fn(() => true); // claim handled so RichText's own cut does nothing
-    const unregister = editor.registerCommand(CUT_COMMAND, spy, COMMAND_PRIORITY_LOW);
-    await act(async () => {
-      editor.dispatchCommand(CUT_COMMAND, null);
-    });
-    unregister();
-
-    expect(spy).toHaveBeenCalled(); // plugin inert; propagation continued
   });
 
   it("consumes DRAGSTART over an unsafe selection when protected (low-priority spy not reached)", async () => {
     let t1: TextNode;
     let t2: TextNode;
-    const { editor } = await testEnvironment(true, () => {
+    const { editor } = await testEnvironment(() => {
       t1 = $createTextNode("first");
       t2 = $createTextNode("second");
       $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
@@ -199,31 +142,11 @@ describe("StructureProtectionPlugin — non-keydown vectors", () => {
 
     expect(spy).not.toHaveBeenCalled(); // HIGH handler blocked propagation
   });
-
-  it("does NOT consume DRAGSTART when not protected (low-priority spy reached)", async () => {
-    let t1: TextNode;
-    let t2: TextNode;
-    const { editor } = await testEnvironment(false, () => {
-      t1 = $createTextNode("first");
-      t2 = $createTextNode("second");
-      $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
-    });
-    updateSelection(editor, t1!, 0, t2!, 6);
-
-    const spy = vi.fn(() => true);
-    const unregister = editor.registerCommand(DRAGSTART_COMMAND, spy, COMMAND_PRIORITY_LOW);
-    await act(async () => {
-      editor.dispatchCommand(DRAGSTART_COMMAND, null as unknown as DragEvent);
-    });
-    unregister();
-
-    expect(spy).toHaveBeenCalled(); // plugin inert; propagation continued
-  });
 });
 
-async function testEnvironment(isStructureProtected: boolean, $initialEditorState: () => void) {
+async function testEnvironment($initialEditorState: () => void) {
   return baseTestEnvironment(
     $initialEditorState,
-    <StructureProtectionPlugin isStructureProtected={isStructureProtected} />,
+    <StructureProtectionPlugin isStructureProtected={true} />,
   );
 }

--- a/libs/shared-react/src/plugins/usj/StructureProtectionPlugin.test.tsx
+++ b/libs/shared-react/src/plugins/usj/StructureProtectionPlugin.test.tsx
@@ -27,16 +27,13 @@ import { $createParaNode, ParaNode } from "shared";
 describe("StructureProtectionPlugin — keyboard", () => {
   it("blocks Backspace-at-start merge when protected", async () => {
     let t2: TextNode;
-    const { editor } = await baseTestEnvironment(
-      () => {
-        t2 = $createTextNode("second");
-        $getRoot().append(
-          $createParaNode("p").append($createTextNode("first")),
-          $createParaNode("q").append(t2),
-        );
-      },
-      <StructureProtectionPlugin isProtected={true} />,
-    );
+    const { editor } = await testEnvironment(true, () => {
+      t2 = $createTextNode("second");
+      $getRoot().append(
+        $createParaNode("p").append($createTextNode("first")),
+        $createParaNode("q").append(t2),
+      );
+    });
     updateSelection(editor, t2!, 0);
 
     await pressKey(editor, "Backspace", 0);
@@ -48,16 +45,13 @@ describe("StructureProtectionPlugin — keyboard", () => {
 
   it("allows Backspace-at-start merge when NOT protected", async () => {
     let t2: TextNode;
-    const { editor } = await baseTestEnvironment(
-      () => {
-        t2 = $createTextNode("second");
-        $getRoot().append(
-          $createParaNode("p").append($createTextNode("first")),
-          $createParaNode("q").append(t2),
-        );
-      },
-      <StructureProtectionPlugin isProtected={false} />,
-    );
+    const { editor } = await testEnvironment(false, () => {
+      t2 = $createTextNode("second");
+      $getRoot().append(
+        $createParaNode("p").append($createTextNode("first")),
+        $createParaNode("q").append(t2),
+      );
+    });
     updateSelection(editor, t2!, 0);
 
     await pressKey(editor, "Backspace", 0);
@@ -69,13 +63,10 @@ describe("StructureProtectionPlugin — keyboard", () => {
 
   it("blocks Enter (paragraph split) when protected", async () => {
     let t1: TextNode;
-    const { editor } = await baseTestEnvironment(
-      () => {
-        t1 = $createTextNode("abcdef");
-        $getRoot().append($createParaNode("p").append(t1));
-      },
-      <StructureProtectionPlugin isProtected={true} />,
-    );
+    const { editor } = await testEnvironment(true, () => {
+      t1 = $createTextNode("abcdef");
+      $getRoot().append($createParaNode("p").append(t1));
+    });
     updateSelection(editor, t1!, 3);
 
     await pressKey(editor, "Enter", 0);
@@ -90,14 +81,11 @@ describe("StructureProtectionPlugin — non-keydown vectors", () => {
   it("blocks controlled text insertion over a selection spanning a block boundary when protected", async () => {
     let t1: TextNode;
     let t2: TextNode;
-    const { editor } = await baseTestEnvironment(
-      () => {
-        t1 = $createTextNode("first");
-        t2 = $createTextNode("second");
-        $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
-      },
-      <StructureProtectionPlugin isProtected={true} />,
-    );
+    const { editor } = await testEnvironment(true, () => {
+      t1 = $createTextNode("first");
+      t2 = $createTextNode("second");
+      $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
+    });
     updateSelection(editor, t1!, 0, t2!, 6);
 
     await act(async () => {
@@ -112,14 +100,11 @@ describe("StructureProtectionPlugin — non-keydown vectors", () => {
   it("allows controlled text insertion spanning a boundary when NOT protected", async () => {
     let t1: TextNode;
     let t2: TextNode;
-    const { editor } = await baseTestEnvironment(
-      () => {
-        t1 = $createTextNode("first");
-        t2 = $createTextNode("second");
-        $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
-      },
-      <StructureProtectionPlugin isProtected={false} />,
-    );
+    const { editor } = await testEnvironment(false, () => {
+      t1 = $createTextNode("first");
+      t2 = $createTextNode("second");
+      $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
+    });
     updateSelection(editor, t1!, 0, t2!, 6);
 
     await act(async () => {
@@ -134,14 +119,11 @@ describe("StructureProtectionPlugin — non-keydown vectors", () => {
   it("blocks insertion over a selection containing a verse marker when protected", async () => {
     let para: ParaNode;
     let t1: TextNode;
-    const { editor } = await baseTestEnvironment(
-      () => {
-        para = $createParaNode("p");
-        t1 = $createTextNode("text");
-        $getRoot().append(para.append($createImmutableVerseNode("1"), t1));
-      },
-      <StructureProtectionPlugin isProtected={true} />,
-    );
+    const { editor } = await testEnvironment(true, () => {
+      para = $createParaNode("p");
+      t1 = $createTextNode("text");
+      $getRoot().append(para.append($createImmutableVerseNode("1"), t1));
+    });
     updateSelection(editor, para!, 0, t1!, 4);
 
     await act(async () => {
@@ -161,14 +143,11 @@ describe("StructureProtectionPlugin — non-keydown vectors", () => {
   it("consumes CUT over an unsafe selection when protected (low-priority spy not reached)", async () => {
     let t1: TextNode;
     let t2: TextNode;
-    const { editor } = await baseTestEnvironment(
-      () => {
-        t1 = $createTextNode("first");
-        t2 = $createTextNode("second");
-        $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
-      },
-      <StructureProtectionPlugin isProtected={true} />,
-    );
+    const { editor } = await testEnvironment(true, () => {
+      t1 = $createTextNode("first");
+      t2 = $createTextNode("second");
+      $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
+    });
     updateSelection(editor, t1!, 0, t2!, 6);
 
     const spy = vi.fn(() => false);
@@ -184,14 +163,11 @@ describe("StructureProtectionPlugin — non-keydown vectors", () => {
   it("does NOT consume CUT when not protected (low-priority spy reached)", async () => {
     let t1: TextNode;
     let t2: TextNode;
-    const { editor } = await baseTestEnvironment(
-      () => {
-        t1 = $createTextNode("first");
-        t2 = $createTextNode("second");
-        $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
-      },
-      <StructureProtectionPlugin isProtected={false} />,
-    );
+    const { editor } = await testEnvironment(false, () => {
+      t1 = $createTextNode("first");
+      t2 = $createTextNode("second");
+      $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
+    });
     updateSelection(editor, t1!, 0, t2!, 6);
 
     const spy = vi.fn(() => true); // claim handled so RichText's own cut does nothing
@@ -207,14 +183,11 @@ describe("StructureProtectionPlugin — non-keydown vectors", () => {
   it("consumes DRAGSTART over an unsafe selection when protected (low-priority spy not reached)", async () => {
     let t1: TextNode;
     let t2: TextNode;
-    const { editor } = await baseTestEnvironment(
-      () => {
-        t1 = $createTextNode("first");
-        t2 = $createTextNode("second");
-        $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
-      },
-      <StructureProtectionPlugin isProtected={true} />,
-    );
+    const { editor } = await testEnvironment(true, () => {
+      t1 = $createTextNode("first");
+      t2 = $createTextNode("second");
+      $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
+    });
     updateSelection(editor, t1!, 0, t2!, 6);
 
     const spy = vi.fn(() => false);
@@ -230,14 +203,11 @@ describe("StructureProtectionPlugin — non-keydown vectors", () => {
   it("does NOT consume DRAGSTART when not protected (low-priority spy reached)", async () => {
     let t1: TextNode;
     let t2: TextNode;
-    const { editor } = await baseTestEnvironment(
-      () => {
-        t1 = $createTextNode("first");
-        t2 = $createTextNode("second");
-        $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
-      },
-      <StructureProtectionPlugin isProtected={false} />,
-    );
+    const { editor } = await testEnvironment(false, () => {
+      t1 = $createTextNode("first");
+      t2 = $createTextNode("second");
+      $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
+    });
     updateSelection(editor, t1!, 0, t2!, 6);
 
     const spy = vi.fn(() => true);
@@ -250,3 +220,10 @@ describe("StructureProtectionPlugin — non-keydown vectors", () => {
     expect(spy).toHaveBeenCalled(); // plugin inert; propagation continued
   });
 });
+
+async function testEnvironment(isProtected: boolean, $initialEditorState: () => void) {
+  return baseTestEnvironment(
+    $initialEditorState,
+    <StructureProtectionPlugin isProtected={isProtected} />,
+  );
+}

--- a/libs/shared-react/src/plugins/usj/StructureProtectionPlugin.tsx
+++ b/libs/shared-react/src/plugins/usj/StructureProtectionPlugin.tsx
@@ -18,18 +18,22 @@ import {
 import { useEffect } from "react";
 
 /**
- * When `isProtected`, blocks keyboard-driven changes to paragraph and verse markers.
+ * When `isStructureProtected`, blocks keyboard-driven changes to paragraph and verse markers.
  * Registers a KEY_DOWN handler at COMMAND_PRIORITY_HIGH, mirroring ArrowNavigationPlugin.
  *
- * @param isProtected - When true, structural keystrokes are intercepted; when false, inert.
+ * @param isStructureProtected - When true, structural keystrokes are intercepted; when false, inert.
  * @returns Always `null`; this component has no UI.
  */
-export function StructureProtectionPlugin({ isProtected }: { isProtected: boolean }): null {
+export function StructureProtectionPlugin({
+  isStructureProtected,
+}: {
+  isStructureProtected: boolean;
+}): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
     const $handleKeyDown = (event: KeyboardEvent): boolean => {
-      if (!isProtected) return false;
+      if (!isStructureProtected) return false;
       const intent = keyDownToIntent(event);
       if (!intent) return false;
       const selection = $getSelection();
@@ -44,7 +48,7 @@ export function StructureProtectionPlugin({ isProtected }: { isProtected: boolea
     // Reuses Rule 1: block when the selection spans a boundary or contains a verse marker.
     // Inspecting pasted/dropped *content* for embedded markers is deferred (see spec §2.5).
     const $blockUnsafeSelection = (payload: unknown): boolean => {
-      if (!isProtected) return false;
+      if (!isStructureProtected) return false;
       const selection = $getSelection();
       if (!selection || !$shouldBlockSelectionReplacement(selection)) return false;
       if (payload instanceof Event) payload.preventDefault();
@@ -63,7 +67,7 @@ export function StructureProtectionPlugin({ isProtected }: { isProtected: boolea
         COMMAND_PRIORITY_HIGH,
       ),
     );
-  }, [editor, isProtected]);
+  }, [editor, isStructureProtected]);
 
   return null;
 }

--- a/libs/shared-react/src/plugins/usj/StructureProtectionPlugin.tsx
+++ b/libs/shared-react/src/plugins/usj/StructureProtectionPlugin.tsx
@@ -6,6 +6,7 @@ import {
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { mergeRegister } from "@lexical/utils";
 import {
+  $getSelection,
   COMMAND_PRIORITY_HIGH,
   CONTROLLED_TEXT_INSERTION_COMMAND,
   CUT_COMMAND,
@@ -31,7 +32,8 @@ export function StructureProtectionPlugin({ isProtected }: { isProtected: boolea
       if (!isProtected) return false;
       const intent = keyDownToIntent(event);
       if (!intent) return false;
-      if ($shouldBlockStructuralEdit(intent)) {
+      const selection = $getSelection();
+      if (selection && $shouldBlockStructuralEdit(selection, intent)) {
         event.preventDefault();
         return true;
       }
@@ -43,7 +45,8 @@ export function StructureProtectionPlugin({ isProtected }: { isProtected: boolea
     // Inspecting pasted/dropped *content* for embedded markers is deferred (see spec §2.5).
     const $blockUnsafeSelection = (payload: unknown): boolean => {
       if (!isProtected) return false;
-      if (!$shouldBlockSelectionReplacement()) return false;
+      const selection = $getSelection();
+      if (!selection || !$shouldBlockSelectionReplacement(selection)) return false;
       if (payload instanceof Event) payload.preventDefault();
       return true;
     };

--- a/libs/shared-react/src/plugins/usj/StructureProtectionPlugin.tsx
+++ b/libs/shared-react/src/plugins/usj/StructureProtectionPlugin.tsx
@@ -46,7 +46,7 @@ export function StructureProtectionPlugin({
 
     // Guard for vectors that bypass KEY_DOWN (cut, paste, drop, IME-composed input).
     // Reuses Rule 1: block when the selection spans a boundary or contains a verse marker.
-    // Inspecting pasted/dropped *content* for embedded markers is deferred (see spec §2.5).
+    // Inspecting pasted/dropped *content* for embedded markers is deferred.
     const $blockUnsafeSelection = (payload: unknown): boolean => {
       if (!isStructureProtected) return false;
       const selection = $getSelection();

--- a/libs/shared-react/src/plugins/usj/StructureProtectionPlugin.tsx
+++ b/libs/shared-react/src/plugins/usj/StructureProtectionPlugin.tsx
@@ -1,0 +1,66 @@
+import {
+  $shouldBlockSelectionReplacement,
+  $shouldBlockStructuralEdit,
+  keyDownToIntent,
+} from "./structureProtection.utils";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { mergeRegister } from "@lexical/utils";
+import {
+  COMMAND_PRIORITY_HIGH,
+  CONTROLLED_TEXT_INSERTION_COMMAND,
+  CUT_COMMAND,
+  DRAGSTART_COMMAND,
+  DROP_COMMAND,
+  KEY_DOWN_COMMAND,
+  PASTE_COMMAND,
+} from "lexical";
+import { useEffect } from "react";
+
+/**
+ * When `isProtected`, blocks keyboard-driven changes to paragraph and verse markers.
+ * Registers a KEY_DOWN handler at COMMAND_PRIORITY_HIGH, mirroring ArrowNavigationPlugin.
+ *
+ * @param isProtected - When true, structural keystrokes are intercepted; when false, inert.
+ * @returns Always `null`; this component has no UI.
+ */
+export function StructureProtectionPlugin({ isProtected }: { isProtected: boolean }): null {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    const $handleKeyDown = (event: KeyboardEvent): boolean => {
+      if (!isProtected) return false;
+      const intent = keyDownToIntent(event);
+      if (!intent) return false;
+      if ($shouldBlockStructuralEdit(intent)) {
+        event.preventDefault();
+        return true;
+      }
+      return false;
+    };
+
+    // Guard for vectors that bypass KEY_DOWN (cut, paste, drop, IME-composed input).
+    // Reuses Rule 1: block when the selection spans a boundary or contains a verse marker.
+    // Inspecting pasted/dropped *content* for embedded markers is deferred (see spec §2.5).
+    const $blockUnsafeSelection = (payload: unknown): boolean => {
+      if (!isProtected) return false;
+      if (!$shouldBlockSelectionReplacement()) return false;
+      if (payload instanceof Event) payload.preventDefault();
+      return true;
+    };
+
+    return mergeRegister(
+      editor.registerCommand(KEY_DOWN_COMMAND, $handleKeyDown, COMMAND_PRIORITY_HIGH),
+      editor.registerCommand(CUT_COMMAND, $blockUnsafeSelection, COMMAND_PRIORITY_HIGH),
+      editor.registerCommand(PASTE_COMMAND, $blockUnsafeSelection, COMMAND_PRIORITY_HIGH),
+      editor.registerCommand(DRAGSTART_COMMAND, $blockUnsafeSelection, COMMAND_PRIORITY_HIGH),
+      editor.registerCommand(DROP_COMMAND, $blockUnsafeSelection, COMMAND_PRIORITY_HIGH),
+      editor.registerCommand(
+        CONTROLLED_TEXT_INSERTION_COMMAND,
+        $blockUnsafeSelection,
+        COMMAND_PRIORITY_HIGH,
+      ),
+    );
+  }, [editor, isProtected]);
+
+  return null;
+}

--- a/libs/shared-react/src/plugins/usj/index.ts
+++ b/libs/shared-react/src/plugins/usj/index.ts
@@ -14,6 +14,7 @@ export * from "./NoteNodePlugin";
 export * from "./OnSelectionChangePlugin";
 export * from "./ParaNodePlugin";
 export * from "./StateChangePlugin";
+export * from "./StructureProtectionPlugin";
 export * from "./text-direction.model";
 export * from "./TextDirectionPlugin";
 export * from "./TextSpacingPlugin";

--- a/libs/shared-react/src/plugins/usj/structureProtection.baseline.test.tsx
+++ b/libs/shared-react/src/plugins/usj/structureProtection.baseline.test.tsx
@@ -1,0 +1,67 @@
+// Should only be used on nodes that are initialized in the test environment.
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+// Reaching inside only for tests.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { updateSelection } from "../../../../../libs/shared/src/nodes/usj/test.utils";
+import { baseTestEnvironment, pressKey } from "./react-test.utils";
+import { $getRoot, $createTextNode, TextNode } from "lexical";
+import { $createParaNode, $createImpliedParaNode, ParaNode, ImpliedParaNode } from "shared";
+
+describe("baseline (unprotected) structural behavior", () => {
+  it("Backspace at start of a ParaNode merges it into the previous paragraph", async () => {
+    let p1: ParaNode;
+    let p2: ParaNode;
+    let t2: TextNode;
+    const { editor } = await baseTestEnvironment(() => {
+      p1 = $createParaNode("p");
+      p2 = $createParaNode("q");
+      t2 = $createTextNode("second");
+      $getRoot().append(p1.append($createTextNode("first")), p2.append(t2));
+    });
+    updateSelection(editor, t2!, 0);
+
+    await pressKey(editor, "Backspace", 0);
+
+    editor.getEditorState().read(() => {
+      // Document the real result: the two paragraphs become one.
+      expect($getRoot().getChildrenSize()).toBe(1);
+    });
+  });
+
+  it("Enter in the middle of a ParaNode splits it into two paragraphs", async () => {
+    let p1: ParaNode;
+    let t1: TextNode;
+    const { editor } = await baseTestEnvironment(() => {
+      p1 = $createParaNode("p");
+      t1 = $createTextNode("abcdef");
+      $getRoot().append(p1.append(t1));
+    });
+    updateSelection(editor, t1!, 3);
+
+    await pressKey(editor, "Enter", 0);
+
+    editor.getEditorState().read(() => {
+      expect($getRoot().getChildrenSize()).toBe(2);
+    });
+  });
+
+  it("Backspace at start of an ImpliedParaNode merges into the previous paragraph", async () => {
+    let p1: ParaNode;
+    let p2: ImpliedParaNode;
+    let t2: TextNode;
+    const { editor } = await baseTestEnvironment(() => {
+      p1 = $createParaNode("p");
+      p2 = $createImpliedParaNode();
+      t2 = $createTextNode("second");
+      $getRoot().append(p1.append($createTextNode("first")), p2.append(t2));
+    });
+    updateSelection(editor, t2!, 0);
+
+    await pressKey(editor, "Backspace", 0);
+
+    editor.getEditorState().read(() => {
+      expect($getRoot().getChildrenSize()).toBe(1);
+    });
+  });
+});

--- a/libs/shared-react/src/plugins/usj/structureProtection.baseline.test.tsx
+++ b/libs/shared-react/src/plugins/usj/structureProtection.baseline.test.tsx
@@ -4,20 +4,29 @@
 // Reaching inside only for tests.
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { updateSelection } from "../../../../../libs/shared/src/nodes/usj/test.utils";
+import { StructureProtectionPlugin } from "./StructureProtectionPlugin";
 import { baseTestEnvironment, pressKey } from "./react-test.utils";
-import { $getRoot, $createTextNode, TextNode } from "lexical";
-import { $createParaNode, $createImpliedParaNode, ParaNode, ImpliedParaNode } from "shared";
+import { act } from "@testing-library/react";
+import {
+  $getRoot,
+  $createTextNode,
+  TextNode,
+  COMMAND_PRIORITY_LOW,
+  CONTROLLED_TEXT_INSERTION_COMMAND,
+  CUT_COMMAND,
+  DRAGSTART_COMMAND,
+} from "lexical";
+import { $createParaNode, $createImpliedParaNode } from "shared";
 
 describe("baseline (unprotected) structural behavior", () => {
   it("Backspace at start of a ParaNode merges it into the previous paragraph", async () => {
-    let p1: ParaNode;
-    let p2: ParaNode;
     let t2: TextNode;
     const { editor } = await baseTestEnvironment(() => {
-      p1 = $createParaNode("p");
-      p2 = $createParaNode("q");
       t2 = $createTextNode("second");
-      $getRoot().append(p1.append($createTextNode("first")), p2.append(t2));
+      $getRoot().append(
+        $createParaNode("p").append($createTextNode("first")),
+        $createParaNode("q").append(t2),
+      );
     });
     updateSelection(editor, t2!, 0);
 
@@ -30,12 +39,10 @@ describe("baseline (unprotected) structural behavior", () => {
   });
 
   it("Enter in the middle of a ParaNode splits it into two paragraphs", async () => {
-    let p1: ParaNode;
     let t1: TextNode;
     const { editor } = await baseTestEnvironment(() => {
-      p1 = $createParaNode("p");
       t1 = $createTextNode("abcdef");
-      $getRoot().append(p1.append(t1));
+      $getRoot().append($createParaNode("p").append(t1));
     });
     updateSelection(editor, t1!, 3);
 
@@ -47,14 +54,13 @@ describe("baseline (unprotected) structural behavior", () => {
   });
 
   it("Backspace at start of an ImpliedParaNode merges into the previous paragraph", async () => {
-    let p1: ParaNode;
-    let p2: ImpliedParaNode;
     let t2: TextNode;
     const { editor } = await baseTestEnvironment(() => {
-      p1 = $createParaNode("p");
-      p2 = $createImpliedParaNode();
       t2 = $createTextNode("second");
-      $getRoot().append(p1.append($createTextNode("first")), p2.append(t2));
+      $getRoot().append(
+        $createParaNode("p").append($createTextNode("first")),
+        $createImpliedParaNode().append(t2),
+      );
     });
     updateSelection(editor, t2!, 0);
 
@@ -65,3 +71,92 @@ describe("baseline (unprotected) structural behavior", () => {
     });
   });
 });
+
+// With the plugin present but disabled (isStructureProtected={false}) the editor must behave exactly
+// like the unprotected baseline above: structural edits go through and the plugin's high-priority
+// handlers stay inert, letting commands propagate.
+describe("StructureProtectionPlugin disabled — behaves like baseline", () => {
+  it("allows Backspace-at-start merge", async () => {
+    let t2: TextNode;
+    const { editor } = await testEnvironment(() => {
+      t2 = $createTextNode("second");
+      $getRoot().append(
+        $createParaNode("p").append($createTextNode("first")),
+        $createParaNode("q").append(t2),
+      );
+    });
+    updateSelection(editor, t2!, 0);
+
+    await pressKey(editor, "Backspace", 0);
+
+    editor.getEditorState().read(() => {
+      expect($getRoot().getChildrenSize()).toBe(1); // merged
+    });
+  });
+
+  it("allows controlled text insertion spanning a boundary", async () => {
+    let t1: TextNode;
+    let t2: TextNode;
+    const { editor } = await testEnvironment(() => {
+      t1 = $createTextNode("first");
+      t2 = $createTextNode("second");
+      $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
+    });
+    updateSelection(editor, t1!, 0, t2!, 6);
+
+    await act(async () => {
+      editor.dispatchCommand(CONTROLLED_TEXT_INSERTION_COMMAND, "x");
+    });
+
+    editor.getEditorState().read(() => {
+      expect($getRoot().getChildrenSize()).toBe(1); // replaced/merged
+    });
+  });
+
+  it("does NOT consume CUT (low-priority spy reached)", async () => {
+    let t1: TextNode;
+    let t2: TextNode;
+    const { editor } = await testEnvironment(() => {
+      t1 = $createTextNode("first");
+      t2 = $createTextNode("second");
+      $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
+    });
+    updateSelection(editor, t1!, 0, t2!, 6);
+
+    const spy = vi.fn(() => true); // claim handled so RichText's own cut does nothing
+    const unregister = editor.registerCommand(CUT_COMMAND, spy, COMMAND_PRIORITY_LOW);
+    await act(async () => {
+      editor.dispatchCommand(CUT_COMMAND, null);
+    });
+    unregister();
+
+    expect(spy).toHaveBeenCalled(); // plugin inert; propagation continued
+  });
+
+  it("does NOT consume DRAGSTART (low-priority spy reached)", async () => {
+    let t1: TextNode;
+    let t2: TextNode;
+    const { editor } = await testEnvironment(() => {
+      t1 = $createTextNode("first");
+      t2 = $createTextNode("second");
+      $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
+    });
+    updateSelection(editor, t1!, 0, t2!, 6);
+
+    const spy = vi.fn(() => true);
+    const unregister = editor.registerCommand(DRAGSTART_COMMAND, spy, COMMAND_PRIORITY_LOW);
+    await act(async () => {
+      editor.dispatchCommand(DRAGSTART_COMMAND, null as unknown as DragEvent);
+    });
+    unregister();
+
+    expect(spy).toHaveBeenCalled(); // plugin inert; propagation continued
+  });
+});
+
+async function testEnvironment($initialEditorState: () => void) {
+  return baseTestEnvironment(
+    $initialEditorState,
+    <StructureProtectionPlugin isStructureProtected={false} />,
+  );
+}

--- a/libs/shared-react/src/plugins/usj/structureProtection.utils.test.ts
+++ b/libs/shared-react/src/plugins/usj/structureProtection.utils.test.ts
@@ -185,7 +185,7 @@ describe("$shouldBlockStructuralEdit (decision logic)", () => {
     });
     updateSelection(editor, t2!, 0);
     editor.getEditorState().read(() => {
-      expect($shouldBlockStructuralEdit("deleteBackward")).toBe(true);
+      expect($shouldBlockStructuralEdit($getSelection()!, "deleteBackward")).toBe(true);
     });
   });
 
@@ -197,7 +197,7 @@ describe("$shouldBlockStructuralEdit (decision logic)", () => {
     });
     updateSelection(editor, t1!, 3);
     editor.getEditorState().read(() => {
-      expect($shouldBlockStructuralEdit("deleteBackward")).toBe(false);
+      expect($shouldBlockStructuralEdit($getSelection()!, "deleteBackward")).toBe(false);
     });
   });
 
@@ -209,7 +209,7 @@ describe("$shouldBlockStructuralEdit (decision logic)", () => {
     });
     updateSelection(editor, t1!, 0);
     editor.getEditorState().read(() => {
-      expect($shouldBlockStructuralEdit("deleteBackward")).toBe(false);
+      expect($shouldBlockStructuralEdit($getSelection()!, "deleteBackward")).toBe(false);
     });
   });
 
@@ -226,7 +226,7 @@ describe("$shouldBlockStructuralEdit (decision logic)", () => {
     });
     updateSelection(editor, t1!, 0);
     editor.getEditorState().read(() => {
-      expect($shouldBlockStructuralEdit("deleteBackward")).toBe(true);
+      expect($shouldBlockStructuralEdit($getSelection()!, "deleteBackward")).toBe(true);
     });
   });
 
@@ -238,7 +238,7 @@ describe("$shouldBlockStructuralEdit (decision logic)", () => {
     });
     updateSelection(editor, t1!, 3);
     editor.getEditorState().read(() => {
-      expect($shouldBlockStructuralEdit("insertParagraph")).toBe(true);
+      expect($shouldBlockStructuralEdit($getSelection()!, "insertParagraph")).toBe(true);
     });
   });
 
@@ -250,7 +250,7 @@ describe("$shouldBlockStructuralEdit (decision logic)", () => {
     });
     updateSelection(editor, t1!, 3);
     editor.getEditorState().read(() => {
-      expect($shouldBlockStructuralEdit("insertText")).toBe(false);
+      expect($shouldBlockStructuralEdit($getSelection()!, "insertText")).toBe(false);
     });
   });
 
@@ -264,7 +264,7 @@ describe("$shouldBlockStructuralEdit (decision logic)", () => {
     });
     updateSelection(editor, t1!, 0, t2!, 6);
     editor.getEditorState().read(() => {
-      expect($shouldBlockStructuralEdit("insertText")).toBe(true);
+      expect($shouldBlockStructuralEdit($getSelection()!, "insertText")).toBe(true);
     });
   });
 });

--- a/libs/shared-react/src/plugins/usj/structureProtection.utils.test.ts
+++ b/libs/shared-react/src/plugins/usj/structureProtection.utils.test.ts
@@ -1,0 +1,270 @@
+// Should only be used on nodes that are initialized in the test environment.
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+// Reaching inside only for tests.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { updateSelection } from "../../../../../libs/shared/src/nodes/usj/test.utils";
+import { baseTestEnvironment } from "./react-test.utils";
+import { $createImmutableVerseNode } from "../../nodes/usj";
+import {
+  $caretAdjacentToVerseMarker,
+  $caretAtParaEnd,
+  $caretAtParaStart,
+  $selectionContainsVerseMarker,
+  $selectionSpansBlockBoundary,
+  $shouldBlockStructuralEdit,
+  keyDownToIntent,
+} from "./structureProtection.utils";
+import {
+  $createNodeSelection,
+  $getRoot,
+  $getSelection,
+  $createTextNode,
+  $setSelection,
+  TextNode,
+} from "lexical";
+import { $createParaNode, $createImpliedParaNode, ParaNode } from "shared";
+
+describe("structureProtection.utils", () => {
+  it("$selectionSpansBlockBoundary: true across two paragraphs", async () => {
+    let t1: TextNode;
+    let t2: TextNode;
+    const { editor } = await baseTestEnvironment(() => {
+      t1 = $createTextNode("first");
+      t2 = $createTextNode("second");
+      $getRoot().append($createParaNode("p").append(t1), $createImpliedParaNode().append(t2));
+    });
+    updateSelection(editor, t1!, 0, t2!, 6);
+    editor.getEditorState().read(() => {
+      expect($selectionSpansBlockBoundary($getSelection()!)).toBe(true);
+    });
+  });
+
+  it("$selectionSpansBlockBoundary: false within one paragraph", async () => {
+    let t1: TextNode;
+    const { editor } = await baseTestEnvironment(() => {
+      t1 = $createTextNode("first");
+      $getRoot().append($createParaNode("p").append(t1));
+    });
+    updateSelection(editor, t1!, 0, t1!, 5);
+    editor.getEditorState().read(() => {
+      expect($selectionSpansBlockBoundary($getSelection()!)).toBe(false);
+    });
+  });
+
+  it("$selectionContainsVerseMarker: true when range includes a verse", async () => {
+    let para: ParaNode;
+    let t1: TextNode;
+    const { editor } = await baseTestEnvironment(() => {
+      para = $createParaNode("p");
+      t1 = $createTextNode("text");
+      $getRoot().append(para.append($createImmutableVerseNode("1"), t1));
+    });
+    updateSelection(editor, para!, 0, t1!, 4);
+    editor.getEditorState().read(() => {
+      expect($selectionContainsVerseMarker($getSelection()!)).toBe(true);
+    });
+  });
+
+  it("$selectionContainsVerseMarker: true for NodeSelection containing a verse node", async () => {
+    let verseNode: ReturnType<typeof $createImmutableVerseNode>;
+    const { editor } = await baseTestEnvironment(() => {
+      verseNode = $createImmutableVerseNode("1");
+      $getRoot().append($createParaNode("p").append(verseNode, $createTextNode("text")));
+    });
+    editor.update(
+      () => {
+        const ns = $createNodeSelection();
+        ns.add(verseNode.getKey());
+        $setSelection(ns);
+      },
+      { discrete: true },
+    );
+    editor.getEditorState().read(() => {
+      expect($selectionContainsVerseMarker($getSelection()!)).toBe(true);
+    });
+  });
+
+  it("$caretAtParaStart: true at offset 0 of first text, false mid-text", async () => {
+    let t1: TextNode;
+    const { editor } = await baseTestEnvironment(() => {
+      t1 = $createTextNode("first");
+      $getRoot().append($createParaNode("p").append(t1));
+    });
+    updateSelection(editor, t1!, 0);
+    editor.getEditorState().read(() => {
+      expect($caretAtParaStart($getSelection()!)).toBe(true);
+    });
+    updateSelection(editor, t1!, 2);
+    editor.getEditorState().read(() => {
+      expect($caretAtParaStart($getSelection()!)).toBe(false);
+    });
+  });
+
+  it("$caretAtParaEnd: true at end of last text, false mid-text", async () => {
+    let t1: TextNode;
+    const { editor } = await baseTestEnvironment(() => {
+      t1 = $createTextNode("first");
+      $getRoot().append($createParaNode("p").append(t1));
+    });
+    updateSelection(editor, t1!, 5);
+    editor.getEditorState().read(() => {
+      expect($caretAtParaEnd($getSelection()!)).toBe(true);
+    });
+    updateSelection(editor, t1!, 2);
+    editor.getEditorState().read(() => {
+      expect($caretAtParaEnd($getSelection()!)).toBe(false);
+    });
+  });
+
+  it("empty paragraph: caret is both at start and at end", async () => {
+    let para: ParaNode;
+    const { editor } = await baseTestEnvironment(() => {
+      para = $createParaNode("p");
+      $getRoot().append($createParaNode("q").append($createTextNode("prev")), para);
+    });
+    updateSelection(editor, para!, 0);
+    editor.getEditorState().read(() => {
+      const sel = $getSelection()!;
+      expect($caretAtParaStart(sel)).toBe(true);
+      expect($caretAtParaEnd(sel)).toBe(true);
+    });
+  });
+
+  it("$caretAdjacentToVerseMarker backward: true when caret immediately follows a verse", async () => {
+    let para: ParaNode;
+    let t1: TextNode;
+    const { editor } = await baseTestEnvironment(() => {
+      para = $createParaNode("p");
+      t1 = $createTextNode("text");
+      $getRoot().append(para.append($createImmutableVerseNode("1"), t1));
+    });
+    updateSelection(editor, t1!, 0);
+    editor.getEditorState().read(() => {
+      expect($caretAdjacentToVerseMarker($getSelection()!, "backward")).toBe(true);
+      expect($caretAdjacentToVerseMarker($getSelection()!, "forward")).toBe(false);
+    });
+  });
+});
+
+describe("keyDownToIntent (B1 — modifier mapping)", () => {
+  const ev = (key: string, mods: KeyboardEventInit = {}) =>
+    new KeyboardEvent("keydown", { key, ...mods });
+
+  it("maps plain and modified Backspace/Delete to deletions (NOT skipped on modifiers)", () => {
+    expect(keyDownToIntent(ev("Backspace"))).toBe("deleteBackward");
+    expect(keyDownToIntent(ev("Backspace", { altKey: true }))).toBe("deleteBackward");
+    expect(keyDownToIntent(ev("Backspace", { metaKey: true }))).toBe("deleteBackward");
+    expect(keyDownToIntent(ev("Backspace", { ctrlKey: true }))).toBe("deleteBackward");
+    expect(keyDownToIntent(ev("Delete"))).toBe("deleteForward");
+    expect(keyDownToIntent(ev("Delete", { altKey: true }))).toBe("deleteForward");
+  });
+
+  it("maps plain Enter to insertParagraph, Shift+Enter to undefined", () => {
+    expect(keyDownToIntent(ev("Enter"))).toBe("insertParagraph");
+    expect(keyDownToIntent(ev("Enter", { shiftKey: true }))).toBeUndefined();
+  });
+
+  it("maps a printable char to insertText, but command-modified/non-editing keys to undefined", () => {
+    expect(keyDownToIntent(ev("a"))).toBe("insertText");
+    expect(keyDownToIntent(ev("a", { ctrlKey: true }))).toBeUndefined();
+    expect(keyDownToIntent(ev("c", { metaKey: true }))).toBeUndefined();
+    expect(keyDownToIntent(ev("ArrowLeft"))).toBeUndefined();
+  });
+});
+
+describe("$shouldBlockStructuralEdit (decision logic)", () => {
+  it("blocks deleteBackward at paragraph start with a previous block", async () => {
+    let t2: TextNode;
+    const { editor } = await baseTestEnvironment(() => {
+      t2 = $createTextNode("second");
+      $getRoot().append(
+        $createParaNode("p").append($createTextNode("first")),
+        $createParaNode("q").append(t2),
+      );
+    });
+    updateSelection(editor, t2!, 0);
+    editor.getEditorState().read(() => {
+      expect($shouldBlockStructuralEdit("deleteBackward")).toBe(true);
+    });
+  });
+
+  it("ALLOWS deleteBackward mid-text (regression: normal editing not blocked)", async () => {
+    let t1: TextNode;
+    const { editor } = await baseTestEnvironment(() => {
+      t1 = $createTextNode("abcdef");
+      $getRoot().append($createParaNode("p").append(t1));
+    });
+    updateSelection(editor, t1!, 3);
+    editor.getEditorState().read(() => {
+      expect($shouldBlockStructuralEdit("deleteBackward")).toBe(false);
+    });
+  });
+
+  it("ALLOWS deleteBackward at the first paragraph start (nothing to merge)", async () => {
+    let t1: TextNode;
+    const { editor } = await baseTestEnvironment(() => {
+      t1 = $createTextNode("first");
+      $getRoot().append($createParaNode("p").append(t1));
+    });
+    updateSelection(editor, t1!, 0);
+    editor.getEditorState().read(() => {
+      expect($shouldBlockStructuralEdit("deleteBackward")).toBe(false);
+    });
+  });
+
+  it("blocks deleteBackward when the caret is immediately after a verse marker", async () => {
+    let para: ParaNode;
+    let t1: TextNode;
+    const { editor } = await baseTestEnvironment(() => {
+      para = $createParaNode("p");
+      t1 = $createTextNode("text");
+      $getRoot().append(
+        $createParaNode("q").append($createTextNode("prev")),
+        para.append($createImmutableVerseNode("1"), t1),
+      );
+    });
+    updateSelection(editor, t1!, 0);
+    editor.getEditorState().read(() => {
+      expect($shouldBlockStructuralEdit("deleteBackward")).toBe(true);
+    });
+  });
+
+  it("always blocks insertParagraph (Enter) at a collapsed caret", async () => {
+    let t1: TextNode;
+    const { editor } = await baseTestEnvironment(() => {
+      t1 = $createTextNode("abcdef");
+      $getRoot().append($createParaNode("p").append(t1));
+    });
+    updateSelection(editor, t1!, 3);
+    editor.getEditorState().read(() => {
+      expect($shouldBlockStructuralEdit("insertParagraph")).toBe(true);
+    });
+  });
+
+  it("ALLOWS insertText at a collapsed caret (typing a character is fine)", async () => {
+    let t1: TextNode;
+    const { editor } = await baseTestEnvironment(() => {
+      t1 = $createTextNode("abcdef");
+      $getRoot().append($createParaNode("p").append(t1));
+    });
+    updateSelection(editor, t1!, 3);
+    editor.getEditorState().read(() => {
+      expect($shouldBlockStructuralEdit("insertText")).toBe(false);
+    });
+  });
+
+  it("blocks any intent over a selection spanning a block boundary", async () => {
+    let t1: TextNode;
+    let t2: TextNode;
+    const { editor } = await baseTestEnvironment(() => {
+      t1 = $createTextNode("first");
+      t2 = $createTextNode("second");
+      $getRoot().append($createParaNode("p").append(t1), $createParaNode("q").append(t2));
+    });
+    updateSelection(editor, t1!, 0, t2!, 6);
+    editor.getEditorState().read(() => {
+      expect($shouldBlockStructuralEdit("insertText")).toBe(true);
+    });
+  });
+});

--- a/libs/shared-react/src/plugins/usj/structureProtection.utils.ts
+++ b/libs/shared-react/src/plugins/usj/structureProtection.utils.ts
@@ -1,7 +1,6 @@
 import { $isSomeVerseNode } from "../../nodes/usj";
 import { $findMatchingParent } from "@lexical/utils";
 import {
-  $getSelection,
   $isElementNode,
   $isNodeSelection,
   $isRangeSelection,
@@ -43,11 +42,7 @@ export function $selectionSpansBlockBoundary(selection: BaseSelection): boolean 
     const para = $getParaAncestor(node);
     if (para) paraKeys.add(para.getKey());
   }
-  if (paraKeys.size > 1) return true;
-  // Fall back to the endpoints in case getNodes() collapsed to a single inline node.
-  const anchorPara = $getParaAncestor(selection.anchor.getNode());
-  const focusPara = $getParaAncestor(selection.focus.getNode());
-  return !!anchorPara && !!focusPara && anchorPara.getKey() !== focusPara.getKey();
+  return paraKeys.size > 1;
 }
 
 /** True when the selection includes any verse marker node. */
@@ -124,19 +119,15 @@ function $hasNeighborBlock(selection: BaseSelection, direction: "backward" | "fo
 }
 
 /**
- * Rule 1 (all input vectors): block when the current selection spans a block boundary or
+ * Rule 1 (all input vectors): block when the given selection spans a block boundary or
  * touches a verse marker. Used by paste/cut/drop/IME guards.
  */
-export function $shouldBlockSelectionReplacement(): boolean {
-  const selection = $getSelection();
-  if (!selection) return false;
+export function $shouldBlockSelectionReplacement(selection: BaseSelection): boolean {
   return $selectionContainsVerseMarker(selection) || $selectionSpansBlockBoundary(selection);
 }
 
 /** Full keyboard decision: combines Rule 1 with collapsed-caret structural rules. */
-export function $shouldBlockStructuralEdit(intent: EditIntent): boolean {
-  const selection = $getSelection();
-  if (!selection) return false;
+export function $shouldBlockStructuralEdit(selection: BaseSelection, intent: EditIntent): boolean {
   if ($selectionContainsVerseMarker(selection) || $selectionSpansBlockBoundary(selection)) {
     return true;
   }

--- a/libs/shared-react/src/plugins/usj/structureProtection.utils.ts
+++ b/libs/shared-react/src/plugins/usj/structureProtection.utils.ts
@@ -1,0 +1,160 @@
+import { $isSomeVerseNode } from "../../nodes/usj";
+import { $findMatchingParent } from "@lexical/utils";
+import {
+  $getSelection,
+  $isElementNode,
+  $isNodeSelection,
+  $isRangeSelection,
+  BaseSelection,
+  LexicalNode,
+} from "lexical";
+import { $isSomeParaNode } from "shared";
+
+/** Editing operations that can alter block structure. */
+export type EditIntent = "insertParagraph" | "deleteBackward" | "deleteForward" | "insertText";
+
+/**
+ * Maps a keydown to the structural edit it would cause, or undefined for non-editing keys.
+ * Deliberately does NOT early-return on Alt/Ctrl/Meta for Backspace/Delete — Alt/Cmd+Backspace
+ * (delete-word / delete-line) are destructive and must be classified as deletions (spec B1).
+ */
+export function keyDownToIntent(event: KeyboardEvent): EditIntent | undefined {
+  if (event.key === "Enter" && !event.shiftKey) return "insertParagraph";
+  if (event.key === "Backspace") return "deleteBackward";
+  if (event.key === "Delete") return "deleteForward";
+  // Printable character with no command modifier. Alt allowed (special chars on some layouts).
+  if (event.key.length === 1 && !event.ctrlKey && !event.metaKey) return "insertText";
+  return undefined;
+}
+
+/** Returns the paragraph (ParaNode or ImpliedParaNode) that contains `node`, if any. */
+function $getParaAncestor(node: LexicalNode | null | undefined): LexicalNode | undefined {
+  if (!node) return undefined;
+  if ($isSomeParaNode(node)) return node;
+  const para = $findMatchingParent(node, (n: LexicalNode) => $isSomeParaNode(n));
+  return para ?? undefined;
+}
+
+/** True when the selection covers more than one paragraph block. */
+export function $selectionSpansBlockBoundary(selection: BaseSelection): boolean {
+  if (!$isRangeSelection(selection)) return false;
+  const paraKeys = new Set<string>();
+  for (const node of selection.getNodes()) {
+    const para = $getParaAncestor(node);
+    if (para) paraKeys.add(para.getKey());
+  }
+  if (paraKeys.size > 1) return true;
+  // Fall back to the endpoints in case getNodes() collapsed to a single inline node.
+  const anchorPara = $getParaAncestor(selection.anchor.getNode());
+  const focusPara = $getParaAncestor(selection.focus.getNode());
+  return !!anchorPara && !!focusPara && anchorPara.getKey() !== focusPara.getKey();
+}
+
+/** True when the selection includes any verse marker node. */
+export function $selectionContainsVerseMarker(selection: BaseSelection): boolean {
+  if (!$isRangeSelection(selection) && !$isNodeSelection(selection)) return false;
+  return selection.getNodes().some((n) => $isSomeVerseNode(n));
+}
+
+/** True when a collapsed caret sits at the very start of its paragraph. */
+export function $caretAtParaStart(selection: BaseSelection): boolean {
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
+  const { anchor } = selection;
+  const node = anchor.getNode();
+  const para = $getParaAncestor(node);
+  if (!para) return false;
+  if (anchor.offset !== 0) return false;
+  // No content between the caret and the paragraph start.
+  let current: LexicalNode | null = node;
+  while (current && current.getKey() !== para.getKey()) {
+    if (current.getPreviousSibling()) return false;
+    current = current.getParent();
+  }
+  return true;
+}
+
+/** True when a collapsed caret sits at the very end of its paragraph. */
+export function $caretAtParaEnd(selection: BaseSelection): boolean {
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
+  const { anchor } = selection;
+  const node = anchor.getNode();
+  const para = $getParaAncestor(node);
+  if (!para) return false;
+  if ($isElementNode(node)) {
+    if (anchor.offset !== node.getChildrenSize()) return false;
+  } else if (anchor.offset !== node.getTextContentSize()) {
+    return false;
+  }
+  let current: LexicalNode | null = node;
+  while (current && current.getKey() !== para.getKey()) {
+    if (current.getNextSibling()) return false;
+    current = current.getParent();
+  }
+  return true;
+}
+
+/** True when the node immediately before/after a collapsed caret is a verse marker. */
+export function $caretAdjacentToVerseMarker(
+  selection: BaseSelection,
+  direction: "backward" | "forward",
+): boolean {
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
+  const { anchor } = selection;
+  const node = anchor.getNode();
+  if (anchor.type === "element" && $isElementNode(node)) {
+    const children = node.getChildren();
+    const idx = direction === "backward" ? anchor.offset - 1 : anchor.offset;
+    if (idx < 0) return false;
+    return $isSomeVerseNode(children[idx]);
+  }
+  if (direction === "backward") {
+    if (anchor.offset !== 0) return false;
+    return $isSomeVerseNode(node.getPreviousSibling());
+  }
+  if (anchor.offset !== node.getTextContentSize()) return false;
+  return $isSomeVerseNode(node.getNextSibling());
+}
+
+/** True when the paragraph holding the caret has a preceding block sibling. */
+function $hasNeighborBlock(selection: BaseSelection, direction: "backward" | "forward"): boolean {
+  if (!$isRangeSelection(selection)) return false;
+  const para = $getParaAncestor(selection.anchor.getNode());
+  if (!para) return false;
+  return !!(direction === "backward" ? para.getPreviousSibling() : para.getNextSibling());
+}
+
+/**
+ * Rule 1 (all input vectors): block when the current selection spans a block boundary or
+ * touches a verse marker. Used by paste/cut/drop/IME guards.
+ */
+export function $shouldBlockSelectionReplacement(): boolean {
+  const selection = $getSelection();
+  if (!selection) return false;
+  return $selectionContainsVerseMarker(selection) || $selectionSpansBlockBoundary(selection);
+}
+
+/** Full keyboard decision: combines Rule 1 with collapsed-caret structural rules. */
+export function $shouldBlockStructuralEdit(intent: EditIntent): boolean {
+  const selection = $getSelection();
+  if (!selection) return false;
+  if ($selectionContainsVerseMarker(selection) || $selectionSpansBlockBoundary(selection)) {
+    return true;
+  }
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
+  switch (intent) {
+    case "insertParagraph":
+      return true;
+    case "deleteBackward":
+      return (
+        ($caretAtParaStart(selection) && $hasNeighborBlock(selection, "backward")) ||
+        $caretAdjacentToVerseMarker(selection, "backward")
+      );
+    case "deleteForward":
+      return (
+        ($caretAtParaEnd(selection) && $hasNeighborBlock(selection, "forward")) ||
+        $caretAdjacentToVerseMarker(selection, "forward")
+      );
+    case "insertText":
+      return false;
+  }
+}

--- a/packages/platform/etc/platform-editor.api.md
+++ b/packages/platform/etc/platform-editor.api.md
@@ -72,8 +72,8 @@ export interface EditorOptions {
     debug?: boolean;
     hasExternalUI?: boolean;
     hasSpellCheck?: boolean;
-    isProtected?: boolean;
     isReadonly?: boolean;
+    isStructureProtected?: boolean;
     markerMenuTrigger?: string;
     nodes?: UsjNodeOptions;
     textDirection?: TextDirection;

--- a/packages/platform/etc/platform-editor.api.md
+++ b/packages/platform/etc/platform-editor.api.md
@@ -72,6 +72,7 @@ export interface EditorOptions {
     debug?: boolean;
     hasExternalUI?: boolean;
     hasSpellCheck?: boolean;
+    isProtected?: boolean;
     isReadonly?: boolean;
     markerMenuTrigger?: string;
     nodes?: UsjNodeOptions;

--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -141,7 +141,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
 
   const {
     isReadonly = false,
-    isProtected = false,
+    isStructureProtected = false,
     hasExternalUI = false,
     hasSpellCheck = false,
     textDirection = "ltr",
@@ -392,7 +392,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
   return (
     <LexicalComposer initialConfig={initialConfig}>
       <EditablePlugin isEditable={!isReadonly} />
-      <StructureProtectionPlugin isProtected={isProtected} />
+      <StructureProtectionPlugin isStructureProtected={isStructureProtected} />
       <div className="editor-container">
         {hasExternalUI ? (
           <StateChangePlugin onStateChange={handleStateChange} />

--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -84,6 +84,7 @@ import {
   pasteSelectionAsPlainText,
   StateChangePlugin,
   StateChangeSnapshot,
+  StructureProtectionPlugin,
   TextDirectionPlugin,
   TextSpacingPlugin,
   UsjNodeOptions,
@@ -139,6 +140,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
 
   const {
     isReadonly = false,
+    isProtected = false,
     hasExternalUI = false,
     hasSpellCheck = false,
     textDirection = "ltr",
@@ -389,6 +391,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
   return (
     <LexicalComposer initialConfig={initialConfig}>
       <EditablePlugin isEditable={!isReadonly} />
+      <StructureProtectionPlugin isProtected={isProtected} />
       <div className="editor-container">
         {hasExternalUI ? (
           <StateChangePlugin onStateChange={handleStateChange} />

--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -392,7 +392,6 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
   return (
     <LexicalComposer initialConfig={initialConfig}>
       <EditablePlugin isEditable={!isReadonly} />
-      <StructureProtectionPlugin isStructureProtected={isStructureProtected} />
       <div className="editor-container">
         {hasExternalUI ? (
           <StateChangePlugin onStateChange={handleStateChange} />
@@ -464,6 +463,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
           />
           <ParaMarkerPrefixGuardPlugin viewOptions={viewOptions} logger={logger} />
           <ParaNodePlugin />
+          <StructureProtectionPlugin isStructureProtected={isStructureProtected} />
           <TextDirectionPlugin textDirection={textDirection} />
           <TextSpacingPlugin />
           {children}

--- a/packages/platform/src/editor/editor.model.ts
+++ b/packages/platform/src/editor/editor.model.ts
@@ -189,6 +189,8 @@ export interface EditorProps<TLogger extends LoggerBasic> {
 export interface EditorOptions {
   /** Is the editor readonly or editable. */
   isReadonly?: boolean;
+  /** When true, paragraph and verse markers cannot be changed via keyboard input. */
+  isProtected?: boolean;
   /** Does the editor have external UI controls so disable the built-in toolbar and marker menu. */
   hasExternalUI?: boolean;
   /** Is the editor enabled for spell checking. */

--- a/packages/platform/src/editor/editor.model.ts
+++ b/packages/platform/src/editor/editor.model.ts
@@ -190,7 +190,7 @@ export interface EditorOptions {
   /** Is the editor readonly or editable. */
   isReadonly?: boolean;
   /** When true, paragraph and verse markers cannot be changed via keyboard input. */
-  isProtected?: boolean;
+  isStructureProtected?: boolean;
   /** Does the editor have external UI controls so disable the built-in toolbar and marker menu. */
   hasExternalUI?: boolean;
   /** Is the editor enabled for spell checking. */


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-4013-structure-protection-keyboard-input

**Base**: origin/main

**Date**: 2026-06-23

**Review model**: Claude Opus 4.8

**Files changed**: 9

## Overview

This branch implements PT-4013 — enforcing paragraph/verse structure protection in the editor's
keyboard input. When structure protection is toggled on (the toggle itself lives in paranext-core),
keyboard-driven changes to paragraph and verse markers must be blocked. The scripture-editors side
ships here: a headless `StructureProtectionPlugin` (registered on `KEY_DOWN_COMMAND` and the
cut/paste/drop/IME commands at `COMMAND_PRIORITY_HIGH`, mirroring `ArrowNavigationPlugin`) and a
`structureProtection.utils` module of pure, `$`-prefixed selection predicates that decide when an
edit would alter block structure. A new optional `isProtected?: boolean` `EditorOptions` flag (default
`false`) threads the state into the editor via `Editor.tsx`.

The analysis found no critical or important issues. The implementation closely follows the
established plugin pattern, reuses existing shared helpers rather than reimplementing tree traversal,
and is backed by thorough unit + baseline + behavior tests with honest documentation of what jsdom
can and cannot drive. The three minor findings were all resolved during the review.

Post-review follow-up: `StructureProtectionPlugin.test.tsx` was refactored to use a local
`testEnvironment(isProtected, $initialEditorState)` wrapper, matching the convention in the sibling
plugin tests (`ParaNodePlugin`, `CharNodePlugin`, `TextSpacingPlugin`, `ArrowNavigationPlugin`)
rather than repeating the plugin element inline in every test. Lint, typecheck, and all tests pass.

## API Changes

- `libs/shared-react` (public API via `src/index.ts` → `plugins` → `plugins/usj`): Added
  `StructureProtectionPlugin` export — a React plugin component
  `({ isProtected }: { isProtected: boolean }) => null`.
- `libs/shared-react`: Added new internal module `structureProtection.utils.ts` exporting
  `EditIntent` (type), `keyDownToIntent`, `$selectionSpansBlockBoundary`,
  `$selectionContainsVerseMarker`, `$caretAtParaStart`, `$caretAtParaEnd`,
  `$caretAdjacentToVerseMarker`, `$shouldBlockSelectionReplacement`, `$shouldBlockStructuralEdit`.
  These are intentionally NOT re-exported from the package barrel (`plugins/usj/index.ts` exports
  only `StructureProtectionPlugin`), so they are internal to the package.
  - During review, `$shouldBlockSelectionReplacement` and `$shouldBlockStructuralEdit` were changed
    to accept an explicit `selection: BaseSelection` parameter (previously they called
    `$getSelection()` internally), aligning them with the sibling predicates and the codebase's
    selection-passing convention.
- `packages/platform` (`platform-editor` public API): Added optional property `isProtected?: boolean`
  to the exported `EditorOptions` interface (reflected in `etc/platform-editor.api.md`). Backward-
  compatible; defaults to `false`.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

None.

### Minor — Consider

- [ ] ~~`structureProtection.utils.ts` helpers are not exported from the package barrel (`index.ts`
  exports only `StructureProtectionPlugin`), unlike the sibling `clipboard.utils`.~~ _(Confirmed
  correct as-is: the helpers are imported only by `StructureProtectionPlugin.tsx`, its own sibling,
  while `clipboard.utils` is exported because two plugins consume it. Not exporting single-consumer
  internals matches the repo's "export only what's used" pattern.)_
- [x] **Inconsistent selection-passing convention: `$shouldBlockSelectionReplacement()` and
  `$shouldBlockStructuralEdit(intent)` called `$getSelection()` internally while every sibling
  predicate took an explicit `selection: BaseSelection` parameter.** _(fixed during review: both
  deciders now take a `selection` parameter; `StructureProtectionPlugin` calls `$getSelection()` once
  per handler and passes it down — matching the codebase pattern `$getCursorSelectionContext(selection,
  ...)`, `$getParaFromSelection(selection)`, `getSelectionStartNode(selection)`. The unused
  `$getSelection` import was removed from the utils, the plugin handlers now null-guard the selection,
  and the 7 test call sites were updated. All 18 tests pass.)_
- [x] **`$selectionSpansBlockBoundary` had a two-phase structure (primary `paraKeys` set + anchor/focus
  endpoint fallback) flagged as possibly over-complex.** _(fixed during review: investigated
  empirically with six selection shapes — text-to-text across paragraphs, element-level boundary
  points, text-into-empty-paragraph, and two genuinely empty paragraphs. In every case
  `selection.getNodes()` includes both `para` nodes, so the primary `paraKeys.size > 1` path always
  fires first; disabling the fallback failed no test. Since `getNodes()` operates on the editor-state
  tree (not the DOM), this is identical in a real browser. The fallback was unreachable dead code and
  was removed, leaving the single primary check. No test added — there is no reachable behavior to
  cover, and a "fallback" test would have passed via the primary path, which would be misleading.)_

[Author response: Finding 1 confirmed a non-issue after pattern check. Findings 2 and 3 were fixed
in-review at the author's request — Finding 2 made the selection-passing convention consistent with
the codebase; Finding 3 removed dead code after empirical confirmation it was unreachable.]

### Template Propagation

#### Shared Regions Modified

None. (scripture-editors repo; no `#region shared with` markers in any changed file.)

#### Extension Config Changes

None. (No `extensions/` directory in this repo; the only non-source change is `.gitignore`.)

## Positive Observations

- `StructureProtectionPlugin` follows the established plugin shape (headless component returning
  `null`, `useLexicalComposerContext`, `mergeRegister` of commands at `COMMAND_PRIORITY_HIGH`),
  explicitly mirroring `ArrowNavigationPlugin` as noted in its JSDoc.
- The utils reuse existing shared helpers (`$isSomeParaNode`, `$isSomeVerseNode`, `$findMatchingParent`)
  rather than reimplementing tree traversal. No duplicate boundary/paragraph utilities exist elsewhere.
- `EditorOptions.isProtected` is a clean, backward-compatible optional addition (default `false`),
  plumbed in exactly parallel to the existing `isReadonly` option, with the API report regenerated.
- Test coverage is strong and deliberate: every predicate, the `keyDownToIntent` modifier mapping
  (including the non-obvious Alt/Cmd+Backspace case), and the `$shouldBlockStructuralEdit` decision
  matrix have positive and negative cases. "ALLOWS" regression tests guard against over-blocking
  normal editing.
- The author documented exactly which paths jsdom cannot drive and why those cases live in unit tests
  instead of behavior tests, and added a baseline test capturing pre-existing unprotected behavior.
- `$`-prefix naming convention (functions that must run inside a Lexical read/update context) is
  applied consistently.

## Interview Notes

- **Stated purpose**: Satisfy PT-4013 — protect paragraph structure when structure protection is
  toggled (the toggle lives in paranext-core). This branch is the scripture-editors keyboard
  enforcement layer. Full implementation plan: `Downloads/Admin Lock Paragraph/admin-lock-paragraph-structure-implementation-plan.md`.
- No critical or important findings, so the design-understanding deep-dive (Step 3.3) was not required.
- The author engaged substantively on all three minor findings, asking for the codebase pattern in
  each case rather than accepting findings at face value — Finding 1 (export pattern), Finding 2
  (selection-passing convention), Finding 3 (what "low confidence" meant and whether a test pattern
  existed). This drove the investigation that resolved all three correctly.
- No outstanding uncertainties were expressed; nothing was deferred to AI.
- Author constraint for this review: no git commits at any point. All changes are staged but
  uncommitted.

## In-Review Quality Check

Changes were made during the review (Findings 2 and 3). All four quality checks passed cleanly with
no fixes required:

- `pnpm nx typecheck shared-react` — passed (shared-react + 3 dependency tasks, no type errors).
- `pnpm nx lint shared-react` — passed (0 errors; the 3 reported warnings are pre-existing and in
  unrelated files — `NodesMenu/Menu/filterAndRankItems.ts`, `annotation/selection.utils.data-driven.test.ts`).
- `prettier --write` on the three changed files — all already correctly formatted (no rewrites).
- `pnpm nx test shared-react` — passed; `structureProtection.utils.test.ts` runs 18 tests, all passing.

(An Nx daemon hashing quirk — `Input '{projectRoot}/tsconfig.lib.json' is not defined` — fired after
tests passed and did not affect outcomes; a re-run with the daemon disabled confirmed clean success.)

## Suggested Review Focus

Prioritized areas for the author-reviewer meeting:

- [ ] Verse-marker adjacency protection (`$caretAdjacentToVerseMarker`, `$shouldBlockStructuralEdit`):
  confirm the element-vs-text point handling covers the real cursor positions around
  `ImmutableVerseNode` in the running editor (unit-tested, but worth a manual sanity check given the
  jsdom limitations the author documented).
- [ ] Non-keyboard input vectors (cut/paste/drop/IME via `CONTROLLED_TEXT_INSERTION_COMMAND`):
  `$blockUnsafeSelection` applies only Rule 1 (selection spans a boundary or contains a verse marker);
  inspecting pasted/dropped *content* for embedded markers is deferred per spec §2.5 — confirm that
  deferral is acceptable for this ticket's scope.
- [ ] Integration with the paranext-core side (PT-4012 `useStructureProtectionState` hook and the
  toggle): this branch only consumes an `isProtected` boolean — verify the wiring in paranext-core
  passes it through correctly when those tickets land.
<!-- review-paratext:summary:end -->

AI-assisted review — Claude Opus 4.8

---



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/489)
<!-- Reviewable:end -->
