### PR TITLE
PT-3835: Make USJ selection locations annotation-transparent

### DIFF
--- a/demos/platform/src/app/app.tsx
+++ b/demos/platform/src/app/app.tsx
@@ -27,6 +27,7 @@ import {
   MarginalRef,
   MarkerMode,
   NoteMode,
+  SelectionRange,
   TextDirection,
   UsjNodeOptions,
   ViewOptions,
@@ -116,6 +117,7 @@ export default function App() {
   const marginalRef = useRef<MarginalRef | null>(null);
   const noteEditorRef = useRef<EditorRef | null>(null);
   const noteNodeKeyRef = useRef<string | undefined>();
+  const selectionRef = useRef<SelectionRange | undefined>(undefined);
   const [isNoteEditorVisible, setIsNoteEditorVisible] = useState(false);
   const [isOptionsDefined, setIsOptionsDefined] = useState(false);
   const [isReadonly, setIsReadonly] = useState(false);
@@ -409,6 +411,34 @@ export default function App() {
               >
                 stand
               </button>
+              <button
+                id="insertAtSelection"
+                onClick={() => {
+                  const selection = selectionRef.current;
+                  if (
+                    selection?.start &&
+                    selection?.end &&
+                    marginalRef.current &&
+                    isUsjTextContentLocation(selection.start) &&
+                    isUsjTextContentLocation(selection.end)
+                  ) {
+                    // Demo-only id: could collide on same-millisecond clicks, which is fine here.
+                    const id = `sel-${Date.now()}`;
+                    marginalRef.current.setAnnotation(
+                      { start: selection.start, end: selection.end },
+                      annotationType,
+                      id,
+                      handleAnnotationOnClick,
+                      handleAnnotationOnRemove,
+                    );
+                    console.log("Inserted annotation at selection", { selection, id });
+                  } else {
+                    console.warn("No valid selection for annotation");
+                  }
+                }}
+              >
+                Insert at selection
+              </button>
             </div>
           </span>
           <pre title="contextMarker" style={{ color: "black" }}>
@@ -525,7 +555,10 @@ export default function App() {
           defaultUsj={EMPTY_USJ}
           scrRef={scrRef}
           onScrRefChange={setScrRef}
-          onSelectionChange={(selection) => console.log({ selection })}
+          onSelectionChange={(selection) => {
+            selectionRef.current = selection;
+            console.log({ selection });
+          }}
           onCommentChange={(comments) => console.log({ comments })}
           onUsjChange={handleUsjChange}
           onStateChange={({

--- a/libs/shared-react/src/plugins/usj/annotation/AnnotationPlugin.test.tsx
+++ b/libs/shared-react/src/plugins/usj/annotation/AnnotationPlugin.test.tsx
@@ -1,8 +1,21 @@
+// Reaching inside only for tests.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { updateSelection } from "../../../../../../libs/shared/src/nodes/usj/test.utils";
 import { baseTestEnvironment } from "../react-test.utils";
 import { AnnotationPlugin, AnnotationRef } from "./AnnotationPlugin";
 import { AnnotationRange } from "./selection.model";
+import { $getUsjSelectionFromEditor } from "./selection.utils";
+import { isUsjTextContentLocation } from "@eten-tech-foundation/scripture-utilities";
 import { act } from "@testing-library/react";
-import { $createTextNode, $getRoot, $isElementNode, $isTextNode, LexicalNode } from "lexical";
+import {
+  $createTextNode,
+  $getRoot,
+  $isElementNode,
+  $isTextNode,
+  LexicalEditor,
+  LexicalNode,
+  TextNode,
+} from "lexical";
 import { createRef } from "react";
 import {
   $createParaNode,
@@ -207,6 +220,88 @@ describe("AnnotationPlugin", () => {
       });
     });
   });
+});
+
+describe("PT-3835: inserting annotations from reported selections", () => {
+  const text = "the neva word and the sleep word";
+  // indexOf: "neva" = 4, "sleep" = 22
+
+  it("annotates front-to-back (the PT-3835 failure direction)", async () => {
+    const { annotationPlugin, editor } = await testEnvironment(() => {
+      $getRoot().append($createParaNode().append($createTextNode(text)));
+    });
+
+    await annotateWordViaReportedSelection(annotationPlugin, editor, "neva", "c-1");
+    await annotateWordViaReportedSelection(annotationPlugin, editor, "sleep", "c-2");
+
+    editor.getEditorState().read(() => $expectAnnotatedWords(["neva", "sleep"]));
+  });
+
+  it("annotates back-to-front (regression guard)", async () => {
+    const { annotationPlugin, editor } = await testEnvironment(() => {
+      $getRoot().append($createParaNode().append($createTextNode(text)));
+    });
+
+    await annotateWordViaReportedSelection(annotationPlugin, editor, "sleep", "c-2");
+    await annotateWordViaReportedSelection(annotationPlugin, editor, "neva", "c-1");
+
+    editor.getEditorState().read(() => $expectAnnotatedWords(["neva", "sleep"]));
+  });
+
+  /**
+   * Select a word in the editor, verify the reported USJ selection is in coalesced-USJ
+   * coordinates (annotation-independent), then insert an annotation with exactly that
+   * reported selection — the paranext-core "Insert Comment" flow.
+   */
+  async function annotateWordViaReportedSelection(
+    annotationPlugin: AnnotationRef,
+    editor: LexicalEditor,
+    word: string,
+    id: string,
+  ) {
+    let target: TextNode | undefined;
+    let localOffset = 0;
+    editor.getEditorState().read(() => {
+      const para = $getRoot().getFirstChild();
+      if (!$isElementNode(para)) throw new Error("Expected a para node");
+      target = para.getAllTextNodes().find((node) => node.getTextContent().includes(word));
+      if (!target) throw new Error(`No text node contains '${word}'`);
+      localOffset = target.getTextContent().indexOf(word);
+    });
+    if (!target) throw new Error(`No text node contains '${word}'`);
+    updateSelection(editor, target, localOffset, target, localOffset + word.length);
+
+    const reported = editor.getEditorState().read($getUsjSelectionFromEditor);
+    const start = reported?.start;
+    const end = reported?.end;
+    if (!start || !end || !isUsjTextContentLocation(start) || !isUsjTextContentLocation(end)) {
+      throw new Error(`Expected a reported text selection for '${word}'`);
+    }
+    // The reported location must be in actual-USJ coordinates regardless of annotations.
+    expect(start).toEqual({
+      jsonPath: "$.content[0].content[0]",
+      offset: text.indexOf(word),
+    });
+    expect(end).toEqual({
+      jsonPath: "$.content[0].content[0]",
+      offset: text.indexOf(word) + word.length,
+    });
+
+    await act(async () => {
+      annotationPlugin.setAnnotation({ start, end }, "review", id);
+    });
+  }
+
+  function $expectAnnotatedWords(words: string[]) {
+    const para = $getRoot().getFirstChild();
+    if (!$isElementNode(para)) throw new Error("Expected a para node");
+    const markTexts = para
+      .getChildren()
+      .filter($isTypedMarkNode)
+      .map((node) => node.getTextContent());
+    expect(markTexts).toEqual(words);
+    expect(para.getTextContent()).toBe(text);
+  }
 });
 
 /**

--- a/libs/shared-react/src/plugins/usj/annotation/selection.utils.annotated.data-driven.test.ts
+++ b/libs/shared-react/src/plugins/usj/annotation/selection.utils.annotated.data-driven.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Annotation-invariance tests for USJ ↔ Lexical selection conversion (PT-3835).
+ *
+ * Loads the usj2Sa serialized states (all 3 marker modes), wraps several USJ ranges in
+ * TypedMarkNodes (in both application orders), then asserts every textContent location still
+ * resolves and round-trips to exactly the same UsjDocumentLocation as in the unannotated
+ * document. Locations are defined against the actual USJ, which never contains annotations,
+ * so annotations must not shift them.
+ *
+ * @see selection.utils.data-driven.test.ts for the unannotated baseline suite.
+ */
+// Reaching inside only for tests.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import {
+  createBasicTestEnvironment,
+  updateSelection,
+} from "../../../../../../libs/shared/src/nodes/usj/test.utils";
+import { usjReactNodes } from "../../../nodes/usj";
+import type { SelectionRange } from "./selection.model";
+import { $getRangeFromUsjSelection, $getUsjSelectionFromEditor } from "./selection.utils";
+import { isUsjTextContentLocation } from "@eten-tech-foundation/scripture-utilities";
+import type { LexicalEditor, LexicalNode, SerializedEditorState } from "lexical";
+import { $wrapSelectionInTypedMarkNode, TypedMarkNode } from "shared";
+import type { LocationEntry2Sa } from "test-data";
+import {
+  usjLocations2Sa,
+  lexicalEditable2Sa,
+  lexicalVisible2Sa,
+  lexicalHidden2Sa,
+} from "test-data";
+
+const MARKER_MODES = [
+  { name: "editable", state: lexicalEditable2Sa },
+  { name: "visible", state: lexicalVisible2Sa },
+  { name: "hidden", state: lexicalHidden2Sa },
+] as const;
+
+const APPLICATION_ORDERS = ["front-to-back", "back-to-front"] as const;
+
+/**
+ * Matches plain text-run paths such as "$.content[20].content[0]" (paragraph-level) or
+ * "$.content[18].content[1].content[0]" (nested inside a char/note node), i.e. any dotted
+ * chain of numeric `content[N]` segments. Excludes property paths like "['marker']".
+ *
+ * Widened from a paragraph-level-only match: the usj2Sa corpus has only 3 distinct
+ * paragraph-level textContent paths, and only 2 of them have an entry at offset >= 4
+ * (the third, `$.content[16].content[2]`, is only sampled at offset 0). Including
+ * char/note-nested text runs is needed to reach 3 qualifying paths.
+ */
+const TEXT_RUN_PATH = /^\$\.content\[\d+\](\.content\[\d+\])+$/;
+
+const textEntries = usjLocations2Sa.filter(
+  (entry) =>
+    entry.locationType === "textContent" && isUsjTextContentLocation(entry.documentLocation),
+);
+
+describe("data-driven: usj2Sa textContent locations are annotation-invariant", () => {
+  describe.each(MARKER_MODES)("'$name' mode", ({ state: serializedState }) => {
+    describe.each(APPLICATION_ORDERS)("annotations applied %s", (order) => {
+      let editor: LexicalEditor;
+
+      beforeAll(() => {
+        editor = createAnnotatedEditor(serializedState, order);
+      });
+
+      for (const entry of textEntries) {
+        it(`round-trips ${entry.description} unchanged`, () => {
+          roundTrip(editor, entry);
+        });
+      }
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers (after the tests; function declarations hoist. The consts above the
+// describe stay there — they are read at collection time.)
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap ranges derived from the corpus itself: the first 3 distinct text-run paths (see
+ * `TEXT_RUN_PATH`) that have an entry at offset >= 4 each get an annotation over [1, 4).
+ * Corpus locations at offsets 1-4 of those paths then sit at annotation edges or inside
+ * annotations; later locations in the same runs exercise the "after an annotation" index shifts.
+ */
+function getAnnotationRanges(): SelectionRange[] {
+  const jsonPaths: string[] = [];
+  for (const entry of textEntries) {
+    const location = entry.documentLocation;
+    if (!isUsjTextContentLocation(location)) continue;
+    if (
+      location.offset >= 4 &&
+      TEXT_RUN_PATH.test(location.jsonPath) &&
+      !jsonPaths.includes(location.jsonPath)
+    ) {
+      jsonPaths.push(location.jsonPath);
+    }
+    if (jsonPaths.length === 3) break;
+  }
+  if (jsonPaths.length < 3) throw new Error("Expected 3 text-run paths in corpus");
+  return jsonPaths.map((jsonPath) => ({
+    start: { jsonPath, offset: 1 },
+    end: { jsonPath, offset: 4 },
+  })) as SelectionRange[];
+}
+
+function createAnnotatedEditor(
+  serializedState: SerializedEditorState,
+  order: (typeof APPLICATION_ORDERS)[number],
+): LexicalEditor {
+  const nodes = [TypedMarkNode, ...usjReactNodes];
+  const { editor } = createBasicTestEnvironment(nodes);
+  editor.setEditorState(editor.parseEditorState(serializedState));
+
+  const ranges = getAnnotationRanges();
+  const orderedRanges = order === "front-to-back" ? ranges : [...ranges].reverse();
+  orderedRanges.forEach((range, i) => {
+    editor.update(
+      () => {
+        const selection = $getRangeFromUsjSelection(range);
+        if (!selection)
+          throw new Error(`Failed to resolve annotation range at ${range.start.jsonPath}`);
+        $wrapSelectionInTypedMarkNode(selection, "test-annotation", `${order}-${i}`);
+      },
+      { discrete: true },
+    );
+  });
+  return editor;
+}
+
+/** Resolve USJ→Lexical, set the selection, read it back as USJ (same as the baseline suite). */
+function roundTrip(editor: LexicalEditor, entry: LocationEntry2Sa) {
+  let anchorNode: LexicalNode | undefined;
+  let anchorOffset: number | undefined;
+
+  editor.getEditorState().read(() => {
+    const editorSelection = $getRangeFromUsjSelection({ start: entry.documentLocation });
+    if (!editorSelection)
+      throw new Error(`Expected editorSelection to be defined for ${entry.description}`);
+    anchorNode = editorSelection.anchor.getNode();
+    anchorOffset = editorSelection.anchor.offset;
+  });
+  if (anchorNode === undefined || anchorOffset === undefined)
+    throw new Error(`Expected resolved selection values for ${entry.description}`);
+
+  updateSelection(editor, anchorNode, anchorOffset);
+
+  editor.getEditorState().read(() => {
+    const roundTripped = $getUsjSelectionFromEditor();
+    if (!roundTripped)
+      throw new Error(`Expected round-tripped selection to be defined for ${entry.description}`);
+    expect(roundTripped.start).toEqual(entry.documentLocation);
+  });
+}

--- a/libs/shared-react/src/plugins/usj/annotation/selection.utils.test.ts
+++ b/libs/shared-react/src/plugins/usj/annotation/selection.utils.test.ts
@@ -162,8 +162,10 @@ describe("$getRangeFromUsjSelection", () => {
       });
 
       editor.getEditorState().read(() => {
+        // Coalesced-USJ coordinates: the TypedMarkNode is invisible in exported USJ, so the
+        // marked text is the para's first (and only) content string — not a nested content item.
         const usjSelection: SelectionRange = {
-          start: { jsonPath: "$.content[0].content[0].content[0]", offset: 7 },
+          start: { jsonPath: "$.content[0].content[0]", offset: 7 },
         };
         const editorSelection = $getRangeFromUsjSelection(usjSelection);
 
@@ -803,6 +805,109 @@ describe("$getRangeFromUsjSelection", () => {
   });
 });
 
+describe("$getRangeFromUsjSelection with annotations (PT-3835)", () => {
+  it("resolves coalesced offsets across the annotation into the right text nodes", () => {
+    const { editor, t1, t3 } = buildAnnotatedEnvironment(); // "the " |man| " who stands"
+
+    editor.getEditorState().read(() => {
+      const usjSelection: SelectionRange = {
+        start: { jsonPath: "$.content[0].content[0]", offset: 2 }, // in "the "
+        end: { jsonPath: "$.content[0].content[0]", offset: 9 }, // in " who stands"
+      };
+      const editorSelection = $getRangeFromUsjSelection(usjSelection);
+
+      if (!editorSelection) throw new Error("Expected editorSelection to be defined");
+      expect(editorSelection.anchor.key).toBe(t1.getKey());
+      expect(editorSelection.anchor.offset).toBe(2);
+      expect(editorSelection.focus.key).toBe(t3.getKey());
+      expect(editorSelection.focus.offset).toBe(2); // 9 - 4 - 3
+    });
+  });
+
+  it("resolves an offset inside the annotation", () => {
+    const { editor, t2 } = buildAnnotatedEnvironment();
+
+    editor.getEditorState().read(() => {
+      const editorSelection = $getRangeFromUsjSelection({
+        start: { jsonPath: "$.content[0].content[0]", offset: 5 },
+      });
+
+      if (!editorSelection) throw new Error("Expected editorSelection to be defined");
+      expect(editorSelection.anchor.key).toBe(t2.getKey());
+      expect(editorSelection.anchor.offset).toBe(1);
+    });
+  });
+
+  it("resolves elements positioned after an annotated run", () => {
+    // USJ content: [0]="aaa bb cc ", [1]=char("LORD"), [2]="dd"
+    let charText: TextNode;
+    let tailText: TextNode;
+    const { editor } = createBasicTestEnvironment([TypedMarkNode, ParaNode, CharNode], () => {
+      charText = $createTextNode("LORD");
+      tailText = $createTextNode("dd");
+      $getRoot().append(
+        $createParaNode().append(
+          $createTextNode("aaa "),
+          $createTypedMarkNode({ t: ["1"] }).append($createTextNode("bb")),
+          $createTextNode(" cc "),
+          $createCharNode("nd").append(charText),
+          tailText,
+        ),
+      );
+    });
+
+    editor.getEditorState().read(() => {
+      // The char's inner text: index 1 must NOT be shifted by the annotation.
+      const charSelection = $getRangeFromUsjSelection({
+        start: { jsonPath: "$.content[0].content[1].content[0]", offset: 2 },
+      });
+      if (!charSelection) throw new Error("Expected charSelection to be defined");
+      // Non-null assertion is safe: charText is assigned during the test setup callback.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      expect(charSelection.anchor.key).toBe(charText!.getKey());
+      expect(charSelection.anchor.offset).toBe(2);
+
+      // Trailing text at logical index 2.
+      const tailSelection = $getRangeFromUsjSelection({
+        start: { jsonPath: "$.content[0].content[2]", offset: 1 },
+      });
+      if (!tailSelection) throw new Error("Expected tailSelection to be defined");
+      // Non-null assertion is safe: tailText is assigned during the test setup callback.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      expect(tailSelection.anchor.key).toBe(tailText!.getKey());
+      expect(tailSelection.anchor.offset).toBe(1);
+    });
+  });
+
+  it("resolves offsets across adjacent overlapping-annotation marks", () => {
+    // Overlapping annotations resolve to FLAT adjacent sibling marks with merged typed IDs
+    // (AnnotationPlugin's nested-element resolver squashes any transient nesting).
+    let overlapText: TextNode;
+    const { editor } = createBasicTestEnvironment([TypedMarkNode, ParaNode], () => {
+      overlapText = $createTextNode("cd");
+      $getRoot().append(
+        $createParaNode().append(
+          $createTextNode("ab"),
+          $createTypedMarkNode({ outer: ["o1"] }).append($createTextNode("")),
+          $createTypedMarkNode({ outer: ["o1"], inner: ["i1"] }).append(overlapText),
+          $createTypedMarkNode({ outer: ["o1"] }).append($createTextNode("ef")),
+        ),
+      );
+    });
+
+    editor.getEditorState().read(() => {
+      const editorSelection = $getRangeFromUsjSelection({
+        start: { jsonPath: "$.content[0].content[0]", offset: 3 }, // "abcdef" → in "cd"
+      });
+      if (!editorSelection) throw new Error("Expected editorSelection to be defined");
+      // Non-null assertion is safe: overlapText is assigned during the test setup callback.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      expect(editorSelection.anchor.key).toBe(overlapText!.getKey());
+      expect(editorSelection.anchor.offset).toBe(1);
+    });
+  });
+});
+
 describe("$getUsjSelectionFromEditor", () => {
   describe("UsjTextContentLocation", () => {
     it("should return undefined when there is no selection", () => {
@@ -1030,14 +1135,75 @@ describe("$getUsjSelectionFromEditor", () => {
         const usjSelection = $getUsjSelectionFromEditor();
 
         if (!usjSelection) throw new Error("Expected usjSelection to be defined");
+        // Coalesced-USJ coordinates: the TypedMarkNode is invisible in exported USJ, so the
+        // marked text is the para's first (and only) content string.
         expect(usjSelection.start).toEqual({
-          jsonPath: "$.content[0].content[0].content[0]",
+          jsonPath: "$.content[0].content[0]",
           offset: 3,
         });
         expect(usjSelection.end).toEqual({
-          jsonPath: "$.content[0].content[0].content[0]",
+          jsonPath: "$.content[0].content[0]",
           offset: 9,
         });
+      });
+    });
+
+    it("should anchor an element point on a mark's non-text child at the mark's logical position", () => {
+      // The mark wraps a CharNode (e.g. from wrapping a partial CharNode selection in an
+      // annotation) rather than plain text, so the offset-0 element point on the mark must not
+      // be resolved as if the mark itself were the logical parent (which would drop the mark's
+      // own content index and produce offset 0 instead of 1).
+      let markNode: TypedMarkNode;
+      const { editor } = createBasicTestEnvironment([ParaNode, TypedMarkNode, CharNode], () => {
+        markNode = $createTypedMarkNode({ testType: ["testId"] }).append(
+          $createCharNode("nd").append($createTextNode("LORD")),
+        );
+        $getRoot().append(
+          $createParaNode().append($createTextNode("ab"), markNode, $createTextNode("cd")),
+        );
+      });
+      // Non-null assertion is safe: markNode is assigned during the test setup callback.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      updateSelection(editor, markNode!, 0);
+
+      editor.getEditorState().read(() => {
+        const usjSelection = $getUsjSelectionFromEditor();
+
+        if (!usjSelection) throw new Error("Expected usjSelection to be defined");
+        // USJ content: [0]="ab", [1]=char, [2]="cd" — the boundary before the mark's content is
+        // logical index 1 (after "ab", before the char).
+        expect(usjSelection.start).toEqual({
+          jsonPath: "$.content[0]",
+          offset: 1,
+        });
+        expect(usjSelection.end).toBeUndefined();
+      });
+    });
+
+    it("should anchor an element point after a mark's non-text child at the boundary past it", () => {
+      let markNode: TypedMarkNode;
+      const { editor } = createBasicTestEnvironment([ParaNode, TypedMarkNode, CharNode], () => {
+        markNode = $createTypedMarkNode({ testType: ["testId"] }).append(
+          $createCharNode("nd").append($createTextNode("LORD")),
+        );
+        $getRoot().append(
+          $createParaNode().append($createTextNode("ab"), markNode, $createTextNode("cd")),
+        );
+      });
+      // Non-null assertion is safe: markNode is assigned during the test setup callback.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      updateSelection(editor, markNode!, 1);
+
+      editor.getEditorState().read(() => {
+        const usjSelection = $getUsjSelectionFromEditor();
+
+        if (!usjSelection) throw new Error("Expected usjSelection to be defined");
+        // The boundary after the mark's content is logical index 2 (before "cd").
+        expect(usjSelection.start).toEqual({
+          jsonPath: "$.content[0]",
+          offset: 2,
+        });
+        expect(usjSelection.end).toBeUndefined();
       });
     });
 
@@ -1343,6 +1509,75 @@ describe("$getUsjSelectionFromEditor", () => {
     });
   });
 });
+
+describe("$getUsjSelectionFromEditor with annotations (PT-3835)", () => {
+  // Para text: "the man who stands" — "man" is annotated (see buildAnnotatedEnvironment,
+  // placed after the tests). USJ has ONE string: content[0].content[0], so all offsets are
+  // absolute within that string.
+  it("reports coalesced USJ coordinates for text after the annotation", () => {
+    const { editor, t3 } = buildAnnotatedEnvironment();
+    updateSelection(editor, t3, 1, t3, 4); // "who" within " who stands"
+
+    editor.getEditorState().read(() => {
+      expect($getUsjSelectionFromEditor()).toEqual({
+        start: { jsonPath: "$.content[0].content[0]", offset: 8 },
+        end: { jsonPath: "$.content[0].content[0]", offset: 11 },
+      });
+    });
+  });
+
+  it("reports coalesced USJ coordinates for text inside the annotation", () => {
+    const { editor, t2 } = buildAnnotatedEnvironment();
+    updateSelection(editor, t2, 0, t2, 3); // "man"
+
+    editor.getEditorState().read(() => {
+      expect($getUsjSelectionFromEditor()).toEqual({
+        start: { jsonPath: "$.content[0].content[0]", offset: 4 },
+        end: { jsonPath: "$.content[0].content[0]", offset: 7 },
+      });
+    });
+  });
+
+  it("reports the same location as an unannotated document", () => {
+    // Unannotated equivalent: one text node "the man who stands".
+    let plain: TextNode;
+    const { editor: plainEditor } = createBasicTestEnvironment([TypedMarkNode, ParaNode], () => {
+      plain = $createTextNode("the man who stands");
+      $getRoot().append($createParaNode().append(plain));
+    });
+    // Non-null assertions are safe: plain is assigned during the test setup callback.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    updateSelection(plainEditor, plain!, 8, plain!, 11);
+    let expected: SelectionRange | undefined;
+    plainEditor.getEditorState().read(() => {
+      expected = $getUsjSelectionFromEditor();
+    });
+
+    const { editor, t3 } = buildAnnotatedEnvironment();
+    updateSelection(editor, t3, 1, t3, 4); // same "who" range
+    editor.getEditorState().read(() => {
+      expect($getUsjSelectionFromEditor()).toEqual(expected);
+    });
+  });
+});
+
+/** Build "the " |man| " who stands" where "man" is annotated. */
+function buildAnnotatedEnvironment() {
+  let t1: TextNode;
+  let t2: TextNode;
+  let t3: TextNode;
+  const { editor } = createBasicTestEnvironment([TypedMarkNode, ParaNode], () => {
+    t1 = $createTextNode("the ");
+    t2 = $createTextNode("man");
+    t3 = $createTextNode(" who stands");
+    $getRoot().append(
+      $createParaNode().append(t1, $createTypedMarkNode({ spelling: ["s1"] }).append(t2), t3),
+    );
+  });
+  // Non-null assertions are safe: the initial state callback ran synchronously.
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return { editor, t1: t1!, t2: t2!, t3: t3! };
+}
 
 describe("round-trip conversion", () => {
   it("should round-trip UsjTextContentLocation selection", () => {

--- a/libs/shared-react/src/plugins/usj/annotation/selection.utils.ts
+++ b/libs/shared-react/src/plugins/usj/annotation/selection.utils.ts
@@ -21,24 +21,29 @@ import {
   $createRangeSelection,
   $getRoot,
   $getSelection,
-  $getState,
   $isElementNode,
-  $isLineBreakNode,
   $isRangeSelection,
   $isTextNode,
   ElementNode,
   LexicalNode,
   RangeSelection,
-  TextNode,
 } from "lexical";
 import {
+  $getElementOffsetFromLogicalIndex,
+  $getLogicalContentItems,
+  $getLogicalIndexOfChild,
+  $getLogicalParent,
+  $getLogicalPointFromElementPoint,
+  $getLogicalTextLocation,
+  $getTextNodeAtLogicalOffset,
   $isMarkerNode,
   $isParaLikeNode,
   $isTypedMarkNode,
   $isVisibleMarkerNode,
+  $shouldIgnoreNodeForContentIndexes,
   ImmutableTypedTextNode,
+  type LogicalContentItem,
   MarkerNode,
-  textTypeState,
 } from "shared";
 
 /**
@@ -122,25 +127,27 @@ function $getNodeFromLocation(
   if (isUsjTextContentLocation(location)) {
     const jsonPathIndexes = indexesFromUsjJsonPath(location.jsonPath);
     let currentNode: LexicalNode | undefined = $getRoot();
-    for (const index of jsonPathIndexes) {
+    for (let i = 0; i < jsonPathIndexes.length; i++) {
       if (!currentNode || !$isElementNode(currentNode)) return [undefined, undefined];
 
-      currentNode = $getContentChildAtIndex(currentNode, index);
+      const item: LogicalContentItem | undefined =
+        $getLogicalContentItems(currentNode)[jsonPathIndexes[i]];
+      if (!item) return [undefined, undefined];
+
+      if (item.type === "text") {
+        // Text items are terminal — the path must end here.
+        if (i !== jsonPathIndexes.length - 1) return [undefined, undefined];
+        return $getTextNodeAtLogicalOffset(item, location.offset) ?? [undefined, undefined];
+      }
+      currentNode = item.node;
     }
 
-    // If we landed on a TypedMarkNode (annotation wrapper), unwrap it to get the actual content
-    if (currentNode && $isTypedMarkNode(currentNode)) {
-      currentNode = currentNode.getFirstChild() ?? undefined;
-    }
-
-    // If the jsonPath resolves to an ElementNode (e.g. "$.content[0]"), interpret offset as a
-    // content-based child boundary offset (what the editor can emit), and return an element point.
+    // The jsonPath resolved to an ElementNode (e.g. "$.content[0]"): interpret offset as a
+    // logical child boundary offset and return an element point.
     if (currentNode && $isElementNode(currentNode)) {
-      const elementOffset = $getElementOffsetFromContentOffset(currentNode, location.offset);
-      return [currentNode, elementOffset];
+      return [currentNode, $getElementOffsetFromLogicalIndex(currentNode, location.offset)];
     }
-
-    return $findTextNodeInMarks(currentNode, location.offset);
+    return [undefined, undefined];
   }
 
   // Handle UsjAttributeKeyLocation and UsjAttributeMarkerLocation BEFORE UsjMarkerLocation
@@ -260,21 +267,6 @@ function $getNodeFromLocation(
   );
 }
 
-/**
- * Converts a content-based offset (skipping ignored nodes) into an element-based child offset.
- * This returns the earliest element offset that corresponds to the given content offset.
- */
-function $getElementOffsetFromContentOffset(parent: ElementNode, contentOffset: number): number {
-  const children = parent.getChildren();
-  let currentContentOffset = 0;
-  for (let elementOffset = 0; elementOffset <= children.length; elementOffset++) {
-    if (currentContentOffset === contentOffset) return elementOffset;
-    if (elementOffset >= children.length) break;
-    if (!$shouldIgnoreNodeForContentIndexes(children[elementOffset])) currentContentOffset += 1;
-  }
-  return children.length;
-}
-
 function $normalizeVisibleMarkerPoint(node: LexicalNode, offset: number): [LexicalNode, number] {
   if (!$isVisibleMarkerNode(node)) return [node, offset];
 
@@ -294,42 +286,6 @@ function $normalizeVisibleMarkerPoint(node: LexicalNode, offset: number): [Lexic
 
 function $getPointType(node: LexicalNode | undefined): "text" | "element" {
   return $isElementNode(node) ? "element" : "text";
-}
-
-/**
- * Find the text node that contains the location offset. Check if the offset fits within the current
- * text node, if it doesn't check in the next nodes ignoring the TypedMarkNodes but looking inside
- * as if the text was contiguous.
- * @param node - Current text node.
- * @param offset - Annotation location offset.
- * @returns the text node and offset where the offset was found in.
- */
-function $findTextNodeInMarks(
-  node: LexicalNode | undefined,
-  offset: number,
-): [TextNode | undefined, number | undefined] {
-  if (!node || !$isTextNode(node)) return [undefined, undefined];
-
-  const text = node.getTextContent();
-  // If offset is within the text (not at the very end), return this node.
-  // If offset equals text.length exactly, continue to next sibling to find the start of next content.
-  if (offset >= 0 && offset < text.length) return [node, offset];
-
-  let nextNode = node.getNextSibling();
-  if (!nextNode) {
-    const parent = node.getParent();
-    if ($isTypedMarkNode(parent)) nextNode = parent.getNextSibling();
-  }
-  if (!nextNode || (!$isTypedMarkNode(nextNode) && !$isTextNode(nextNode))) {
-    // No more siblings - if offset equals text.length, return end of current node
-    if (offset === text.length) return [node, offset];
-    return [undefined, undefined];
-  }
-
-  const nextOffset = offset - text.length;
-  if (nextNode && $isTextNode(nextNode)) return $findTextNodeInMarks(nextNode, nextOffset);
-
-  return $findTextNodeInMarks(nextNode.getFirstChild() ?? undefined, nextOffset);
 }
 
 /**
@@ -378,24 +334,10 @@ function $navigateToNode(jsonPath: string): LexicalNode | undefined {
   for (const index of jsonPathIndexes) {
     if (!currentNode || !$isElementNode(currentNode)) return undefined;
 
-    currentNode = $getContentChildAtIndex(currentNode, index);
+    const item: LogicalContentItem | undefined = $getLogicalContentItems(currentNode)[index];
+    currentNode = item?.type === "element" ? item.node : undefined;
   }
   return currentNode;
-}
-
-function $getContentChildAtIndex(
-  parent: ElementNode,
-  contentIndex: number,
-): LexicalNode | undefined {
-  const children = parent.getChildren();
-  let currentIndex = 0;
-  for (const child of children) {
-    if ($shouldIgnoreNodeForContentIndexes(child)) continue;
-    if (currentIndex === contentIndex) return child;
-
-    currentIndex += 1;
-  }
-  return undefined;
 }
 
 /**
@@ -451,7 +393,36 @@ function $getLocationFromNode(node: LexicalNode, offset: number): UsjDocumentLoc
     } satisfies UsjPropertyValueLocation;
   }
 
-  // Element selection - offset is a child index, convert to content-based offset
+  if ($isTypedMarkNode(node)) {
+    // An element point on the annotation wrapper: convert to the equivalent point as if the
+    // mark did not exist.
+    const childrenSize = node.getChildrenSize();
+    const childAtOffset = node.getChildAtIndex(Math.min(offset, childrenSize - 1));
+    if ($isTextNode(childAtOffset)) {
+      const localOffset = offset >= childrenSize ? childAtOffset.getTextContentSize() : 0;
+      return $getLocationFromNode(childAtOffset, localOffset);
+    }
+
+    // Non-text child (e.g. a CharNode wrapped in the mark) or an empty mark (childAtOffset is
+    // null): anchor on the logical parent at the mark's own position instead of falling through
+    // to treat the mark itself as the logical parent, which would drop the mark's content index.
+    // The mark contributes no content of its own, so the boundary before/after it is the
+    // boundary before/after its own position in the logical parent.
+    // Known approximation: for a mark with several children of different kinds, an INTERIOR
+    // boundary (offset between two of the mark's children) does not place the point between
+    // those exact children — it snaps to the front (or back) edge of the whole mark, so the
+    // reported position can be off by the length of the mark's preceding text. That is a valid
+    // nearby point in the correct text run; placing it exactly would require the resolution
+    // side to express points inside a mark.
+    const logicalParent = $getLogicalParent(node);
+    if (logicalParent?.is(node.getParent())) {
+      const markIndex = node.getIndexWithinParent();
+      const elementOffset = offset >= childrenSize ? markIndex + 1 : markIndex;
+      return $getLocationFromNode(logicalParent, elementOffset);
+    }
+  }
+
+  // Element selection - offset is a child index, convert to a logical point.
   if ($isElementNode(node)) {
     const childAtOffset = node.getChildAtIndex(offset);
     if ($isVisibleMarkerNode(childAtOffset)) {
@@ -460,11 +431,35 @@ function $getLocationFromNode(node: LexicalNode, offset: number): UsjDocumentLoc
       } satisfies UsjMarkerLocation;
     }
 
-    const contentOffset = $getContentOffsetFromElementOffset(node, offset);
-    return { jsonPath: usjJsonPathFromIndexes($getJsonPathIndexes(node)), offset: contentOffset };
+    const logicalPoint = $getLogicalPointFromElementPoint(node, offset);
+    if (logicalPoint.type === "text") {
+      // The boundary falls inside a coalesced USJ text item (e.g. at an annotation edge).
+      return {
+        jsonPath: usjJsonPathFromIndexes([...$getJsonPathIndexes(node), logicalPoint.index]),
+        offset: logicalPoint.offset,
+      };
+    }
+    return {
+      jsonPath: usjJsonPathFromIndexes($getJsonPathIndexes(node)),
+      offset: logicalPoint.index,
+    };
   }
 
-  // Regular text node - UsjTextContentLocation
+  // Regular text node - UsjTextContentLocation in coalesced-USJ coordinates.
+  if ($isTextNode(node)) {
+    const logicalTextLocation = $getLogicalTextLocation(node, offset);
+    if (logicalTextLocation) {
+      return {
+        jsonPath: usjJsonPathFromIndexes([
+          ...$getJsonPathIndexes(logicalTextLocation.parent),
+          logicalTextLocation.index,
+        ]),
+        offset: logicalTextLocation.offset,
+      };
+    }
+  }
+
+  // Fallback for nodes outside the logical content model (e.g. presentation-only text).
   return { jsonPath: usjJsonPathFromIndexes($getJsonPathIndexes(node)), offset };
 }
 
@@ -476,7 +471,8 @@ function $getMarkerAnchorNode(markerNode: MarkerNode): LexicalNode | undefined {
   if (
     previousContentSibling &&
     !$isParaLikeNode(previousContentSibling) &&
-    !$isTextNode(previousContentSibling)
+    !$isTextNode(previousContentSibling) &&
+    !$isTypedMarkNode(previousContentSibling)
   ) {
     return previousContentSibling;
   }
@@ -494,66 +490,21 @@ function $getPreviousContentSibling(child: LexicalNode): LexicalNode | undefined
 }
 
 /**
- * Gets the jsonPath indexes from a node by traversing up to the root.
+ * Gets the jsonPath indexes from a node by traversing up to the root using logical
+ * (annotation-transparent) content indexes.
  * @param node - The node to get the path for.
  * @returns An array of indexes representing the path from root to node.
  */
 function $getJsonPathIndexes(node: LexicalNode): number[] {
   const jsonPathIndexes: number[] = [];
   let current: LexicalNode | null = node;
-  while (current?.getParent()) {
-    const parent: ElementNode | null = current.getParent();
-    if (parent) {
-      const index = $getContentIndexWithinParent(parent, current);
-      if (index >= 0) jsonPathIndexes.unshift(index);
-    }
+  while (current) {
+    const parent = $getLogicalParent(current);
+    if (!parent) break;
+
+    const index = $getLogicalIndexOfChild(parent, current);
+    if (index >= 0) jsonPathIndexes.unshift(index);
     current = parent;
   }
   return jsonPathIndexes;
-}
-
-function $getContentIndexWithinParent(parent: ElementNode, child: LexicalNode): number {
-  const children = parent.getChildren();
-  let index = 0;
-  for (const sibling of children) {
-    if ($shouldIgnoreNodeForContentIndexes(sibling)) {
-      if (sibling === child) return -1;
-
-      continue;
-    }
-    if (sibling === child) return index;
-
-    index += 1;
-  }
-  return -1;
-}
-
-/**
- * Converts an element-based child offset to a content-based offset.
- * Element offsets count all children, content offsets skip non-content nodes.
- * @param parent - The parent element node.
- * @param elementOffset - The element-based child offset.
- * @returns The content-based offset.
- */
-function $getContentOffsetFromElementOffset(parent: ElementNode, elementOffset: number): number {
-  const children = parent.getChildren();
-  let contentOffset = 0;
-  for (let i = 0; i < elementOffset && i < children.length; i++) {
-    if (!$shouldIgnoreNodeForContentIndexes(children[i])) {
-      contentOffset++;
-    }
-  }
-  return contentOffset;
-}
-
-function $shouldIgnoreNodeForContentIndexes(node: LexicalNode | null | undefined): boolean {
-  if (!node) return false;
-  if ($isLineBreakNode(node)) return true;
-  if ($isMarkerNode(node)) return true;
-  if ($isVisibleMarkerNode(node)) return true;
-  if ($isTextNode(node)) {
-    const textType = $getState(node, textTypeState);
-    if (textType === "marker-trailing-space" || textType === "attribute") return true;
-  }
-  return false;
 }

--- a/libs/shared/src/nodes/usj/node-utils.test.ts
+++ b/libs/shared/src/nodes/usj/node-utils.test.ts
@@ -1,19 +1,43 @@
+import { $createMarkerNode } from "../features/MarkerNode.js";
+import { $createTypedMarkNode, TypedMarkNode } from "../features/TypedMarkNode.js";
+import { $createCharNode } from "./CharNode.js";
 import { $createImmutableChapterNode } from "./ImmutableChapterNode.js";
+import { usjBaseNodes } from "./index.js";
 import {
+  $getElementOffsetFromLogicalIndex,
+  $getLogicalContentItems,
+  $getLogicalIndexOfChild,
+  $getLogicalParent,
+  $getLogicalPointFromElementPoint,
+  $getLogicalTextLocation,
+  $getTextNodeAtLogicalOffset,
   $isSomeChapterNode,
   getNextVerse,
   getUnknownAttributes,
   isSelectionStartNodeExpectedError,
   isValidNumberedMarker,
   isVerseInRange,
+  LogicalContentItem,
+  LogicalTextItem,
   parseNumberFromMarkerText,
   removeNodeAndAfter,
   removeNodesBeforeNode,
 } from "./node.utils.js";
+import { NBSP } from "./node-constants.js";
 import { $createParaNode } from "./ParaNode.js";
 import { createBasicTestEnvironment } from "./test.utils.js";
+import { $createVerseNode, VerseNode } from "./VerseNode.js";
 import { MarkerObject } from "@eten-tech-foundation/scripture-utilities";
-import { $getNodeByKey, $getRoot, NodeKey } from "lexical";
+import {
+  $getNodeByKey,
+  $getRoot,
+  NodeKey,
+  $createTextNode,
+  $isElementNode,
+  TextNode,
+} from "lexical";
+
+const nodes = [TypedMarkNode, ...usjBaseNodes];
 
 describe("Editor Node Utilities", () => {
   describe("isValidNumberedMarker()", () => {
@@ -364,4 +388,456 @@ describe("Editor Node Utilities", () => {
       expect(isSelectionStartNodeExpectedError(new Error("some other error"))).toBe(false);
     });
   });
+
+  describe("$getLogicalContentItems", () => {
+    it("returns one text item for a plain text paragraph", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        $getRoot().append($createParaNode().append($createTextNode("Hello world")));
+      });
+
+      editor.getEditorState().read(() => {
+        const items = $getFirstParaItems();
+
+        expect(items).toHaveLength(1);
+        $expectTextItem(items[0], [{ text: "Hello world", start: 0 }]);
+      });
+    });
+
+    it("coalesces text split by a TypedMarkNode into one item", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        $getRoot().append(
+          $createParaNode().append(
+            $createTextNode("the "),
+            $createTypedMarkNode({ spelling: ["s1"] }).append($createTextNode("man")),
+            $createTextNode(" who"),
+          ),
+        );
+      });
+
+      editor.getEditorState().read(() => {
+        const items = $getFirstParaItems();
+
+        expect(items).toHaveLength(1);
+        $expectTextItem(items[0], [
+          { text: "the ", start: 0 },
+          { text: "man", start: 4 },
+          { text: " who", start: 7 },
+        ]);
+      });
+    });
+
+    it("coalesces text across adjacent overlapping-annotation marks (flat structure)", () => {
+      // Overlapping annotations never nest: AnnotationPlugin's nested-element resolver flattens
+      // them into adjacent sibling marks with merged typed IDs. This mirrors that real structure
+      // for "man who" (grammar) overlapping "man" (spelling).
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        $getRoot().append(
+          $createParaNode().append(
+            $createTextNode("the "),
+            $createTypedMarkNode({ spelling: ["s1"], grammar: ["g1"] }).append(
+              $createTextNode("man"),
+            ),
+            $createTypedMarkNode({ grammar: ["g1"] }).append($createTextNode(" who")),
+            $createTextNode(" stands"),
+          ),
+        );
+      });
+
+      editor.getEditorState().read(() => {
+        const items = $getFirstParaItems();
+
+        expect(items).toHaveLength(1);
+        $expectTextItem(items[0], [
+          { text: "the ", start: 0 },
+          { text: "man", start: 4 },
+          { text: " who", start: 7 },
+          { text: " stands", start: 11 },
+        ]);
+      });
+    });
+
+    it("breaks a text run at a non-text element (CharNode)", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        $getRoot().append(
+          $createParaNode().append(
+            $createTextNode("aaa "),
+            $createCharNode("nd").append($createTextNode("LORD")),
+            $createTextNode(" bbb"),
+          ),
+        );
+      });
+
+      editor.getEditorState().read(() => {
+        const items = $getFirstParaItems();
+
+        expect(items).toHaveLength(3);
+        $expectTextItem(items[0], [{ text: "aaa ", start: 0 }]);
+        expect(items[1].type).toBe("element");
+        $expectTextItem(items[2], [{ text: " bbb", start: 0 }]);
+      });
+    });
+
+    it("emits editable VerseNodes as standalone items, breaking text runs", () => {
+      // VerseNode extends TextNode (editable-marker rendering, e.g. "\v 1 "), but the
+      // editor→USJ exporter always emits it as its own verse marker item — never coalesced
+      // into the surrounding string content.
+      let v1: VerseNode;
+      let v2: VerseNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        v1 = $createVerseNode("1", "\\v 1 ");
+        v2 = $createVerseNode("2", "\\v 2 ");
+        $getRoot().append(
+          $createParaNode("p").append(
+            v1,
+            $createTextNode("In the beginning "),
+            v2,
+            $createTextNode("and the earth"),
+          ),
+        );
+      });
+
+      editor.getEditorState().read(() => {
+        const items = $getFirstParaItems();
+
+        expect(items).toHaveLength(4);
+        expect(items[0]).toEqual({ type: "element", node: v1 });
+        $expectTextItem(items[1], [{ text: "In the beginning ", start: 0 }]);
+        expect(items[2]).toEqual({ type: "element", node: v2 });
+        $expectTextItem(items[3], [{ text: "and the earth", start: 0 }]);
+      });
+    });
+
+    it("skips presentation-only MarkerNodes without breaking the run", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        $getRoot().append(
+          $createParaNode("p").append($createMarkerNode("p"), $createTextNode("verse text")),
+        );
+      });
+
+      editor.getEditorState().read(() => {
+        const items = $getFirstParaItems();
+
+        expect(items).toHaveLength(1);
+        $expectTextItem(items[0], [{ text: "verse text", start: 0 }]);
+      });
+    });
+
+    it("skips standalone NBSP spacer text nodes between content items", () => {
+      // Visible/hidden modes insert NBSP spacer text nodes between element items (e.g. between
+      // char nodes in a note). The editor→USJ conversion drops them, so they are not USJ
+      // content. A spacer only survives as its own node next to elements — Lexical merges
+      // adjacent plain text nodes, so an NBSP beside other text is not a separate node.
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        $getRoot().append(
+          $createParaNode().append(
+            $createCharNode("nd").append($createTextNode("aaa")),
+            $createTextNode(NBSP),
+            $createCharNode("nd").append($createTextNode("bbb")),
+          ),
+        );
+      });
+
+      editor.getEditorState().read(() => {
+        const items = $getFirstParaItems();
+
+        expect(items).toHaveLength(2);
+        expect(items[0].type).toBe("element");
+        expect(items[1].type).toBe("element");
+      });
+    });
+
+    it("emits a non-text element wrapped inside a TypedMarkNode as its own item", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        $getRoot().append(
+          $createParaNode().append(
+            $createTextNode("x"),
+            $createTypedMarkNode({ t: ["1"] }).append(
+              $createTextNode("y"),
+              $createCharNode("nd").append($createTextNode("LORD")),
+              $createTextNode("z"),
+            ),
+          ),
+        );
+      });
+
+      editor.getEditorState().read(() => {
+        const items = $getFirstParaItems();
+
+        // run "xy" | char | run "z"
+        expect(items).toHaveLength(3);
+        $expectTextItem(items[0], [
+          { text: "x", start: 0 },
+          { text: "y", start: 1 },
+        ]);
+        expect(items[1].type).toBe("element");
+        $expectTextItem(items[2], [{ text: "z", start: 0 }]);
+      });
+    });
+
+    it("returns an empty array for an empty paragraph", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        $getRoot().append($createParaNode());
+      });
+
+      editor.getEditorState().read(() => {
+        expect($getFirstParaItems()).toEqual([]);
+      });
+    });
+  });
+
+  describe("$getLogicalParent / $getLogicalIndexOfChild / $getLogicalTextLocation", () => {
+    it("resolves through TypedMarkNode wrappers to the real parent and run index", () => {
+      let markedText: TextNode;
+      let trailingText: TextNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        markedText = $createTextNode("man");
+        trailingText = $createTextNode(" who");
+        $getRoot().append(
+          $createParaNode().append(
+            $createTextNode("the "),
+            $createTypedMarkNode({ spelling: ["s1"] }).append(markedText),
+            trailingText,
+          ),
+        );
+      });
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isElementNode(para)) throw new Error("Expected an ElementNode");
+
+        // Logical parent of text inside the mark is the para, not the mark.
+        expect($getLogicalParent(markedText)?.getKey()).toBe(para.getKey());
+        // All three text pieces belong to logical item 0.
+        expect($getLogicalIndexOfChild(para, markedText)).toBe(0);
+        expect($getLogicalIndexOfChild(para, trailingText)).toBe(0);
+
+        // Cumulative offsets: "the " (4) + "man" (3) + " who".
+        expect($getLogicalTextLocation(markedText, 1)).toEqual({
+          parent: para,
+          index: 0,
+          offset: 5,
+        });
+        expect($getLogicalTextLocation(trailingText, 2)).toEqual({
+          parent: para,
+          index: 0,
+          offset: 9,
+        });
+      });
+    });
+
+    it("gives elements after an annotated run their logical index", () => {
+      let charNode: ReturnType<typeof $createCharNode>;
+      let tailText: TextNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        charNode = $createCharNode("nd");
+        tailText = $createTextNode("dd");
+        $getRoot().append(
+          $createParaNode().append(
+            $createTextNode("aaa "),
+            $createTypedMarkNode({ t: ["1"] }).append($createTextNode("bb")),
+            $createTextNode(" cc "),
+            charNode.append($createTextNode("LORD")),
+            tailText,
+          ),
+        );
+      });
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isElementNode(para)) throw new Error("Expected an ElementNode");
+
+        // USJ content: [0]="aaa bb cc ", [1]=char, [2]="dd" — the mark is invisible.
+        expect($getLogicalIndexOfChild(para, charNode)).toBe(1);
+        expect($getLogicalIndexOfChild(para, tailText)).toBe(2);
+        expect($getLogicalTextLocation(tailText, 1)).toEqual({
+          parent: para,
+          index: 2,
+          offset: 1,
+        });
+      });
+    });
+
+    it("returns -1 / undefined for presentation-only nodes", () => {
+      let markerNode: ReturnType<typeof $createMarkerNode>;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        markerNode = $createMarkerNode("p");
+        $getRoot().append($createParaNode("p").append(markerNode, $createTextNode("hi")));
+      });
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isElementNode(para)) throw new Error("Expected an ElementNode");
+        expect($getLogicalIndexOfChild(para, markerNode)).toBe(-1);
+        expect($getLogicalTextLocation(markerNode, 0)).toBeUndefined();
+      });
+    });
+  });
+
+  describe("$getTextNodeAtLogicalOffset", () => {
+    it("finds the segment and local offset for cumulative offsets", () => {
+      const { editor, t1, t2, t3 } = buildAnnotatedPara();
+      editor.getEditorState().read(() => {
+        const item = $getFirstParaTextItem();
+
+        expect($getTextNodeAtLogicalOffset(item, 2)).toEqual([t1, 2]); // in "the "
+        expect($getTextNodeAtLogicalOffset(item, 5)).toEqual([t2, 1]); // in "man"
+        expect($getTextNodeAtLogicalOffset(item, 9)).toEqual([t3, 2]); // in " who"
+      });
+    });
+
+    it("prefers the next segment's start at internal boundaries", () => {
+      const { editor, t2 } = buildAnnotatedPara();
+      editor.getEditorState().read(() => {
+        const item = $getFirstParaTextItem();
+
+        // Offset 4 is the boundary "the "|"man": the mark's text at local offset 0.
+        expect($getTextNodeAtLogicalOffset(item, 4)).toEqual([t2, 0]);
+      });
+    });
+
+    it("returns the end of the last segment for offset === length, undefined beyond", () => {
+      const { editor, t3 } = buildAnnotatedPara();
+      editor.getEditorState().read(() => {
+        const item = $getFirstParaTextItem();
+
+        expect($getTextNodeAtLogicalOffset(item, 11)).toEqual([t3, 4]); // "the man who".length
+        expect($getTextNodeAtLogicalOffset(item, 12)).toBeUndefined();
+      });
+    });
+  });
+
+  describe("$getLogicalPointFromElementPoint / $getElementOffsetFromLogicalIndex", () => {
+    it("maps element boundaries around an annotated run", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        $getRoot().append(
+          $createParaNode().append(
+            $createTextNode("aaa "),
+            $createTypedMarkNode({ t: ["1"] }).append($createTextNode("bb")),
+            $createTextNode(" cc "),
+            $createCharNode("nd").append($createTextNode("LORD")),
+            $createTextNode("dd"),
+          ),
+        );
+      });
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isElementNode(para)) throw new Error("Expected an ElementNode");
+        // Lexical children:      0="aaa "  1=Mark  2=" cc "  3=Char  4="dd"
+        // Logical content items: 0="aaa bb cc "   1=Char     2="dd"
+
+        // Boundary before child 0 = before item 0.
+        expect($getLogicalPointFromElementPoint(para, 0)).toEqual({ type: "index", index: 0 });
+        // Boundary before the mark falls INSIDE logical item 0 at cumulative offset 4.
+        expect($getLogicalPointFromElementPoint(para, 1)).toEqual({
+          type: "text",
+          index: 0,
+          offset: 4,
+        });
+        // Boundary before " cc " is also inside item 0, at offset 6.
+        expect($getLogicalPointFromElementPoint(para, 2)).toEqual({
+          type: "text",
+          index: 0,
+          offset: 6,
+        });
+        // Boundary before the char is the clean boundary between items 0 and 1.
+        expect($getLogicalPointFromElementPoint(para, 3)).toEqual({ type: "index", index: 1 });
+        // End boundary.
+        expect($getLogicalPointFromElementPoint(para, 5)).toEqual({ type: "index", index: 3 });
+
+        // Inverse: earliest element child offset for each logical boundary.
+        expect($getElementOffsetFromLogicalIndex(para, 0)).toBe(0);
+        expect($getElementOffsetFromLogicalIndex(para, 1)).toBe(3); // after " cc "
+        expect($getElementOffsetFromLogicalIndex(para, 2)).toBe(4); // after Char
+        expect($getElementOffsetFromLogicalIndex(para, 3)).toBe(5); // after "dd"
+      });
+    });
+
+    it("resolves a boundary at a mark wrapping a non-text element child", () => {
+      // The mark wraps a CharNode rather than plain text (e.g. from wrapping a partial CharNode
+      // selection in an annotation). This pins the $isDescendantOf element-item branch: the
+      // "child" passed in is the mark itself, and the matching item's node (the CharNode) is a
+      // descendant of it, not equal to it.
+      let markNode: TypedMarkNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        markNode = $createTypedMarkNode({ t: ["1"] }).append(
+          $createCharNode("nd").append($createTextNode("LORD")),
+        );
+        $getRoot().append(
+          $createParaNode().append($createTextNode("ab"), markNode, $createTextNode("cd")),
+        );
+      });
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isElementNode(para)) throw new Error("Expected an ElementNode");
+        // Lexical children:      0="ab"  1=Mark  2="cd"
+        // Logical content items: 0="ab"  1=Char  2="cd"
+
+        // Boundary before the mark (child index 1) falls on the char's logical index, not the
+        // mark's own (dropped) index.
+        expect($getLogicalPointFromElementPoint(para, 1)).toEqual({ type: "index", index: 1 });
+      });
+    });
+  });
 });
