### PR TITLE
PT-3835: Don't insert verse spacing after gutter para marker prefixes

### DIFF
--- a/libs/shared-react/src/plugins/usj/TextSpacingPlugin.test.tsx
+++ b/libs/shared-react/src/plugins/usj/TextSpacingPlugin.test.tsx
@@ -16,6 +16,7 @@ import { $createTextNode, $getRoot, $isTextNode, TextNode, $setSelection } from 
 import {
   $createCharNode,
   $createImmutableChapterNode,
+  $createImmutableTypedTextNode,
   $createNoteNode,
   $createParaNode,
   $createTypedMarkNode,
@@ -24,6 +25,9 @@ import {
   $isParaNode,
   $isTypedMarkNode,
   $isUnknownNode,
+  $isVisibleMarkerNode,
+  NBSP,
+  openingMarkerText,
   ParaNode,
   UnknownNode,
 } from "shared";
@@ -360,6 +364,34 @@ describe("TextSpacingPlugin", () => {
       // Should remain [UnknownNode, VerseNode]
       expect(para.getChildren()).toHaveLength(2);
       expect($isUnknownNode(para.getChildAtIndex(0))).toBe(true);
+      expect($isSomeVerseNode(para.getChildAtIndex(1))).toBe(true);
+    });
+  });
+
+  it("should not insert a space before a verse if preceded by a gutter paragraph marker prefix", async () => {
+    // Regression test for PT-3835 Gen 2: gutter mode (`hasGutterParaMarkers: true`) renders the
+    // paragraph's `\p` marker as a visible-marker ImmutableTypedTextNode (textType "marker") that is
+    // verse 1's previous sibling. That node is a DecoratorNode, not a TextNode/UnknownNode, so
+    // $verseNodeTransform used to treat it like arbitrary unrecognized content and insert a spurious
+    // leading space, shifting every logical content index in the paragraph.
+    const { editor } = await testEnvironment(() => {
+      $getRoot().append(
+        $createParaNode().append(
+          $createImmutableTypedTextNode("marker", openingMarkerText("p") + NBSP),
+          $createImmutableVerseNode("1"),
+        ),
+      );
+    });
+
+    // Trigger an update (no change expected).
+    await act(async () => editor.update(() => undefined));
+
+    editor.getEditorState().read(() => {
+      const para = $getRoot().getFirstChild();
+      if (!$isParaNode(para)) throw new Error("Expected a ParaNode");
+      // Should remain [marker prefix, VerseNode] -- no spurious space inserted.
+      expect(para.getChildren()).toHaveLength(2);
+      expect($isVisibleMarkerNode(para.getChildAtIndex(0))).toBe(true);
       expect($isSomeVerseNode(para.getChildAtIndex(1))).toBe(true);
     });
   });

