### PR TITLE
platform: stop stale book echo when the host navigates across books

### DIFF
--- a/packages/platform/src/editor/ScriptureReferencePlugin.test.tsx
+++ b/packages/platform/src/editor/ScriptureReferencePlugin.test.tsx
@@ -90,7 +90,7 @@ describe("ScriptureReferencePlugin", () => {
       // async load). scrRef.book already matches the content at mount, so no sync fires yet.
       const { setScrRef } = await testEnvironment(scrRef, mockOnScrRefChange);
 
-      // Host navigates across books (e.g. NUM -> LEV): scrRef now targets a different book (and
+      // Host navigates across books (here GEN -> EXO): scrRef now targets a different book (and
       // a verse that still exists in the stale document, isolating this test to the book-sync
       // listener rather than the separate cursor-placement/BCV path), but the editor still
       // contains the OLD book's BookNode.

--- a/packages/platform/src/editor/ScriptureReferencePlugin.test.tsx
+++ b/packages/platform/src/editor/ScriptureReferencePlugin.test.tsx
@@ -83,6 +83,23 @@ describe("ScriptureReferencePlugin", () => {
 
       expect(mockOnScrRefChange).not.toHaveBeenCalled();
     });
+
+    it("should not echo the stale document's book when scrRef navigates to a different book while the old document is still loaded", async () => {
+      // Content stays on GEN (the old document hasn't been swapped in yet - simulates the
+      // window between a host navigating across books and the new book's USJ finishing its
+      // async load). scrRef.book already matches the content at mount, so no sync fires yet.
+      const { setScrRef } = await testEnvironment(scrRef, mockOnScrRefChange);
+
+      // Host navigates across books (e.g. NUM -> LEV): scrRef now targets a different book (and
+      // a verse that still exists in the stale document, isolating this test to the book-sync
+      // listener rather than the separate cursor-placement/BCV path), but the editor still
+      // contains the OLD book's BookNode.
+      await setScrRef({ book: "EXO", chapterNum: 1, verseNum: 2 });
+
+      // The plugin must not echo the stale document's book back to the host combined with the
+      // new chapter/verse - that would corrupt the navigation (e.g. EXO 1:2 -> GEN 1:2).
+      expect(mockOnScrRefChange).not.toHaveBeenCalled();
+    });
   });
 
   describe("Selection Change", () => {

--- a/packages/platform/src/editor/ScriptureReferencePlugin.tsx
+++ b/packages/platform/src/editor/ScriptureReferencePlugin.tsx
@@ -87,16 +87,13 @@ export default function ScriptureReferencePlugin({
     [editor, chapterNum, verseNum],
   );
 
-  // Book node sync: correct scrRef.book to match the *currently loaded document's* BookNode
-  // (initial tree + later updates/replacements). Registered once per editor instance ([editor]
-  // only) rather than re-registering on every chapterNum/verseNum change - scrRefRef/
-  // onScrRefChangeRef already track the latest values, so re-registration isn't needed for
-  // freshness, and re-registering would replay the skipInitialization: false initialization pass
-  // against whatever document is currently mounted. On a chapter/verse-only navigation (or a
-  // cross-book navigation still awaiting its new document to load) that document is stale, so a
-  // replay would incorrectly echo the OLD book paired with the NEW chapter/verse back to the
-  // host. Registering once means this only fires for genuine BookNode mutations: the initial
-  // mount (skipInitialization: false's replay) and any later real document swap.
+  // Book node sync: correct scrRef.book to match the currently loaded document's BookNode.
+  // Fires on every non-destroyed BookNode mutation (initial-mount replay + later swaps); the
+  // `code !== current.book` guard below is what makes stray firings harmless. Registered once
+  // per editor ([editor] only), NOT re-registered on chapterNum/verseNum change: the refs
+  // already keep values fresh, and re-registering would replay skipInitialization: false against
+  // the still-mounted (stale) document on every navigation, echoing the OLD book with the NEW
+  // chapter/verse back to the host.
   useEffect(
     () =>
       editor.registerMutationListener(

--- a/packages/platform/src/editor/ScriptureReferencePlugin.tsx
+++ b/packages/platform/src/editor/ScriptureReferencePlugin.tsx
@@ -60,53 +60,67 @@ export default function ScriptureReferencePlugin({
     onScrRefChangeRef.current = onScrRefChange;
   }, [scrRef, onScrRefChange]);
 
-  // Book node: move cursor when a new BookNode appears after load; sync scrRef.book when the
-  // book code changes (initial tree + updates). Uses a second listener with skipInitialization:
-  // false so existing BookNodes from initial editor state are included (updateListener ran on
-  // every keystroke; this only runs when BookNodes are created/updated).
+  // Book node created: move cursor to the verse start once a new BookNode appears after the
+  // initial load (e.g. a different book's document has finished mounting). Re-registers on every
+  // chapterNum/verseNum change so the closure captures the latest target position; safe to
+  // re-register because skipInitialization: true means re-registering never replays existing
+  // BookNodes, only genuinely new "created" mutations going forward.
   useEffect(
     () =>
-      mergeRegister(
-        editor.registerMutationListener(
-          BookNode,
-          (nodeMutations) => {
-            editor.update(
-              () => {
-                for (const [nodeKey, mutation] of nodeMutations) {
-                  const bookNode = $getNodeByKey<BookNode>(nodeKey);
-                  if (bookNode && $isBookNode(bookNode) && mutation === "created") {
-                    $moveCursorToVerseStart(chapterNum, verseNum, hasCursorMovedRef);
-                  }
+      editor.registerMutationListener(
+        BookNode,
+        (nodeMutations) => {
+          editor.update(
+            () => {
+              for (const [nodeKey, mutation] of nodeMutations) {
+                const bookNode = $getNodeByKey<BookNode>(nodeKey);
+                if (bookNode && $isBookNode(bookNode) && mutation === "created") {
+                  $moveCursorToVerseStart(chapterNum, verseNum, hasCursorMovedRef);
                 }
-              },
-              { tag: CURSOR_CHANGE_TAG },
-            );
-          },
-          { skipInitialization: true },
-        ),
-        editor.registerMutationListener(
-          BookNode,
-          (nodeMutations) => {
-            editor.update(
-              () => {
-                for (const [nodeKey, mutation] of nodeMutations) {
-                  if (mutation === "destroyed") continue;
-                  const bookNode = $getNodeByKey<BookNode>(nodeKey);
-                  if (!bookNode || !$isBookNode(bookNode)) continue;
-                  const code = bookNode.getCode();
-                  const current = scrRefRef.current;
-                  if (code && code !== current.book) {
-                    onScrRefChangeRef.current({ ...current, book: code });
-                  }
-                }
-              },
-              { tag: CURSOR_CHANGE_TAG },
-            );
-          },
-          { skipInitialization: false },
-        ),
+              }
+            },
+            { tag: CURSOR_CHANGE_TAG },
+          );
+        },
+        { skipInitialization: true },
       ),
     [editor, chapterNum, verseNum],
+  );
+
+  // Book node sync: correct scrRef.book to match the *currently loaded document's* BookNode
+  // (initial tree + later updates/replacements). Registered once per editor instance ([editor]
+  // only) rather than re-registering on every chapterNum/verseNum change - scrRefRef/
+  // onScrRefChangeRef already track the latest values, so re-registration isn't needed for
+  // freshness, and re-registering would replay the skipInitialization: false initialization pass
+  // against whatever document is currently mounted. On a chapter/verse-only navigation (or a
+  // cross-book navigation still awaiting its new document to load) that document is stale, so a
+  // replay would incorrectly echo the OLD book paired with the NEW chapter/verse back to the
+  // host. Registering once means this only fires for genuine BookNode mutations: the initial
+  // mount (skipInitialization: false's replay) and any later real document swap.
+  useEffect(
+    () =>
+      editor.registerMutationListener(
+        BookNode,
+        (nodeMutations) => {
+          editor.update(
+            () => {
+              for (const [nodeKey, mutation] of nodeMutations) {
+                if (mutation === "destroyed") continue;
+                const bookNode = $getNodeByKey<BookNode>(nodeKey);
+                if (!bookNode || !$isBookNode(bookNode)) continue;
+                const code = bookNode.getCode();
+                const current = scrRefRef.current;
+                if (code && code !== current.book) {
+                  onScrRefChangeRef.current({ ...current, book: code });
+                }
+              }
+            },
+            { tag: CURSOR_CHANGE_TAG },
+          );
+        },
+        { skipInitialization: false },
+      ),
+    [editor],
   );
 
   // Scripture Reference changed


### PR DESCRIPTION
## Problem

When a host application (Platform.Bible) navigates the scripture reference across a book boundary — e.g. NUM 1 → "previous chapter" → LEV 27:1 — the editor echoes a corrupted reference back through `onScrRefChange`: the OLD book with the NEW chapter/verse (`NUM 27:1`). The host's navigation is overwritten and the user lands on chapter 27 of the wrong book.

## What broke, and where

#457 added the BookNode **book-sync listener** (`skipInitialization: false`) to `ScriptureReferencePlugin`, so the ref's `book` follows the loaded document — a legitimate and still-desired behavior. That PR also added `scrRefRef`/`onScrRefChangeRef` refs specifically so the listener could read current values **without re-registering** (its comment says it should "only run when BookNodes are created/updated").

However, the listener was registered inside the pre-existing `useEffect` keyed on `[editor, chapterNum, verseNum]`. Every chapter/verse-only navigation therefore tears down and re-registers the listener, and because it uses `skipInitialization: false`, each re-registration replays initialization against the **still-mounted old document** (the new book's content loads async in the host). During that window `scrRefRef.current` already holds the new ref (LEV 27:1) while the stale document's BookNode still reads `NUM` → the listener fires `onScrRefChange({ ...current, book: 'NUM' })` → NUM 27:1.

## Fix — preserving #457's intent

Split the two BookNode listeners into separate effects:

- The **book-sync listener** now registers once per editor (`[editor]` deps), reading current values through the refs #457 already added for exactly this purpose. Its mount-time initialization still performs the legitimate book correction #457 introduced, and it still reacts to genuine BookNode created/updated mutations — it just no longer replays against a stale document on every chapter/verse navigation.
- The **cursor-move listener** keeps its original deps and behavior, byte-identical.

This completes the design #457's own refs and comment describe, rather than changing what the listener is for.

## Testing

- New regression test: ref moves to a different book while the old document is still loaded → `onScrRefChange` must NOT fire with the old book. Fails on the pre-fix code with exactly the production echo shape; passes with the fix.
- The three pre-existing book-sync tests (mount-time correction) pass **unmodified**; full platform-editor suite 116 passed / 3 skipped; whole-monorepo test/lint/typecheck/format clean.
- Live-verified in Platform.Bible via a local yalc build: NUM 1 → previous chapter lands and stays on LEV 27:1 (polled ~5s for late echoes); same-book navigation, in-editor verse-click ref updates, in-editor book jumps, and fresh-editor loads all behave.

AI-assisted (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/498)
<!-- Reviewable:end -->