+
+// ---------------------------------------------------------------------------
+// Helpers (function declarations hoist, so they may live after the tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Gets the logical content items of the first (para) child of root. Must be called inside an
+ * active editor state read scope, e.g. `editor.getEditorState().read(...)`.
+ */
+function $getFirstParaItems(): LogicalContentItem[] {
+  const para = $getRoot().getFirstChild();
+  if (!$isElementNode(para)) throw new Error("Expected an ElementNode");
+  return $getLogicalContentItems(para);
+}
+
+/**
+ * Gets the first logical content item of the first (para) child of root, asserting it is a
+ * text item. Must be called inside an active editor state read scope.
+ */
+function $getFirstParaTextItem(): LogicalTextItem {
+  const [item] = $getFirstParaItems();
+  if (item?.type !== "text") throw new Error("Expected a text item");
+  return item;
+}
+
+/**
+ * Asserts a text item's segment texts and cumulative starts. Must be called inside an active
+ * editor state read scope, e.g. `editor.getEditorState().read(...)`.
+ */
+function $expectTextItem(
+  item: LogicalContentItem,
+  expectedSegments: { text: string; start: number }[],
+) {
+  if (item.type !== "text") throw new Error("Expected a text item");
+  expect(
+    item.segments.map((segment) => ({
+      text: segment.node.getTextContent(),
+      start: segment.start,
+    })),
+  ).toEqual(expectedSegments);
+  expect(item.length).toBe(expectedSegments.reduce((sum, segment) => sum + segment.text.length, 0));
+}
+
+/** Build "the " |man| " who" where "man" is annotated, returning the three text nodes. */
+function buildAnnotatedPara() {
+  let t1: TextNode;
+  let t2: TextNode;
+  let t3: TextNode;
+  const { editor } = createBasicTestEnvironment(nodes, () => {
+    t1 = $createTextNode("the ");
+    t2 = $createTextNode("man");
+    t3 = $createTextNode(" who");
+    $getRoot().append(
+      $createParaNode().append(t1, $createTypedMarkNode({ s: ["1"] }).append(t2), t3),
+    );
+  });
+  // Non-null assertion is safe: the initial state callback ran synchronously.
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return { editor, t1: t1!, t2: t2!, t3: t3! };
+}