--- a/libs/shared-react/src/plugins/usj/TextSpacingPlugin.test.tsx
+++ b/libs/shared-react/src/plugins/usj/TextSpacingPlugin.test.tsx
@@ -21,6 +21,7 @@ import {
   $createParaNode,
   $createTypedMarkNode,
   $createUnknownNode,
+  $getLogicalContentItems,
   $isCharNode,
   $isParaNode,
   $isTypedMarkNode,
@@ -393,6 +394,91 @@ describe("TextSpacingPlugin", () => {
       expect(para.getChildren()).toHaveLength(2);
       expect($isVisibleMarkerNode(para.getChildAtIndex(0))).toBe(true);
       expect($isSomeVerseNode(para.getChildAtIndex(1))).toBe(true);
+    });
+  });
+
+  it("should space an annotation over plain text before a verse without shifting its logical index", async () => {
+    // The annotation wrapper is transparent to USJ content: the inserted space coalesces onto
+    // the wrapped text's run (the trailing-space transform can't reach text inside a
+    // TypedMarkNode), so the verse's logical content index is unchanged.
+    const { editor } = await testEnvironment(() => {
+      $getRoot().append(
+        $createParaNode().append(
+          $createImmutableVerseNode("1"),
+          $createTextNode("the "),
+          $createTypedMarkNode({ t: ["1"] }).append($createTextNode("beginning")),
+          $createImmutableVerseNode("2"),
+        ),
+      );
+    });
+
+    // Trigger an update (transforms run).
+    await act(async () => editor.update(() => undefined));
+
+    editor.getEditorState().read(() => {
+      const para = $getRoot().getFirstChild();
+      if (!$isParaNode(para)) throw new Error("Expected a ParaNode");
+      // [verse 1, "the beginning ", verse 2] — space coalesced into the run, no index shift.
+      expect($getLogicalContentItems(para)).toHaveLength(3);
+      expect(para.getTextContent()).toBe("the beginning ");
+    });
+  });
+
+  it("should insert the structural space when an annotation ending on a CharNode precedes a verse", async () => {
+    // A space between a char and a following verse marker is structural, not content: USJ→USFM
+    // conversion needs it and Paratext 9 re-inserts it when removed. Canonical USJ therefore has
+    // a standalone " " item here, so inserting it matches the exported shape — the annotation
+    // wrapper must not suppress it.
+    const { editor } = await testEnvironment(() => {
+      $getRoot().append(
+        $createParaNode().append(
+          $createImmutableVerseNode("1"),
+          $createTextNode("text "),
+          $createTypedMarkNode({ t: ["1"] }).append(
+            $createCharNode("nd").append($createTextNode("LORD")),
+          ),
+          $createImmutableVerseNode("2"),
+        ),
+      );
+    });
+
+    // Trigger an update (transforms run).
+    await act(async () => editor.update(() => undefined));
+
+    editor.getEditorState().read(() => {
+      const para = $getRoot().getFirstChild();
+      if (!$isParaNode(para)) throw new Error("Expected a ParaNode");
+      // [verse 1, "text ", char, " ", verse 2] — the structural space is its own content item,
+      // exactly as canonical USJ from Paratext has it.
+      const items = $getLogicalContentItems(para);
+      expect(items).toHaveLength(5);
+      expect(items[3].type).toBe("text");
+    });
+  });
+
+  it("should not insert a space before a verse for an empty annotation wrapper", async () => {
+    // An empty TypedMarkNode resolves to no content, so no structural space belongs after it —
+    // inserting one would add exporter-visible USJ content because of a presentation-only node.
+    const { editor } = await testEnvironment(() => {
+      $getRoot().append(
+        $createParaNode().append(
+          $createImmutableVerseNode("1"),
+          $createTextNode("a "),
+          $createTypedMarkNode({ t: ["1"] }),
+          $createImmutableVerseNode("2"),
+        ),
+      );
+    });
+
+    // Trigger an update (transforms run).
+    await act(async () => editor.update(() => undefined));
+
+    editor.getEditorState().read(() => {
+      const para = $getRoot().getFirstChild();
+      if (!$isParaNode(para)) throw new Error("Expected a ParaNode");
+      // [verse 1, "a ", verse 2] — no double space, no extra content item.
+      expect($getLogicalContentItems(para)).toHaveLength(3);
+      expect(para.getTextContent()).toBe("a ");
     });
   });
 

--- a/libs/shared-react/src/plugins/usj/TextSpacingPlugin.tsx
+++ b/libs/shared-react/src/plugins/usj/TextSpacingPlugin.tsx
@@ -13,6 +13,7 @@ import {
   $isCharNode,
   $isNoteNode,
   $isParaLikeNode,
+  $isParaMarkerPrefix,
   $isTypedMarkNode,
   $isUnknownNode,
   CharNode,
@@ -116,7 +117,11 @@ function $verseNodeTransform(node: SomeVerseNode): void {
     previousSibling &&
     !$isSomeVerseNode(previousSibling) &&
     !$isTextNode(previousSibling) &&
-    !$isUnknownNode(previousSibling)
+    !$isUnknownNode(previousSibling) &&
+    // Para marker prefixes carry their own trailing spacing (NBSP baked into the prefix text),
+    // and an inserted plain " " would be exporter-visible USJ content that shifts every content
+    // index in the paragraph (see PT-3835).
+    !$isParaMarkerPrefix(previousSibling)
   )
     node.insertBefore($createTextNode(" "));
 }