--- a/libs/shared/src/nodes/usj/node.utils.ts
+++ b/libs/shared/src/nodes/usj/node.utils.ts
@@ -5,9 +5,11 @@ import {
   $getCommonAncestor,
   $getState,
   $isElementNode,
+  $isLineBreakNode,
   $isRangeSelection,
   $isTextNode,
   BaseSelection,
+  ElementNode,
   LexicalEditor,
   LexicalNode,
   NodeKey,
@@ -16,13 +18,14 @@ import {
   SerializedTextNode,
   TextNode,
 } from "lexical";
-import { charIdState } from "../collab/delta.state.js";
+import { charIdState, textTypeState } from "../collab/delta.state.js";
 import {
   $isImmutableTypedTextNode,
   ImmutableTypedTextNode,
   isSerializedImmutableTypedTextNode,
 } from "../features/ImmutableTypedTextNode.js";
 import { $isMarkerNode, isSerializedMarkerNode } from "../features/MarkerNode.js";
+import { $isTypedMarkNode } from "../features/TypedMarkNode.js";
 import { $isUnknownNode, UnknownNode } from "../features/UnknownNode.js";
 import { $isBookNode, BookNode } from "./BookNode.js";
 import {
@@ -62,6 +65,34 @@ export type SomeChapterNode = ChapterNode | ImmutableChapterNode;
 export type SomeParaNode = ParaNode | ImpliedParaNode;
 
 export type ParaLikeNode = SomeParaNode | BookNode;
+
+/** A piece of a logical text item: one Lexical TextNode and its cumulative start offset. */
+export interface LogicalTextSegment {
+  node: TextNode;
+  /** Offset of this segment's first character within the logical text item. */
+  start: number;
+}
+
+/**
+ * One USJ content item as represented in the editor. Either a standalone content item (CharNode,
+ * NoteNode, VerseNode, MilestoneNode, …) or a coalesced text run: the maximal sequence of plain
+ * TextNodes (exact "text" type) — top-level, inside TypedMarkNodes (annotations), or separated
+ * only by presentation-only nodes — that the editor→USJ conversion exports as a single string.
+ * TextNode subclasses never join a run: VerseNode is a standalone item (the exporter emits it
+ * as its own verse marker object) and MarkerNode is presentation-only scaffolding.
+ */
+export interface LogicalTextItem {
+  type: "text";
+  segments: LogicalTextSegment[];
+  length: number;
+}
+
+export type LogicalContentItem = { type: "element"; node: LexicalNode } | LogicalTextItem;
+
+/** A point in logical USJ content: between items, or inside a coalesced text item. */
+export type LogicalPoint =
+  | { type: "index"; index: number }
+  | { type: "text"; index: number; offset: number };
 
 /** RegEx to test for a string only containing digits. */
 const ONLY_DIGITS_TEST = /^\d+$/;
@@ -712,5 +743,229 @@ function getSelectionStartNodeInner(selection: BaseSelection | null): LexicalNod
     return selection.isBackward() ? nodes[nodes.length - 1] : nodes[0];
   }
 
+  return undefined;
+}
+
+/**
+ * Checks whether a node is presentation-only and therefore not part of USJ content:
+ * line breaks, marker scaffolding (editable and visible), marker-trailing-space or
+ * attribute text, and empty or NBSP-only spacer text (which the editor→USJ conversion
+ * drops as well; ideally the USJ→editor conversion would create such spacers as
+ * presentation-typed text nodes instead — follow-up work).
+ * @param node - The node to check.
+ * @returns `true` if the node must be skipped when computing USJ content indexes.
+ */
+export function $shouldIgnoreNodeForContentIndexes(node: LexicalNode | null | undefined): boolean {
+  if (!node) return false;
+  if ($isLineBreakNode(node)) return true;
+  if ($isMarkerNode(node)) return true;
+  if ($isVisibleMarkerNode(node)) return true;
+  if ($isTextNode(node)) {
+    const textType = $getState(node, textTypeState);
+    if (textType === "marker-trailing-space" || textType === "attribute") return true;
+
+    const text = node.getTextContent();
+    if (text === "" || text === NBSP) return true;
+  }
+  return false;
+}
+
+/**
+ * Maps a parent element's Lexical children to its logical USJ content items — the items the
+ * editor→USJ conversion would export: presentation-only nodes skipped, TypedMarkNodes
+ * transparent (children spliced in, recursively), contiguous text coalesced into single items.
+ *
+ * Known exclusion: comment-type TypedMarkNodes are treated as transparent like every other
+ * mark, even though the exporter still serializes them as milestone items. That milestone
+ * serialization is deprecated and pending removal, so the model intentionally ignores it.
+ * @param parent - The parent element node.
+ * @returns the logical content items in document order.
+ */
+export function $getLogicalContentItems(parent: ElementNode): LogicalContentItem[] {
+  const items: LogicalContentItem[] = [];
+  let run: { segments: LogicalTextSegment[]; length: number } | undefined;
+
+  const flushRun = () => {
+    if (run) {
+      items.push({ type: "text", segments: run.segments, length: run.length });
+      run = undefined;
+    }
+  };
+
+  const visit = (node: LexicalNode) => {
+    if ($shouldIgnoreNodeForContentIndexes(node)) return;
+    if ($isTypedMarkNode(node)) {
+      // Recursion is defense-in-depth: nested marks only exist transiently before the
+      // AnnotationPlugin's nested-element resolver flattens them into siblings.
+      node.getChildren().forEach(visit);
+      return;
+    }
+    // Only plain TextNodes (exact "text" type) join a coalesced run, mirroring the exporter.
+    // TextNode subclasses (e.g. VerseNode) fall through to become standalone items.
+    if ($isTextNode(node) && node.getType() === TextNode.getType()) {
+      run ??= { segments: [], length: 0 };
+      run.segments.push({ node, start: run.length });
+      run.length += node.getTextContentSize();
+      return;
+    }
+    flushRun();
+    items.push({ type: "element", node });
+  };
+
+  parent.getChildren().forEach(visit);
+  flushRun();
+  return items;
+}
+
+/**
+ * Gets the nearest ancestor that is not a TypedMarkNode — the element that owns the node's
+ * logical content index (annotation wrappers are transparent in USJ).
+ * @param node - The node to get the logical parent of.
+ * @returns the logical parent element, or `null` at the root.
+ */
+export function $getLogicalParent(node: LexicalNode): ElementNode | null {
+  let parent: ElementNode | null = node.getParent();
+  while (parent && $isTypedMarkNode(parent)) parent = parent.getParent();
+  return parent;
+}
+
+/**
+ * Gets the logical content index of the item containing the child (the child may be nested
+ * inside TypedMarkNodes under the parent).
+ * @param parent - The logical parent element.
+ * @param child - The node to find.
+ * @returns the logical index, or -1 if the child is presentation-only or not found.
+ */
+export function $getLogicalIndexOfChild(parent: ElementNode, child: LexicalNode): number {
+  return $getLogicalContentItems(parent).findIndex((item) =>
+    item.type === "element"
+      ? item.node.is(child)
+      : item.segments.some((segment) => segment.node.is(child)),
+  );
+}
+
+/**
+ * Converts a (TextNode, local offset) point to logical USJ text coordinates: the index of the
+ * coalesced text item within the logical parent and the cumulative offset within it.
+ * @param textNode - The Lexical text node.
+ * @param offset - The offset within the text node.
+ * @returns the logical parent, item index, and cumulative offset, or `undefined` if the text
+ *   node is not part of any logical text item (e.g. presentation-only text).
+ */
+export function $getLogicalTextLocation(
+  textNode: TextNode,
+  offset: number,
+): { parent: ElementNode; index: number; offset: number } | undefined {
+  const parent = $getLogicalParent(textNode);
+  if (!parent) return undefined;
+
+  const items = $getLogicalContentItems(parent);
+  for (let index = 0; index < items.length; index++) {
+    const item = items[index];
+    if (item.type !== "text") continue;
+
+    const segment = item.segments.find((segment) => segment.node.is(textNode));
+    if (segment) return { parent, index, offset: segment.start + offset };
+  }
+  return undefined;
+}
+
+/**
+ * Finds the TextNode and local offset at a cumulative offset within a logical text item.
+ * At internal segment boundaries the next segment's start is preferred, so a point at an
+ * annotation edge targets the start of the following content rather than the end of the
+ * previous piece.
+ * @param item - The logical text item.
+ * @param offset - The cumulative offset within the item.
+ * @returns the text node and local offset, or `undefined` when out of range.
+ */
+export function $getTextNodeAtLogicalOffset(
+  item: LogicalTextItem,
+  offset: number,
+): [TextNode, number] | undefined {
+  if (offset < 0 || offset > item.length) return undefined;
+
+  for (const segment of item.segments) {
+    const segmentLength = segment.node.getTextContentSize();
+    if (offset >= segment.start && offset < segment.start + segmentLength)
+      return [segment.node, offset - segment.start];
+  }
+  // offset === item.length: end of the last segment.
+  const lastSegment = item.segments[item.segments.length - 1];
+  if (!lastSegment) return undefined;
+  return [lastSegment.node, offset - lastSegment.start];
+}
+
+/**
+ * Converts an element point (parent + child index) to a logical point. Boundaries that fall
+ * inside a coalesced text item (e.g. at an annotation edge) become text points; boundaries
+ * between logical items become index points.
+ * @param parent - The parent element node of the element point.
+ * @param elementOffset - The child index of the element point.
+ * @returns the logical point.
+ */
+export function $getLogicalPointFromElementPoint(
+  parent: ElementNode,
+  elementOffset: number,
+): LogicalPoint {
+  const items = $getLogicalContentItems(parent);
+  const child = parent.getChildAtIndex(elementOffset);
+  if (!child) return { type: "index", index: items.length };
+
+  // Boundary before a presentation-only node: use the boundary before the next content child.
+  if ($shouldIgnoreNodeForContentIndexes(child))
+    return $getLogicalPointFromElementPoint(parent, elementOffset + 1);
+
+  for (let index = 0; index < items.length; index++) {
+    const item = items[index];
+    if (item.type === "element") {
+      if (item.node.is(child) || $isDescendantOf(item.node, child.getKey()))
+        return { type: "index", index };
+      continue;
+    }
+    for (const segment of item.segments) {
+      if (segment.node.is(child) || $isDescendantOf(segment.node, child.getKey())) {
+        return segment.start === 0
+          ? { type: "index", index }
+          : { type: "text", index, offset: segment.start };
+      }
+    }
+  }
+  return { type: "index", index: items.length };
+}
+
+/**
+ * Converts a logical boundary index to the earliest element child offset at that boundary
+ * (the inverse of `$getLogicalPointFromElementPoint` for index points).
+ * @param parent - The parent element node.
+ * @param logicalIndex - The logical boundary index (0 = before the first item).
+ * @returns the element child offset.
+ */
+export function $getElementOffsetFromLogicalIndex(
+  parent: ElementNode,
+  logicalIndex: number,
+): number {
+  if (logicalIndex <= 0) return 0;
+
+  const items = $getLogicalContentItems(parent);
+  if (items.length === 0 || logicalIndex > items.length) return parent.getChildrenSize();
+
+  const previousItem = items[logicalIndex - 1];
+  const lastNode =
+    previousItem.type === "element"
+      ? previousItem.node
+      : previousItem.segments[previousItem.segments.length - 1]?.node;
+  const topLevelChild = lastNode ? $findChildOfParent(parent, lastNode) : undefined;
+  return topLevelChild ? topLevelChild.getIndexWithinParent() + 1 : parent.getChildrenSize();
+}
+
+/** Walks up from a descendant to the direct child of the given parent. */
+function $findChildOfParent(parent: ElementNode, descendant: LexicalNode): LexicalNode | undefined {
+  let current: LexicalNode | null = descendant;
+  while (current) {
+    const currentParent: ElementNode | null = current.getParent();
+    if (currentParent?.is(parent)) return current;
+    current = currentParent;
+  }
   return undefined;
 }

--- a/packages/platform/src/editor/adaptors/editor-usj.adaptor.ts
+++ b/packages/platform/src/editor/adaptors/editor-usj.adaptor.ts
@@ -334,6 +334,9 @@ function replaceMarkWithMilestones(
   }
 }
 
+// Keep this function's content semantics in sync with `$getLogicalContentItems` in
+// `libs/shared/src/nodes/usj/node.utils.ts` — the logical content model mirrors which nodes
+// this export skips, splices (TypedMarkNodes), and coalesces into single text strings.
 function recurseNodes(
   nodes: SerializedLexicalNode[],
   noteCaller?: string,


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-3835-annotation-selection

**Base**: origin/main

**Date**: 2026-07-06

**Review model**: Claude Fable 5

**Files changed**: 8 (7 in the committed squash; in-review fixes touched 1 additional file, `packages/platform/src/editor/adaptors/editor-usj.adaptor.ts`. Step 1.3 reported 12, which included 5 uncommitted local workstation config files excluded from this review.)

## Overview

Fixes Jira PT-3835: selection locations (`jsonPath` + `offset`) reported by `onSelectionChange` and consumed by `setAnnotation` previously counted `TypedMarkNode` annotation wrappers as content items, even though annotations do not exist in exported USJ (the editor→USJ adaptor strips them and coalesces split text back into single strings). Once one annotation existed in a paragraph, locations at or after it were wrong against the real USJ; hosts like paranext-core that resolve reported locations against actual USJ failed (e.g. `No result found for JSONPath query: $.content[20].content[2]`) when inserting annotations front-to-back. Inside this repo the bug was invisible because both conversion directions shared the same wrong convention and the errors cancelled.

The fix adds a logical content model to `libs/shared/src/nodes/usj/node.utils.ts` (`$getLogicalContentItems` and lookup helpers) that mirrors what `recurseNodes` in the platform `editor-usj.adaptor.ts` exports — presentation-only nodes skipped without breaking text runs, TypedMarkNodes transparent, contiguous plain text coalesced with cumulative segment offsets — and rebuilds both conversion directions in `libs/shared-react/.../selection.utils.ts` on that single model. Published package APIs are unchanged. Test coverage: unit tests for the model, a 204-case data-driven annotation-invariance suite (3 marker modes × 2 insertion orders over the 2SA corpus), `AnnotationPlugin` integration tests reproducing the repro flow in both orders, and an "Insert at selection" button in the platform demo for manual verification.

## API Changes

- `packages/*`: no files changed — the published public API surface (exports, types, signatures) is unchanged.
- `libs/shared` (`node.utils.ts`, re-exported via `export *` barrels): added exports — types `LogicalTextSegment`, `LogicalTextItem`, `LogicalContentItem`, `LogicalPoint`; functions `$shouldIgnoreNodeForContentIndexes`, `$getLogicalContentItems`, `$getLogicalParent`, `$getLogicalIndexOfChild`, `$getLogicalTextLocation`, `$getTextNodeAtLogicalOffset`, `$getLogicalPointFromElementPoint`, `$getElementOffsetFromLogicalIndex`. All additive; no exports removed or modified.
- `libs/shared-react` (`selection.utils.ts`): exported surface unchanged (`$getRangeFromUsjSelection`, `$getUsjSelectionFromEditor`); only private helpers were replaced.
- Runtime behavior of the unchanged APIs changed by design: `UsjTextContentLocation` values emitted by `onSelectionChange` and consumed by `setAnnotation` are now annotation-transparent (coalesced-USJ coordinates) in documents containing annotations.

(Analysis caveat: the API checklist targets paranext-core surfaces; the analyzer mapped it onto this repo's structure — `packages/*` = published API, `libs/*` = internal.)

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [ ] ~~Deliberate behavior change on unchanged API signatures (`selection.utils.ts`): hosts that shipped workarounds compensating for the old annotation-inclusive coordinates would double-adjust; recommend release-notes callout and coordinated paranext-core rollout~~ _(author: the previous behavior was not intentional — it was the bug; this fix was surfaced by paranext-core itself and there are no known workarounds)_
- [x] `$getLogicalContentItems` JSDoc overstated exporter parity: comment-type TypedMarkNodes are serialized as milestone items by the exporter, so logical indexes diverge for paragraphs containing comments _(fixed during review: known-exclusion note added to the JSDoc — comment marks are treated as transparent like all marks; the milestone serialization is deprecated and pending removal, so the model intentionally ignores it)_

[Author response: Finding 1 dismissed as designed — bug fix restoring the documented contract. Finding 2 fixed with the documentation note the author requested.]

### Minor — Consider

- [x] Exporter-parity gap: exporter drops NBSP-only/empty text nodes, model counted their characters _(fixed during review: `$shouldIgnoreNodeForContentIndexes` now skips empty and NBSP-only spacer text, with a revert-tested unit test using the real-world shape — a standalone NBSP spacer between element items, since Lexical merges adjacent plain text nodes. The deeper fix — creating NBSP spacers as presentation-typed text nodes in the USJ→editor direction — is noted in the code as follow-up work beyond this PR.)_
- [ ] ~~Mixed-children-inside-mark boundary: a logical boundary between a text child and a non-text child inside a mark resolves past the whole mark (`$getElementOffsetFromLogicalIndex` / `$getLocationFromNode`)~~ _(author dismissed as the documented known edge: rare scenario, output is a valid nearby point in the correct run — strictly better than both prior behaviors; an exact fix requires a resolution-side change able to return points inside a mark (~30–50 lines), reviewed and declined for this PR)_
- [x] The model mirrors `recurseNodes` but neither exporter copy referenced it _(fixed during review: "keep in sync" comment added above the platform `recurseNodes`; the scribe copy was dismissed — scribe is no longer being kept updated)_
- [x] Code comment cited "(see PT-3835 final review)" — a reference unreachable from the code _(fixed during review: citation trimmed; the surrounding comment carries the reasoning)_
- [x] `$getTextNodeAtLogicalOffset` accepted the full `LogicalContentItem` union and rejected element items at runtime _(fixed during review: parameter tightened to a new exported `LogicalTextItem` interface — misuse is now a compile error; tests use a narrowing `$getFirstParaTextItem()` helper)_
- [x] Demo "Insert at selection" id `sel-${Date.now()}` can collide on same-millisecond clicks _(fixed during review: comment added noting the collision is acceptable for demo-only scaffolding)_
- [ ] ~~`$shouldIgnoreNodeForContentIndexes` has no direct unit tests~~ _(author dismissed as adequately covered: moved-verbatim logic exercised indirectly by the `$getLogicalContentItems` tests, and the new NBSP spacer test directly covers the newest branch)_

[Author response: author requested fixes for five of the seven; the two dismissals are reasoned above.]

### Template Propagation

#### Shared Regions Modified

None. (No `#region shared with` markers exist in this repository.)

#### Extension Config Changes

None. (No config/build files changed; this repo has no `extensions/` directory.)

## Positive Observations

- Strong consolidation: five ad-hoc one-direction content-index helpers were replaced by a single well-documented logical content model in `libs/shared`, and both conversion directions now derive from it — eliminating the asymmetry-by-duplication that caused PT-3835.
- `$shouldIgnoreNodeForContentIndexes` was moved verbatim to the correct layer and consumed through existing barrels; new code reuses the existing `$isDescendantOf` helper rather than re-implementing ancestry checks.
- TSDoc on the new model is unusually thorough about edge cases (VerseNode/MarkerNode extending TextNode; nested-mark recursion as defense-in-depth; segment-boundary preference at annotation edges).
- Test investment matches the change: every new exported utility has direct unit tests; the 204-case invariance suite derives its annotation ranges from the corpus itself and hard-fails (rather than silently skipping) if the corpus stops qualifying; integration tests replicate the actual host "insert at reported selection" flow in both insertion orders.
- The changed expectation in the pre-existing test suite is the intended behavior fix and is annotated with an explanatory comment; tests are behavior-focused (round-trip assertions against USJ locations, not implementation internals).
- The demo button guards correctly (`isUsjTextContentLocation` on both endpoints, null-checked ref) and follows the demo app's existing conventions.

## Interview Notes

- **Stated purpose**: bug fix for PT-3835 (from the branch commit message) — make selection locations annotation-transparent so they are interpreted against the actual USJ.
- **Root cause, in the author's words**: what was hard to spot was that adding annotations forward or backward through the text worked in this repo (even though forward failed in core) because the Lexical↔USJ selection conversion had the same error in both directions — the errors cancelled. You had to inspect the actual selection values and ask whether they were correct, rather than observing annotations appearing in the expected places. This demonstrates clear author understanding of the failure mode and the fix.
- **Behavior-change finding**: dismissed as designed — the old coordinates were unintentional; no known host workarounds exist to break.
- **Comment milestones**: deprecated code pending removal; the model intentionally ignores milestone serialization (now documented in the JSDoc).
- **Scribe**: no longer being kept updated — its copy of `recurseNodes` was deliberately left without the sync comment.
- **Verification status**: paranext-core has been retested against this fix and the original repro is resolved. Playwright e2e tests in paranext-core remain follow-up work (per the ticket's Definition of Done).
- **New bug surfaced in core**: with this fix in place, a separate pre-existing paranext-core bug is now easier to see — it reports a notification that the selection can't include markers even though the selection doesn't include any. To be tracked in core.
- No areas of author uncertainty or AI-deferral were observed; the author explained the design and each dismissal with specific technical reasoning.

## In-Review Quality Check

- `pnpm nx run-many -t typecheck`: passed for all 10 projects.
- `pnpm nx run-many -t lint`: one error auto-fixed — the new `LogicalTextItem` type alias violated `@typescript-eslint/consistent-type-definitions` and was changed to an `interface`; 0 errors remain (pre-existing warnings only).
- `pnpm nx format:check`: passed.
- Tests: `shared` 107 passed; `shared-react` 1265 passed (3 pre-existing skips). No unfixable failures.

## Suggested Review Focus

- [ ] The logical content model (`$getLogicalContentItems` in `libs/shared/src/nodes/usj/node.utils.ts`): confirm the skip/splice/coalesce rules match the platform exporter's `recurseNodes` case-for-case, including the plain-`"text"`-type-only run membership (VerseNode extends TextNode) and the new NBSP/empty spacer skip.
- [ ] The self-cancelling-error root cause: worth walking through how both conversion directions shared the wrong convention, since it explains why this repo's tests couldn't catch the bug before the invariance suite existed.
- [ ] Consumer-visible nuances for the paranext-core rollout: annotation-edge element points now emit deeper `textContent` locations; stale mark-counting locations persisted by hosts resolve to `undefined` (the bug being fixed).
- [ ] Dismissed known edge: interior element point between mixed children inside a mark approximates to a nearby point in the correct run — confirm the team is comfortable shipping this documented limitation.
- [ ] Follow-up items to track: USJ→editor adaptor creating NBSP spacers as presentation-typed text nodes; Playwright e2e in paranext-core; the newly visible core bug (spurious "selection can't include markers" notification).
<!-- review-paratext:summary:end -->

AI-assisted — [session](<session URL>)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/496)
<!-- Reviewable:end -->