--- a/libs/shared-react/src/plugins/usj/TextSpacingPlugin.tsx
+++ b/libs/shared-react/src/plugins/usj/TextSpacingPlugin.tsx
@@ -7,7 +7,7 @@ import {
 } from "../../nodes/usj/node-react.utils";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { mergeRegister } from "@lexical/utils";
-import { $createTextNode, $isTextNode, LexicalEditor, TextNode } from "lexical";
+import { $createTextNode, $isTextNode, LexicalEditor, LexicalNode, TextNode } from "lexical";
 import { useEffect } from "react";
 import {
   $isCharNode,
@@ -112,16 +112,26 @@ function $textNodeInUnknownTransform(node: TextNode, editor: LexicalEditor): voi
 function $verseNodeTransform(node: SomeVerseNode): void {
   if (!node.isAttached()) return;
 
-  const previousSibling = node.getPreviousSibling();
+  // Annotation wrappers (TypedMarkNode) are presentation-only, so the spacing decision depends
+  // on the content INSIDE them: resolve to the wrapper's last content child (nested wrappers
+  // are transient but resolved for safety). An empty wrapper resolves to null and inserts
+  // nothing.
+  let previousSibling: LexicalNode | null = node.getPreviousSibling();
+  while ($isTypedMarkNode(previousSibling)) previousSibling = previousSibling.getLastChild();
+
   if (
     previousSibling &&
     !$isSomeVerseNode(previousSibling) &&
-    !$isTextNode(previousSibling) &&
     !$isUnknownNode(previousSibling) &&
-    // Para marker prefixes carry their own trailing spacing (NBSP baked into the prefix text),
-    // and an inserted plain " " would be exporter-visible USJ content that shifts every content
-    // index in the paragraph (see PT-3835).
-    !$isParaMarkerPrefix(previousSibling)
+    // Para marker prefixes are presentation scaffolding, not USJ content, so no structural
+    // space belongs after them — and an inserted plain " " would be exporter-visible USJ
+    // content that shifts every content index in the paragraph (see PT-3835). Their visual
+    // separation comes from the prefix nodes' own text.
+    !$isParaMarkerPrefix(previousSibling) &&
+    // Bare text before a verse gets its structural space from $textNodeTrailingSpaceTransform;
+    // text inside an annotation wrapper can't (that transform skips TypedMarkNode parents), so
+    // the space is inserted here instead and coalesces onto the same USJ text run.
+    (!$isTextNode(previousSibling) || $isTypedMarkNode(previousSibling.getParent()))
   )
     node.insertBefore($createTextNode(" "));
 }

--- a/packages/platform/src/editor/annotation-pending-rewrap.test.tsx
+++ b/packages/platform/src/editor/annotation-pending-rewrap.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * PT-3835 follow-up (Gen 2 repro): re-applying a comment annotation to the SAME range after a
+ * pending-annotation wrap/unwrap cycle must resolve. Mirrors paranext-core's Insert Comment
+ * save flow exactly: setAnnotation(pending) → save → removeAnnotation(pending) →
+ * setAnnotation(threadId, same range). Confirmed failing in the app at the last step with
+ * "Failed to find start or end node of the annotation."
+ *
+ * MINIMAL FAILING CONFIGURATION: the failure needs the REAL platform Editor (full plugin
+ * stack, driven through its ref API like paranext does) with formatted view options plus
+ * `hasGutterParaMarkers: true` — gutter mode renders paragraph markers as extra immutable
+ * typed-text nodes in the tree. It does NOT reproduce in a minimal LexicalComposer harness
+ * mounting only the AnnotationPlugin (even with identical view options passed to the USJ
+ * adaptor), nor in the real Editor without the gutter option
+ * (`showCharMarkerTitles`/`hasActiveTextFocusBox` alone don't trigger it either — see the
+ * passing control below). Same-tick and separate-act sequencing fail identically at the
+ * re-apply step; the pending annotation and its removal both work.
+ *
+ * The suite covers both failing-mode variants (gutter-only minimal config, and
+ * titles/gutter/focus-box all on — the original app configuration) plus the all-off passing
+ * control.
+ */
+import Editor from "./Editor";
+import { EditorRef } from "./editor.model";
+import { Usj, USJ_TYPE, USJ_VERSION } from "@eten-tech-foundation/scripture-utilities";
+import { act, render } from "@testing-library/react";
+import { createRef } from "react";
+import { AnnotationRange, getViewOptions, ViewOptions } from "shared-react";
+import { vi } from "vitest";
+
+// Genesis 2:1-3 (WEB). In verse 1: "earth" = 17..22, "all" = 28..31.
+const v1Text = "The heavens, the earth, and all their vast array were finished.";
+
+const usjGen2: Usj = {
+  type: USJ_TYPE,
+  version: USJ_VERSION,
+  content: [
+    { type: "chapter", marker: "c", number: "2" },
+    {
+      type: "para",
+      marker: "p",
+      content: [
+        { type: "verse", marker: "v", number: "1" },
+        v1Text,
+        { type: "verse", marker: "v", number: "2" },
+        "On the seventh day God finished his work which he had done; and he rested on the seventh" +
+          " day from all his work which he had done.",
+        { type: "verse", marker: "v", number: "3" },
+        "God blessed the seventh day, and made it holy, because he rested in it from all his work" +
+          " of creation which he had done.",
+      ],
+    },
+  ],
+};
+
+// USJ content: [0]=chapter, [1]=para. Para content items: [0]=verse 1 marker, [1]=v1 text, ...
+const jsonPath = "$.content[1].content[1]";
+const earthStart = v1Text.indexOf("earth");
+const earthRange: AnnotationRange = {
+  start: { jsonPath, offset: earthStart },
+  end: { jsonPath, offset: earthStart + "earth".length },
+};
+
+// Used to pin the original defect's step 5: after the rewrap, every reported selection in that
+// paragraph (not just the annotated range itself) must still resolve to correct USJ coordinates.
+const allStart = v1Text.indexOf("all");
+const allRange: AnnotationRange = {
+  start: { jsonPath, offset: allStart },
+  end: { jsonPath, offset: allStart + "all".length },
+};
+
+const formattedViewOptions = getViewOptions("formatted");
+if (!formattedViewOptions) throw new Error("Expected formatted view options to exist");
+
+/**
+ * Both failing-mode variants: the minimal failing configuration (gutter only) and the original
+ * app configuration (`showCharMarkerTitles`/`hasGutterParaMarkers`/`hasActiveTextFocusBox` all
+ * on). The all-off configuration is the passing control below.
+ */
+const failingModeVariants: { name: string; viewOptions: ViewOptions }[] = [
+  {
+    name: "gutter only (minimal failing config)",
+    viewOptions: { ...formattedViewOptions, hasGutterParaMarkers: true },
+  },
+  {
+    name: "titles/gutter/focus-box all on",
+    viewOptions: {
+      ...formattedViewOptions,
+      showCharMarkerTitles: true,
+      hasGutterParaMarkers: true,
+      hasActiveTextFocusBox: true,
+    },
+  },
+];
+
+describe.each(failingModeVariants)(
+  "pending-comment rewrap in the real Editor, $name",
+  ({ viewOptions }) => {
+    it("fixture sanity: 'earth' USJ coordinates round-trip through the Editor selection API", async () => {
+      const editor = await createRealEditor(viewOptions, createLoggerMock());
+
+      await act(async () => {
+        editor.setSelection({ start: earthRange.start, end: earthRange.end });
+      });
+      const reported = editor.getSelection();
+
+      // If THIS fails the fixture/jsonPath assumptions are wrong — fix the test, not the code.
+      expect(reported?.start).toEqual(earthRange.start);
+      expect(reported?.end).toEqual(earthRange.end);
+    });
+
+    it("re-applies the same range after a pending wrap/unwrap cycle", async () => {
+      const logError = createLoggerMock();
+      const editor = await createRealEditor(viewOptions, logError);
+
+      // 1. Pending highlight (works in the app too).
+      await act(async () => {
+        editor.setAnnotation(earthRange, "translator-comment", "pending-comment");
+      });
+      expect(logError).not.toHaveBeenCalled();
+      expectDomMarkOver("earth");
+
+      // 2. Save removes the pending annotation (works in the app too).
+      await act(async () => {
+        editor.removeAnnotation("translator-comment", "pending-comment");
+      });
+      expectNoDomMarks();
+
+      // 3. Thread annotation with the SAME captured range. Did FAIL HERE, exactly like the app:
+      //    logger.error("Failed to find start or end node of the annotation.") and no mark is
+      //    created.
+      await act(async () => {
+        editor.setAnnotation(earthRange, "translator-comment", "thread-1");
+      });
+      expect(logError).not.toHaveBeenCalled();
+      expectDomMarkOver("earth");
+
+      // 4. Post-rewrap: selection reporting elsewhere in the same paragraph must still resolve to
+      //    correct, coalesced USJ coordinates. This pins step 5 of the original defect: after the
+      //    rewrap, every reported selection in that paragraph was wrong.
+      await act(async () => {
+        editor.setSelection({ start: allRange.start, end: allRange.end });
+      });
+      const reportedAfterRewrap = editor.getSelection();
+      expect(reportedAfterRewrap?.start).toEqual(allRange.start);
+      expect(reportedAfterRewrap?.end).toEqual(allRange.end);
+    });
+
+    it("re-applies when remove and set happen back-to-back in one update cycle", async () => {
+      // The app calls removeAnnotation + setAnnotation in ONE event handler, so cover the
+      // same-tick sequencing as its own case. Fails identically to the separate-act variant.
+      const logError = createLoggerMock();
+      const editor = await createRealEditor(viewOptions, logError);
+
+      await act(async () => {
+        editor.setAnnotation(earthRange, "translator-comment", "pending-comment");
+      });
+      await act(async () => {
+        editor.removeAnnotation("translator-comment", "pending-comment");
+        editor.setAnnotation(earthRange, "translator-comment", "thread-1");
+      });
+
+      expect(logError).not.toHaveBeenCalled();
+      expectDomMarkOver("earth");
+    });
+  },
+);
+
+describe("control: same lifecycle in the real Editor WITHOUT gutter para markers", () => {
+  it("re-applies the same range after a pending wrap/unwrap cycle (plain formatted view)", async () => {
+    // Passing control documenting the boundary: identical lifecycle, identical Editor, only
+    // `hasGutterParaMarkers` differs. (`showCharMarkerTitles: true` or
+    // `hasActiveTextFocusBox: true` alone also pass — verified during narrowing.)
+    const logError = createLoggerMock();
+    const editor = await createRealEditor(formattedViewOptions, logError);
+
+    await act(async () => {
+      editor.setAnnotation(earthRange, "translator-comment", "pending-comment");
+    });
+    await act(async () => {
+      editor.removeAnnotation("translator-comment", "pending-comment");
+    });
+    await act(async () => {
+      editor.setAnnotation(earthRange, "translator-comment", "thread-1");
+    });
+
+    expect(logError).not.toHaveBeenCalled();
+    expectDomMarkOver("earth");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers (after the tests; function declarations hoist)
+// ---------------------------------------------------------------------------
+
+/** A `vi.fn()` typed to satisfy `LoggerBasic`'s `(...params: unknown[]) => void` methods. */
+type LoggerMock = ReturnType<typeof vi.fn<(...params: unknown[]) => void>>;
+
+function createLoggerMock(): LoggerMock {
+  return vi.fn<(...params: unknown[]) => void>();
+}
+
+/**
+ * Mount the REAL platform Editor (full plugin stack) with the given view options and return its
+ * ref API — the same surface paranext-core drives.
+ */
+async function createRealEditor(
+  viewOptions: ViewOptions,
+  logError: LoggerMock,
+): Promise<EditorRef> {
+  const logger = {
+    error: logError,
+    warn: createLoggerMock(),
+    info: createLoggerMock(),
+    debug: createLoggerMock(),
+  };
+  const ref = createRef<EditorRef>();
+  await act(async () => {
+    render(
+      <Editor ref={ref} defaultUsj={usjGen2} options={{ view: viewOptions }} logger={logger} />,
+    );
+  });
+  if (!ref.current) throw new Error("EditorRef did not mount");
+  return ref.current;
+}
+
+/** Asserts exactly one rendered <mark> element exists and it wraps the expected text. */
+function expectDomMarkOver(expectedText: string) {
+  const markTexts = [...document.querySelectorAll("mark")].map((mark) => mark.textContent);
+  expect(markTexts).toEqual([expectedText]);
+}
+
+/** Asserts no rendered <mark> elements remain (annotation fully removed). */
+function expectNoDomMarks() {
+  expect(document.querySelectorAll("mark")).toHaveLength(0);
+}

--- a/packages/platform/src/editor/annotation-pending-rewrap.test.tsx
+++ b/packages/platform/src/editor/annotation-pending-rewrap.test.tsx
@@ -5,15 +5,16 @@
  * setAnnotation(threadId, same range). Confirmed failing in the app at the last step with
  * "Failed to find start or end node of the annotation."
  *
- * MINIMAL FAILING CONFIGURATION: the failure needs the REAL platform Editor (full plugin
- * stack, driven through its ref API like paranext does) with formatted view options plus
- * `hasGutterParaMarkers: true` — gutter mode renders paragraph markers as extra immutable
- * typed-text nodes in the tree. It does NOT reproduce in a minimal LexicalComposer harness
- * mounting only the AnnotationPlugin (even with identical view options passed to the USJ
- * adaptor), nor in the real Editor without the gutter option
- * (`showCharMarkerTitles`/`hasActiveTextFocusBox` alone don't trigger it either — see the
- * passing control below). Same-tick and separate-act sequencing fail identically at the
- * re-apply step; the pending annotation and its removal both work.
+ * Reproduces ONLY with: real platform Editor + formatted view + `hasGutterParaMarkers: true`.
+ * Does NOT reproduce with:
+ *   - a minimal LexicalComposer mounting only AnnotationPlugin (even with identical view options)
+ *   - the real Editor without the gutter option
+ *   - `showCharMarkerTitles` / `hasActiveTextFocusBox` alone (see the passing control)
+ *
+ * Detail: gutter mode renders paragraph markers as extra immutable typed-text nodes in the
+ * tree, and the failure needs the full plugin stack driven through the Editor's ref API like
+ * paranext does. Same-tick and separate-act sequencing fail identically at the re-apply step;
+ * the pending annotation and its removal both work.
  *
  * The suite covers both failing-mode variants (gutter-only minimal config, and
  * titles/gutter/focus-box all on — the original app configuration) plus the all-off passing


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-3835-part2

**Base**: pt-3835-annotation-selection (this branch is stacked on the PT-3835 branch / PR #496; diffing against `origin/main` would re-include the parent PR's already-reviewed changes)

**Date**: 2026-07-07

**Review model**: Claude Fable 5

**Files changed**: 3

## Overview

Follow-up fix for PT-3835, found while verifying the annotation-transparency fix in paranext-core. With gutter para markers enabled (formatted view), a paragraph's first child is a `\p` marker prefix node that `TextSpacingPlugin`'s `$verseNodeTransform` did not recognize, so the first editor update inserted a spurious single-space TextNode before verse 1. That space is real content to both the logical content model and the editor→USJ export, shifting every content index in the paragraph by one. In paranext-core's Insert Comment flow this made the thread annotation fail to re-apply after the pending annotation was removed ("Failed to find start or end node of the annotation.") and left every subsequent reported selection off by one, tripping the host's marker-validation guard. The same latent bug existed in plain visible-marker mode.

The fix is a one-line guard: exclude para marker prefixes (`$isParaMarkerPrefix`) from the transform's insert-space condition — marker prefixes carry their own trailing spacing. The transform's remaining insertion paths are intentional: the author verified in Paratext 9 that a space between a note/char and a following verse marker is *structural* (USJ→USFM conversion needs it; P9 re-inserts it when removed), so only the marker-prefix case was spurious. Coverage: a unit regression in `TextSpacingPlugin.test.tsx`, plus a lifecycle suite (`annotation-pending-rewrap.test.tsx`) mounting the real platform Editor and running the exact host flow under both failing-mode view-option variants plus an all-off passing control, asserting post-rewrap selections still report coalesced-USJ coordinates. The author retested in paranext-core: working in both Genesis 1 and Genesis 2 scenarios.

## API Changes

None. No public API surfaces changed:

- `packages/platform` (`@eten-tech-foundation/platform-editor`, published): only a new test file was added — no source or export changes.
- `libs/shared-react` (internal lib): `TextSpacingPlugin.tsx` changed internally (one added condition inside the non-exported `$verseNodeTransform`); the exported `TextSpacingPlugin` component's signature and exports are unchanged.
- `libs/shared`: not modified.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

None.

### Minor — Consider

- [x] Missing in-code rationale for the `!$isParaMarkerPrefix` exclusion in `TextSpacingPlugin.tsx` (the "why" lived only in tests and the commit message) _(fixed during review: comment added above the condition — marker prefixes carry their own trailing NBSP, and an inserted plain space becomes exporter-visible USJ content that shifts content indices; folded into the amended commit)_
- [ ] ~~Test-helper duplication between `annotation-pending-rewrap.test.tsx` (`createRealEditor`, DOM-mark helpers) and `Editor.test.tsx` (`createEditorRefForTesting`, `getMarkElement`)~~ _(author dismissed: same pattern, not verbatim duplication — the new helpers' parameterization (view options, injected logger error-spy, all-marks text assertions) is load-bearing; extract a shared helper when a third editor-lifecycle test file appears)_
- [x] The commit message's "known follow-up" (transform still inserts `" "` when a verse follows a NoteNode/CharNode) was untracked in code _(fixed during review — and reclassified: the author tested in Paratext 9 that this space is structural, not content — USJ→USFM conversion requires it and P9 re-inserts it when removed. No follow-up ticket needed; the commit message was amended to document that the remaining insertion paths are intentional and only the marker-prefix case was spurious)_
- [x] Process references in the lifecycle test's comments ("found by working the contingency ladder", "spec-mandated failing-mode variants") lacked context for future readers _(fixed during review: references trimmed; the boundary knowledge — minimal failing configuration and what does NOT reproduce — kept intact)_

[Author response: author requested fixes for three; the helper-duplication finding was dismissed with the extract-at-third-file rationale. The follow-up finding produced a genuine domain insight (structural vs content spaces) that reshaped the commit message rather than a ticket.]

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

None.

## Positive Observations

- The fix reuses the existing shared predicate `$isParaMarkerPrefix` rather than inlining node-type checks, covers both prefix flavors (editable `MarkerNode` and gutter/visible `ImmutableTypedTextNode`), and matches the transform's existing exclusion-list style exactly.
- The unit regression constructs the exact gutter-mode node shape the adaptor produces (`$createImmutableTypedTextNode("marker", openingMarkerText("p") + NBSP)`) rather than a stand-in, and is verifiably falsifiable (without the guard, the child count assertion fails).
- The lifecycle suite is exemplary regression engineering: it mounts the real `Editor` through the same `EditorRef` API paranext-core drives, includes a fixture-sanity test that distinguishes fixture bugs from code bugs, covers both failing-mode variants plus an all-off control, covers same-tick and separate-act sequencing (matching the app's single event handler), and pins the original defect's downstream symptom (post-rewrap selections elsewhere still report correct coalesced-USJ coordinates). The header documents the minimal failing configuration and what does NOT reproduce it.
- Both suites verified passing by multiple independent analyzers (18/18 unit, 7/7 lifecycle); RTL auto-cleanup prevents cross-test DOM contamination.
- Test placement and naming follow repo conventions; no localization, build-config, or shadcn surfaces touched.

## Interview Notes

- **Stated purpose**: from the branch commit message — stop `TextSpacingPlugin` inserting a spurious, index-shifting space after gutter para marker prefixes (PT-3835 follow-up found during core verification).
- **Key domain insight from the author**: when asked about tracking the "remaining insertion paths" as a follow-up bug, the author tested the behavior in Paratext 9 — deleting the space between a footnote/char and a following verse marker causes P9 to re-insert it, because that space is *structural* (required when converting USJ to USFM), not content. So the transform's remaining insertions are correct by design; only the marker-prefix case was spurious. The commit message was amended to record this.
- **Verification status**: the author retested in paranext-core — working in both Genesis 1 and Genesis 2 scenarios (the original 100%-reproducible failure is gone).
- **Open follow-up**: the paranext-core Playwright e2e tests (PT-3835 Definition of Done item) remain follow-up work in that repo.
- The author demonstrated clear understanding throughout — including independently testing conversion behavior in Paratext 9 to settle a finding. No uncertainty or AI-deferral observed.

## In-Review Quality Check

- `pnpm nx run-many -t typecheck`: all 10 projects pass.
- `pnpm nx lint shared-react` / `pnpm nx lint @eten-tech-foundation/platform-editor`: 0 errors.
- `pnpm nx format:check`: clean.
- Focused tests: `TextSpacingPlugin` 18/18, `annotation-pending-rewrap` 7/7.
- No auto-fixes needed; all in-review changes were comment-only. (Note: an earlier commit attempt surfaced that the repo still tracks `.claude/`/`CLAUDE.md` paths now replaced by ai-prompts symlinks on this machine, which broke lint-staged's backup — the author fixed the local state; a repo-level untrack+gitignore may be worth a separate change.)

## Suggested Review Focus

- [ ] The guard's blast radius: `$verseNodeTransform` no longer inserts a space after ANY para marker prefix in any mode — this also silently fixes the same latent bug in plain visible-marker mode. Confirm no visible-mode rendering depended on the old space (analysis found none: prefixes carry their own trailing NBSP).
- [ ] The structural-vs-content space distinction (author's Paratext 9 finding): spaces between note/char and a following verse are required for USJ→USFM conversion. Worth aligning on this as the documented rule for future TextSpacingPlugin work.
- [ ] The lifecycle suite (`annotation-pending-rewrap.test.tsx`) as a pattern: real-Editor-mount regression tests for host-flow bugs — consider whether future editor-level defects should get the same treatment.
- [ ] Stacking: this branch is based on `pt-3835-annotation-selection` (PR #496) — decide merge order / whether to fold into #496.
- [ ] Follow-up work: paranext-core Playwright e2e tests for the PT-3835 DoD.
<!-- review-paratext:summary:end -->

AI-assisted — [session](<session URL>)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/497)
<!-- Reviewable:end -->
