### PR TITLE
platform: rebuild ScriptureReferencePlugin as a navigation state machine

### DIFF
--- a/packages/platform/src/editor/ScriptureReferencePlugin.test.tsx
+++ b/packages/platform/src/editor/ScriptureReferencePlugin.test.tsx
@@ -233,7 +233,8 @@ describe("ScriptureReferencePlugin", () => {
           verse1Key = nodeWithVerse1.getFirstChild()?.getKey();
         }
       });
-      // Clear hasCursorMovedRef (set by initial "move cursor to verse start" effect) so our dispatch runs BCV logic.
+      // First dispatch consumes the mount cursor-placement suppression in the old code and is a
+      // no-op report (position == scrRef) in the new code.
       await act(async () => {
         editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
       });
@@ -519,12 +520,11 @@ describe("ScriptureReferencePlugin", () => {
       await setScrRef({ book: "GEN", chapterNum: 1, verseNum: 0 });
       await flushQueuedEvents();
 
-      // Nothing echoed; the caret left the old position toward the chapter top region.
+      // Nothing echoed; the caret landed at the chapter top - verse 0 places at the start of the
+      // chapter's first para (the section head).
       expect(mockOnScrRefChange).not.toHaveBeenCalled();
       editor.getEditorState().read(() => {
-        const selection = $getSelection();
-        const startNode = getSelectionStartNodeForTest(selection);
-        expect(startNode?.getTextContent()).not.toBe("second verse text ");
+        $expectSelectionToBe(sectionTextNode, 0);
       });
     });
 
@@ -605,6 +605,30 @@ describe("ScriptureReferencePlugin", () => {
       // the prop's book (I1's documented fallback) with the document's chapter/verse.
       expect(mockOnScrRefChange).toHaveBeenCalledWith(
         expect.objectContaining({ book: "GEN", chapterNum: 1, verseNum: 2 }),
+      );
+    });
+
+    it("carries the host's versificationStr on position reports", async () => {
+      const { editor } = await testEnvironment(
+        { book: "GEN", chapterNum: 1, verseNum: 1, versificationStr: "English" },
+        mockOnScrRefChange,
+      );
+      await pressEditor(editor);
+
+      updateSelection(editor, secondVerseTextNode, 2);
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+
+      // A document states no versification, so the host's must ride along - a report that strips
+      // it could map to the wrong physical verse under a divergent versification.
+      expect(mockOnScrRefChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          book: "GEN",
+          chapterNum: 1,
+          verseNum: 2,
+          versificationStr: "English",
+        }),
       );
     });
 
@@ -749,6 +773,29 @@ describe("ScriptureReferencePlugin", () => {
       expect(mockOnScrRefChange).toHaveBeenCalledWith(
         expect.objectContaining({ book: "GEN", chapterNum: 1, verseNum: 3 }),
       );
+    });
+
+    it("emits nothing when a verse number is malformed (non-numeric)", async () => {
+      let malformedVerseText: TextNode | undefined;
+      const { editor } = await testEnvironment(scrRef, mockOnScrRefChange, () => {
+        malformedVerseText = $createTextNode("unnumbered verse text ");
+        $getRoot().append(
+          $createBookNode("GEN").append($createTextNode("Test Book")),
+          $createImmutableChapterNode("1"),
+          $createParaNode().append($createImmutableVerseNode("x"), malformedVerseText),
+        );
+      });
+      await pressEditor(editor);
+      if (!malformedVerseText) throw new Error("fixture text not found");
+
+      updateSelection(editor, malformedVerseText, 2);
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+      await flushQueuedEvents();
+
+      // I5: a verse whose number does not parse addresses nothing - silence, not {verseNum: NaN}.
+      expect(mockOnScrRefChange).not.toHaveBeenCalled();
     });
 
     it("closes the navigation window on beforeinput (IME/voice/paste input paths)", async () => {

--- a/packages/platform/src/editor/ScriptureReferencePlugin.test.tsx
+++ b/packages/platform/src/editor/ScriptureReferencePlugin.test.tsx
@@ -23,10 +23,55 @@ import {
   SELECTION_CHANGE_COMMAND,
   $createTextNode,
   LexicalEditor,
+  $getSelection,
 } from "lexical";
+import type { BaseSelection } from "lexical";
 import { useEffect, useState } from "react";
-import { $createBookNode, $createImmutableChapterNode, $createParaNode } from "shared";
+import {
+  $createBookNode,
+  $createImmutableChapterNode,
+  $createParaNode,
+  $isBookNode,
+  getSelectionStartNode,
+} from "shared";
 import { $createImmutableVerseNode, usjReactNodes } from "shared-react";
+
+beforeAll(() => {
+  // jsdom has no layout engine, so it never implemented `Range.getBoundingClientRect` (unlike
+  // `Element.getBoundingClientRect`, which jsdom stubs to an empty rect). Lexical's
+  // updateDOMSelection reads it on the scroll-into-view path: for a collapsed selection it
+  // resolves `selectionTarget` to either an element child (offset lookup) or, when the native
+  // DOM selection doesn't resolve to an element boundary, `domSelection.getRangeAt(0)` - a Range
+  // over a Text node, which is what the plugin's document-swap cursor placement
+  // (`verseOrParaNode.select(0, 0)` in $moveCursorToVerseStart) produces here. Without this shim
+  // that call throws "selectionTarget.getBoundingClientRect is not a function" from inside
+  // Lexical's async $commitPendingUpdates (see node_modules/lexical/Lexical.dev.mjs:7931),
+  // outside any test's promise chain, so it surfaces as an unhandled error rather than a test
+  // failure. An empty DOMRect is the standard, semantically-truthful stand-in: jsdom has no real
+  // layout to report.
+  Range.prototype.getBoundingClientRect = () => new DOMRect();
+
+  // jsdom's HTMLElement.focus() collapses the document Selection to the start of the focused
+  // element; a real browser preserves an existing in-element selection across focus(). Lexical's
+  // updateDOMSelection calls `rootElement.focus({ preventScroll: true })` on its "DOM selection
+  // already matches the target" branch (a cursor-visibility ensure-focus) whenever the root isn't
+  // document.activeElement - which, after a mutating editor.update that leaves the caret unmoved
+  // (e.g. appending an unrelated node), is exactly the branch taken. In a real browser that call
+  // is a harmless no-op for the selection; in jsdom it wipes the caret the reconcile just
+  // confirmed, and a later deferred native `selectionchange` reads the corrupted (collapsed-to-
+  // start) selection back into the editor state. Restoring the pre-focus range models the real
+  // browser and keeps the caret where Lexical placed it.
+  const originalFocus = HTMLElement.prototype.focus;
+  HTMLElement.prototype.focus = function focus(options?: FocusOptions) {
+    const selection = document.getSelection();
+    const savedRange = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : undefined;
+    originalFocus.call(this, options);
+    if (savedRange && selection) {
+      selection.removeAllRanges();
+      selection.addRange(savedRange);
+    }
+  };
+});
 
 let sectionTextNode: TextNode;
 let firstVerseTextNode: TextNode;
@@ -210,6 +255,520 @@ describe("ScriptureReferencePlugin", () => {
       );
     });
   });
+
+  describe("Characterization (pinned behavior, old and new implementation)", () => {
+    it("reports a genuine selection change in another verse", async () => {
+      const { editor } = await testEnvironment(scrRef, mockOnScrRefChange);
+      // First dispatch consumes the mount cursor-placement suppression in the old code and is a
+      // no-op report (position == scrRef) in the new code.
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+      mockOnScrRefChange.mockClear();
+
+      updateSelection(editor, secondVerseTextNode, 2);
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+      await flushQueuedEvents();
+
+      expect(mockOnScrRefChange).toHaveBeenCalled();
+      // Under a non-echoing test host the pre-rework implementation may report the same position a
+      // second time when jsdom's queued native selectionchange replays (the host never updates the
+      // prop, so the position still differs from it). Identical duplicates are tolerated by this pin;
+      // any call with a DIFFERENT payload is a regression.
+      mockOnScrRefChange.mock.calls.forEach(([reported]) => {
+        expect(reported).toMatchObject({ book: "GEN", chapterNum: 1, verseNum: 2 });
+      });
+    });
+
+    it("does not move the caret when our own report echoes back as the prop", async () => {
+      const { editor, setScrRef } = await testEnvironment(scrRef, mockOnScrRefChange);
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+      updateSelection(editor, secondVerseTextNode, 5);
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+      expect(mockOnScrRefChange).toHaveBeenCalledWith(expect.objectContaining({ verseNum: 2 }));
+
+      // The host reflects our report back verbatim - the caret must stay exactly where it was
+      // (mid-verse, offset 5), not snap to the verse start.
+      await setScrRef({ book: "GEN", chapterNum: 1, verseNum: 2 });
+      await flushQueuedEvents();
+
+      editor.getEditorState().read(() => {
+        $expectSelectionToBe(secondVerseTextNode, 5);
+      });
+    });
+
+    it("corrects the host's book exactly once on an in-editor document swap", async () => {
+      const { editor } = await testEnvironment(scrRef, mockOnScrRefChange);
+
+      await swapDocument(editor, () => $appendScrRefPluginFixture("EXO"));
+      await flushQueuedEvents();
+
+      expect(mockOnScrRefChange).toHaveBeenCalledTimes(1);
+      expect(mockOnScrRefChange).toHaveBeenCalledWith(
+        expect.objectContaining({ book: "EXO", chapterNum: 1, verseNum: 1 }),
+      );
+    });
+
+    it("reports 1:0 for a click in book-intro content before the first chapter", async () => {
+      const { editor } = await testEnvironment(scrRef, mockOnScrRefChange);
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+      mockOnScrRefChange.mockClear();
+      let bookTitleTextNode: TextNode | undefined;
+      editor.getEditorState().read(() => {
+        const bookNode = $getRoot().getFirstChild();
+        if (bookNode && $isElementNode(bookNode)) {
+          const child = bookNode.getFirstChild();
+          if (child instanceof TextNode) bookTitleTextNode = child;
+        }
+      });
+      if (!bookTitleTextNode) throw new Error("fixture book title not found");
+
+      updateSelection(editor, bookTitleTextNode, 2);
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+
+      // Content before \c 1 addresses as chapter 1 verse 0 (USFM convention).
+      expect(mockOnScrRefChange).toHaveBeenCalledWith(
+        expect.objectContaining({ book: "GEN", chapterNum: 1, verseNum: 0 }),
+      );
+    });
+  });
+
+  describe("Navigation races", () => {
+    it("emits nothing while an external navigation to a not-yet-loaded chapter settles, then lands on the target", async () => {
+      const { editor, setScrRef } = await testEnvironment(scrRef, mockOnScrRefChange);
+
+      // Host navigates to GEN 2:9; chapter 2's content has not loaded (document still chapter 1).
+      await setScrRef({ book: "GEN", chapterNum: 2, verseNum: 9 });
+
+      // The editor settles the caret somewhere in the stale content (e.g. the section head) and a
+      // selectionchange fires - the pre-fix code reports this settle as a user move (verse 0 /
+      // wrong chapter), corrupting the navigation.
+      updateSelection(editor, sectionTextNode, 0);
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+      await flushQueuedEvents();
+      expect(mockOnScrRefChange).not.toHaveBeenCalled();
+
+      // Chapter 2's document arrives (full swap, like LoadStatePlugin).
+      await swapDocument(editor, $chapter2State);
+      await flushQueuedEvents();
+
+      // The caret landed on the navigation target and nothing was ever echoed to the host.
+      expect(mockOnScrRefChange).not.toHaveBeenCalled();
+      editor.getEditorState().read(() => {
+        const selection = $getSelection();
+        const startNode = getSelectionStartNodeForTest(selection);
+        expect(startNode?.getTextContent()).toBe("verse nine ");
+      });
+    });
+
+    it("keeps the caret still when two reports echo back in order (FIFO, not a slot)", async () => {
+      const { editor, setScrRef } = await testEnvironment(scrRef, mockOnScrRefChange);
+      await pressEditor(editor); // ensure idle
+      // Report #1: verse 2. Report #2: verse 3 (range 3-4). Both before any echo returns.
+      updateSelection(editor, secondVerseTextNode, 1);
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+      updateSelection(editor, thirdVerseTextNode, 4);
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+      expect(mockOnScrRefChange).toHaveBeenCalledTimes(2);
+      const [firstEcho] = mockOnScrRefChange.mock.calls[0];
+      const [secondEcho] = mockOnScrRefChange.mock.calls[1];
+      mockOnScrRefChange.mockClear();
+
+      // Host echoes both, in order. Neither may move the caret off thirdVerse offset 4.
+      await setScrRef(firstEcho);
+      await setScrRef(secondEcho);
+      await flushQueuedEvents();
+
+      editor.getEditorState().read(() => {
+        $expectSelectionToBe(thirdVerseTextNode, 4);
+      });
+      expect(mockOnScrRefChange).not.toHaveBeenCalled();
+    });
+
+    it("does not report a stale settle from a superseded navigation (rapid list navigation)", async () => {
+      const { editor, setScrRef } = await testEnvironment(scrRef, mockOnScrRefChange);
+
+      // Item A: GEN 1:2 (content present, cursor placed). Item B follows before A's queued
+      // selectionchange fires.
+      await setScrRef({ book: "GEN", chapterNum: 1, verseNum: 2 });
+      await setScrRef({ book: "GEN", chapterNum: 2, verseNum: 9 });
+
+      // A's queued settle now fires, describing the verse-2 position - obsolete. Must be silent.
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+      await flushQueuedEvents();
+      expect(mockOnScrRefChange).not.toHaveBeenCalled();
+
+      // B's chapter arrives and the caret lands on 2:9; still nothing echoed.
+      await swapDocument(editor, $chapter2State);
+      await flushQueuedEvents();
+      expect(mockOnScrRefChange).not.toHaveBeenCalled();
+    });
+
+    it("treats an echo arriving after a newer external navigation as external (documented trade-off)", async () => {
+      const { editor, setScrRef } = await testEnvironment(scrRef, mockOnScrRefChange);
+      await pressEditor(editor);
+      updateSelection(editor, secondVerseTextNode, 1);
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+      const [ourReport] = mockOnScrRefChange.mock.calls[0];
+      mockOnScrRefChange.mockClear();
+
+      // A newer external navigation clears the pending-echo queue...
+      await setScrRef({ book: "GEN", chapterNum: 1, verseNum: 3 });
+      // ...so our old report arriving late is (deliberately) treated as a real navigation: the
+      // caret moves to it. Reordered host writes are the host's statement of intent.
+      await setScrRef(ourReport);
+      await flushQueuedEvents();
+
+      editor.getEditorState().read(() => {
+        $expectSelectionToBe(secondVerseTextNode, 0);
+      });
+    });
+
+    it("ignores a superseded book's document landing during a newer navigation", async () => {
+      const { editor, setScrRef } = await testEnvironment(scrRef, mockOnScrRefChange);
+
+      // GEN -> EXO 3:2 -> LEV 5:1 in quick succession; then EXO's USJ lands late.
+      await setScrRef({ book: "EXO", chapterNum: 3, verseNum: 2 });
+      await setScrRef({ book: "LEV", chapterNum: 5, verseNum: 1 });
+      await swapDocument(editor, () => $appendScrRefPluginFixture("EXO"));
+      await flushQueuedEvents();
+
+      // The late EXO arrival must not hijack the LEV navigation: no emission at all.
+      expect(mockOnScrRefChange).not.toHaveBeenCalled();
+    });
+
+    it("does not echo the stale book when its BookNode is edited during a cross-book navigation", async () => {
+      const { editor, setScrRef } = await testEnvironment(scrRef, mockOnScrRefChange);
+
+      // Host navigates GEN -> EXO 1:2; GEN's document is still mounted, awaiting EXO's USJ.
+      await setScrRef({ book: "EXO", chapterNum: 1, verseNum: 2 });
+
+      // A structural edit clones GEN's BookNode ("updated" mutation) - e.g. a remote delta on the
+      // \id line. Pre-fix, this re-emitted {book: GEN, chapterNum: 1, verseNum: 2}.
+      await act(async () => {
+        editor.update(() => {
+          const bookNode = $getRoot().getChildren().find($isBookNode);
+          bookNode?.append($createTextNode(" edited"));
+        });
+      });
+      await flushQueuedEvents();
+
+      expect(mockOnScrRefChange).not.toHaveBeenCalled();
+    });
+
+    it("syncs from the first BookNode only when a document has strays", async () => {
+      const { editor } = await testEnvironment(scrRef, mockOnScrRefChange);
+
+      // A stray second BookNode (malformed USJ / cross-editor paste) appears. The first (GEN)
+      // matches scrRef, so nothing may be emitted - the stray EXO must not drive a correction.
+      await act(async () => {
+        editor.update(() => {
+          $getRoot().append($createBookNode("EXO").append($createTextNode("Stray")));
+        });
+      });
+      await flushQueuedEvents();
+
+      expect(mockOnScrRefChange).not.toHaveBeenCalled();
+    });
+
+    it("reports the user's first click after a navigation (window closes on pointerdown)", async () => {
+      const { editor, setScrRef } = await testEnvironment(scrRef, mockOnScrRefChange);
+
+      // Navigation is still settling (chapter 2 never loads - worst case).
+      await setScrRef({ book: "GEN", chapterNum: 2, verseNum: 9 });
+      expect(mockOnScrRefChange).not.toHaveBeenCalled();
+
+      // The user clicks verse 2 in the (stale) document: pointerdown fires before the click's
+      // selectionchange, so the window is closed by the time the position reports.
+      await pressEditor(editor);
+      updateSelection(editor, secondVerseTextNode, 3);
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+
+      expect(mockOnScrRefChange).toHaveBeenCalledTimes(1);
+      expect(mockOnScrRefChange).toHaveBeenCalledWith(
+        expect.objectContaining({ book: "GEN", chapterNum: 1, verseNum: 2 }),
+      );
+    });
+
+    it("applies a navigation to verse 0 (chapter top) without echoing anything", async () => {
+      const { editor, setScrRef } = await testEnvironment(scrRef, mockOnScrRefChange);
+      updateSelection(editor, secondVerseTextNode, 3);
+
+      await setScrRef({ book: "GEN", chapterNum: 1, verseNum: 0 });
+      await flushQueuedEvents();
+
+      // Nothing echoed; the caret left the old position toward the chapter top region.
+      expect(mockOnScrRefChange).not.toHaveBeenCalled();
+      editor.getEditorState().read(() => {
+        const selection = $getSelection();
+        const startNode = getSelectionStartNodeForTest(selection);
+        expect(startNode?.getTextContent()).not.toBe("second verse text ");
+      });
+    });
+
+    it("does not swallow the first user click after navigation in a read-only editor", async () => {
+      const { editor, setScrRef } = await testEnvironment(scrRef, mockOnScrRefChange);
+      await act(async () => {
+        editor.setEditable(false);
+      });
+
+      // Host navigates; in read-only editors Lexical skips the DOM-selection write, so no native
+      // selectionchange ever consumes anything. The pre-fix one-shot flag stayed armed here.
+      await setScrRef({ book: "GEN", chapterNum: 1, verseNum: 2 });
+
+      // First real user click must report - state-based suppression cannot wedge.
+      await pressEditor(editor);
+      // Nested dispatch mirrors Lexical's onSelectionChange delivery (document-level selectionchange
+      // is ungated by editability).
+      await act(async () => {
+        editor.update(() => {
+          const selection = $createRangeSelection();
+          selection.anchor = $createPoint(thirdVerseTextNode.getKey(), 1, "text");
+          selection.focus = $createPoint(thirdVerseTextNode.getKey(), 1, "text");
+          $setSelection(selection);
+          editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+        });
+      });
+
+      expect(mockOnScrRefChange).toHaveBeenCalledWith(
+        expect.objectContaining({ book: "GEN", chapterNum: 1, verseNum: 3, verse: "3-4" }),
+      );
+    });
+
+    it("does not move the caret into a wrong-book document arriving mid-navigation (placement gate)", async () => {
+      const { editor, setScrRef } = await testEnvironment(scrRef, mockOnScrRefChange);
+      updateSelection(editor, secondVerseTextNode, 3);
+
+      // Host navigates to LEV 1:2; GEN stays mounted (LEV's document never arrives).
+      await setScrRef({ book: "LEV", chapterNum: 1, verseNum: 2 });
+
+      // A superseded EXO document arrives - the wrong book for the in-flight LEV navigation.
+      // The machine must neither emit nor place the caret at the navigation's chapter/verse
+      // inside this wrong-book document (placement targets only the navigation's own book).
+      await swapDocument(editor, () => $appendScrRefPluginFixture("EXO"));
+      await flushQueuedEvents();
+
+      expect(mockOnScrRefChange).not.toHaveBeenCalled();
+      editor.getEditorState().read(() => {
+        const startNode = getSelectionStartNodeForTest($getSelection());
+        // A wrongly-fired placement would land exactly here: EXO's verse-2 text at offset 0.
+        expect(startNode?.getTextContent()).not.toBe("second verse text ");
+      });
+    });
+
+    it("falls back to the prop book for position reports when the document has no book code", async () => {
+      const { editor } = await testEnvironment(scrRef, mockOnScrRefChange, () =>
+        $appendScrRefPluginFixture(""),
+      );
+      await flushQueuedEvents();
+      mockOnScrRefChange.mockClear();
+      await pressEditor(editor);
+
+      let emptyCodeVerse2Text: TextNode | undefined;
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getChildAtIndex(4); // book, chapter, section, verse-1 para, verse-2 para
+        if (para && $isElementNode(para)) {
+          const last = para.getLastChild();
+          if (last instanceof TextNode) emptyCodeVerse2Text = last;
+        }
+      });
+      if (!emptyCodeVerse2Text) throw new Error("empty-code fixture verse-2 text not found");
+
+      updateSelection(editor, emptyCodeVerse2Text, 2);
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+
+      // The document's BookNode has code "" - it cannot name its own book, so the report carries
+      // the prop's book (I1's documented fallback) with the document's chapter/verse.
+      expect(mockOnScrRefChange).toHaveBeenCalledWith(
+        expect.objectContaining({ book: "GEN", chapterNum: 1, verseNum: 2 }),
+      );
+    });
+
+    it("emits nothing for a selection in a document with no book and no chapter (unaddressable)", async () => {
+      let looseTextNode: TextNode | undefined;
+      const { editor } = await testEnvironment(scrRef, mockOnScrRefChange, () => {
+        looseTextNode = $createTextNode("loose text outside any book or chapter");
+        $getRoot().append($createParaNode().append(looseTextNode));
+      });
+      await flushQueuedEvents();
+      mockOnScrRefChange.mockClear();
+      await pressEditor(editor);
+      if (!looseTextNode) throw new Error("loose fixture text not found");
+
+      updateSelection(editor, looseTextNode, 2);
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+      await flushQueuedEvents();
+
+      // I5: a document with no BookNode and no ChapterNode cannot address any position - silence.
+      expect(mockOnScrRefChange).not.toHaveBeenCalled();
+    });
+
+    it("clears earlier pending echoes when a later report's echo returns (batched host)", async () => {
+      const { editor, setScrRef } = await testEnvironment(scrRef, mockOnScrRefChange);
+      await pressEditor(editor);
+      // Two reports in flight: verse 2, then verse 3 (range 3-4).
+      updateSelection(editor, secondVerseTextNode, 1);
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+      updateSelection(editor, thirdVerseTextNode, 4);
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+      expect(mockOnScrRefChange).toHaveBeenCalledTimes(2);
+      const [, [secondReport]] = mockOnScrRefChange.mock.calls;
+      mockOnScrRefChange.mockClear();
+
+      // A batching host renders only the LAST state: only the second report echoes back. Consuming
+      // it must splice through the queue (clearing the first report's pending echo too).
+      await setScrRef(secondReport);
+      await flushQueuedEvents();
+      editor.getEditorState().read(() => {
+        $expectSelectionToBe(thirdVerseTextNode, 4);
+      });
+
+      // The first report's ref must NOT linger as a pending echo: a genuine external navigation to
+      // that same ref must be APPLIED (caret moves), not swallowed as our own echo returning.
+      await setScrRef({ book: "GEN", chapterNum: 1, verseNum: 2 });
+      await flushQueuedEvents();
+      editor.getEditorState().read(() => {
+        $expectSelectionToBe(secondVerseTextNode, 0);
+      });
+    });
+
+    it("does not reset the verse on an idle same-book reload (view-option toggle)", async () => {
+      const { editor } = await testEnvironment(
+        { book: "GEN", chapterNum: 1, verseNum: 2 },
+        mockOnScrRefChange,
+      );
+      await pressEditor(editor); // ensure idle
+      updateSelection(editor, secondVerseTextNode, 3); // user parked mid verse 2
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+      mockOnScrRefChange.mockClear();
+
+      // Same-book, same-scrRef full reload - what a view-option toggle triggers via LoadStatePlugin.
+      await swapDocument(editor, $defaultInitialEditorState);
+      await flushQueuedEvents();
+
+      // The reload's transient chapter-top settle must be silenced (pre-fix: emitted verseNum 0).
+      expect(mockOnScrRefChange).not.toHaveBeenCalled();
+    });
+
+    it("reports the first click after an idle same-book reload (reload window does not wedge)", async () => {
+      const { editor } = await testEnvironment(
+        { book: "GEN", chapterNum: 1, verseNum: 2 },
+        mockOnScrRefChange,
+      );
+      await pressEditor(editor);
+      await swapDocument(editor, $defaultInitialEditorState);
+      await flushQueuedEvents();
+      mockOnScrRefChange.mockClear();
+
+      await pressEditor(editor);
+      updateSelection(editor, thirdVerseTextNode, 1);
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+
+      expect(mockOnScrRefChange).toHaveBeenCalledWith(
+        expect.objectContaining({ book: "GEN", chapterNum: 1, verseNum: 3, verse: "3-4" }),
+      );
+    });
+
+    it("does not move the caret when a pasted BookNode arrives while a document is loaded", async () => {
+      const { editor } = await testEnvironment(scrRef, mockOnScrRefChange);
+      await pressEditor(editor);
+      updateSelection(editor, thirdVerseTextNode, 2); // user editing in verse 3-4
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+      mockOnScrRefChange.mockClear();
+
+      // A pure-created BookNode lands (cross-editor paste / undo) - NOT a document replacement.
+      await act(async () => {
+        editor.update(() => {
+          $getRoot().append($createBookNode("EXO").append($createTextNode("Pasted")));
+        });
+      });
+      await flushQueuedEvents();
+
+      // No placement (caret stays where the user was editing), no emission from the stray.
+      editor.getEditorState().read(() => {
+        $expectSelectionToBe(thirdVerseTextNode, 2);
+      });
+    });
+
+    it("treats a malformed verse range as not containing the verse instead of throwing", async () => {
+      let malformedVerseText: TextNode | undefined;
+      const { editor } = await testEnvironment(scrRef, mockOnScrRefChange, () => {
+        malformedVerseText = $createTextNode("backwards range text ");
+        $getRoot().append(
+          $createBookNode("GEN").append($createTextNode("Test Book")),
+          $createImmutableChapterNode("1"),
+          $createParaNode().append($createImmutableVerseNode("3-2"), malformedVerseText),
+        );
+      });
+      await pressEditor(editor);
+      if (!malformedVerseText) throw new Error("fixture text not found");
+
+      updateSelection(editor, malformedVerseText, 2);
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+
+      // No throw escaped the listener, and the position still reports (verseNum from the range's
+      // first number; the malformed range string rides along).
+      expect(mockOnScrRefChange).toHaveBeenCalledWith(
+        expect.objectContaining({ book: "GEN", chapterNum: 1, verseNum: 3 }),
+      );
+    });
+
+    it("closes the navigation window on beforeinput (IME/voice/paste input paths)", async () => {
+      const { editor, setScrRef } = await testEnvironment(scrRef, mockOnScrRefChange);
+      await setScrRef({ book: "GEN", chapterNum: 2, verseNum: 9 }); // window open, chapter 2 never loads
+      expect(mockOnScrRefChange).not.toHaveBeenCalled();
+
+      await act(async () => {
+        editor.getRootElement()?.dispatchEvent(new Event("beforeinput", { bubbles: true }));
+      });
+      updateSelection(editor, secondVerseTextNode, 3);
+      await act(async () => {
+        editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+      });
+
+      expect(mockOnScrRefChange).toHaveBeenCalledWith(
+        expect.objectContaining({ book: "GEN", chapterNum: 1, verseNum: 2 }),
+      );
+    });
+  });
 });
 
 function $defaultInitialEditorState() {
@@ -240,6 +799,17 @@ function $appendScrRefPluginFixture(bookCode: BookCode | "") {
       $createImmutableVerseNode("3-4"),
       $createTextNode("third verse text "),
     ),
+  );
+}
+
+/** A GEN document holding only chapter 2 (verses 8-10), as a chapter-level load would produce. */
+function $chapter2State() {
+  $getRoot().append(
+    $createBookNode("GEN").append($createTextNode("Test Book")),
+    $createImmutableChapterNode("2"),
+    $createParaNode().append($createImmutableVerseNode("8"), $createTextNode("verse eight ")),
+    $createParaNode().append($createImmutableVerseNode("9"), $createTextNode("verse nine ")),
+    $createParaNode().append($createImmutableVerseNode("10"), $createTextNode("verse ten ")),
   );
 }
 
@@ -306,4 +876,48 @@ async function testEnvironment(
   // `editor` is defined on React render.
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   return { editor: editor!, setScrRef };
+}
+
+/**
+ * Flush queued macrotasks + microtasks inside act(). jsdom fires native `selectionchange` via
+ * setTimeout(0), and the plugin defers cursor placement by a microtask, so tests that assert
+ * "nothing further happens" must flush both before asserting quiescence.
+ */
+async function flushQueuedEvents() {
+  await act(async () => {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  });
+}
+
+/**
+ * Replace the whole document in one update - the same shape LoadStatePlugin's setEditorState
+ * swap produces (old BookNode destroyed + new BookNode created in a single mutation batch).
+ */
+async function swapDocument(editor: LexicalEditor, $newState: () => void) {
+  await act(async () => {
+    editor.update(() => {
+      $getRoot().clear();
+      $newState();
+    });
+  });
+}
+
+/** Simulate genuine user input on the editor root (what ends a navigation window). Flushes first:
+ * a real click can never race an *earlier, already-completed* DOM write's own native
+ * `selectionchange` notification - in a real browser that notification is effectively immediate,
+ * long before a human could physically click. jsdom instead defers it via `setTimeout(0)` (see
+ * `flushQueuedEvents`), so without this flush a still-pending echo of an earlier programmatic
+ * placement can arrive after this press has already closed the window and be misread as the
+ * user's settle. */
+async function pressEditor(editor: LexicalEditor) {
+  await flushQueuedEvents();
+  await act(async () => {
+    editor.getRootElement()?.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+  });
+}
+
+function getSelectionStartNodeForTest(selection: BaseSelection | null) {
+  return getSelectionStartNode(selection);
 }

--- a/packages/platform/src/editor/ScriptureReferencePlugin.tsx
+++ b/packages/platform/src/editor/ScriptureReferencePlugin.tsx
@@ -44,7 +44,8 @@ import {
  *   - position report: chapter + verse read from the loaded document in ONE snapshot, with the
  *     book from that same snapshot's BookNode - falling back to the scrRef prop's book ONLY
  *     when the document has no book code (a book-less document cannot name its own book, and
- *     corrections never fire there, so the prop is the sole authority);
+ *     corrections never fire there, so the prop is the sole authority) - and the prop's
+ *     versificationStr riding along (a document states no versification);
  *   - book correction: { ...scrRef, book: <document's book> } - the one deliberate mixed-source
  *     shape ("keep your position, fix the book"), for documents whose book differs from scrRef.
  *
@@ -77,7 +78,8 @@ import {
  *
  * Invariants (each backed by a named test in ScriptureReferencePlugin.test.tsx):
  *   I1 single-source        position reports come from one document snapshot (book falls back
- *                           to the prop only when the document has no book code)
+ *                           to the prop only when the document has no book code;
+ *                           versificationStr always rides from the prop - a document has none)
  *   I2 navigating-silence   zero emissions while navigating
  *   I3 echo-inert           echoed props never move the caret nor open a window
  *   I4 user-report          after user input, the next differing selection reports (sole
@@ -203,6 +205,7 @@ function $resolvePosition(): ResolvedPosition | undefined {
 
   const verseNode = $resolveVerseNode(startNode, selection);
   const { verseNum, verse } = $getEffectiveVerseForBcv(verseNode ?? undefined, selection);
+  if (Number.isNaN(verseNum)) return undefined; // unaddressable - consistent with I5
   return { book: bookNode?.getCode() || undefined, chapterNum, verseNum, verse };
 }
 
@@ -225,13 +228,20 @@ function positionMatchesScrRef(position: ResolvedPosition, scrRef: SerializedVer
     : scrRef.verseNum === position.verseNum;
 }
 
-function positionToScrRef(position: ResolvedPosition, fallbackBook: string): SerializedVerseRef {
+function positionToScrRef(
+  position: ResolvedPosition,
+  hostRef: SerializedVerseRef,
+): SerializedVerseRef {
   const ref: SerializedVerseRef = {
-    book: position.book || fallbackBook,
+    book: position.book || hostRef.book,
     chapterNum: position.chapterNum,
     verseNum: position.verseNum,
   };
   if (position.verse != null) ref.verse = position.verse;
+  // A document states no versification, so the host's rides along on every position report;
+  // stripping it could map the reference to the wrong physical verse under a divergent
+  // versification. refsEqual ignores it, so echo detection is unaffected.
+  if (hostRef.versificationStr != null) ref.versificationStr = hostRef.versificationStr;
   return ref;
 }
 
@@ -294,7 +304,10 @@ function onDocumentChanged(
 }
 
 /** Mutation listeners must not call editor.update synchronously (repo rule); defer one
- * microtask, as LoadStatePlugin does. Reads the latest scrRef at execution time. */
+ * microtask, as LoadStatePlugin does. Reads the latest scrRef at execution time. Deliberately
+ * NOT book-gated at fire time: on an idle cross-book REPLACEMENT the book correction's echo is
+ * still in flight when this fires, so scrRef.book still names the old book and a gate here
+ * would skip the placement that makes the caret match the just-emitted correction. */
 function schedulePlacement(machine: Machine, editor: LexicalEditor) {
   queueMicrotask(() => {
     editor.update(
@@ -317,7 +330,7 @@ function onSelectionSettled(machine: Machine, position: ResolvedPosition | undef
   if (machine.phase === "navigating") return; // settles of an in-flight navigation are noise
   if (!position) return; // never report a position the document cannot address
   if (positionMatchesScrRef(position, machine.scrRef)) return;
-  report(machine, positionToScrRef(position, machine.scrRef.book));
+  report(machine, positionToScrRef(position, machine.scrRef));
 }
 
 /** `userInteracted`: real input ends settling; what follows is the user's. */
@@ -361,6 +374,10 @@ export default function ScriptureReferencePlugin({
   // skipInitialization: false replays the mounted document so mount-time placement and the
   // mount-time book correction work. Reads the FIRST BookNode of the root only - stray extra
   // BookNodes (malformed USJ, cross-editor paste) must not drive contradictory corrections.
+  // Must register BEFORE the verse-node listener below: Lexical delivers mutation listeners in
+  // registration order, and a document swap must flip phase to "navigating" here before the
+  // verse listener's synchronous SELECTION_CHANGE_COMMAND dispatch is classified - reordering
+  // reintroduces the R2 clobber (pinned by the swap-correction and view-option-toggle tests).
   useEffect(
     () =>
       editor.registerMutationListener(
@@ -398,7 +415,8 @@ export default function ScriptureReferencePlugin({
 
   // Verse node destroyed - SELECTION_CHANGE_COMMAND won't fire if the cursor position didn't
   // change (e.g. cursor was at offset 0 of the node after the verse, and stays there after
-  // deletion of the non-keyboard-selectable DecoratorNode).
+  // deletion of the non-keyboard-selectable DecoratorNode). Must register AFTER the BookNode
+  // listener above - see the registration-order note there.
   useEffect(() => {
     const onVerseDestroyed = (nodeMutations: Map<string, "created" | "updated" | "destroyed">) => {
       const hasCreatedOrDestroyedVerse = [...nodeMutations.values()].some(
@@ -415,6 +433,9 @@ export default function ScriptureReferencePlugin({
   // userInteracted: pointer/keyboard/beforeinput on the editor root is the only reliable signal
   // that programmatic settling is over and selection changes are the user's again. beforeinput
   // catches IME/voice/paste input paths that move the selection without a pointerdown or keydown.
+  // ANY keydown counts, including pure modifiers and Escape: closing the window early fails
+  // toward user control (worst case, one stale settle reports), while filtering keys fails
+  // toward suppressing a real user move - eager close is the deliberate choice.
   useEffect(() => {
     const handleUserInput = () => onUserInteracted(machineRef.current);
     return editor.registerRootListener((rootElement, prevRootElement) => {
@@ -439,10 +460,10 @@ function $moveCursorToVerseStart(chapterNum: number, verseNum: number) {
 
   const children = $getRoot().getChildren();
   const chapterNode = $findChapter(children, chapterNum);
-  const nodesInChapter = removeNodesBeforeNode(children, chapterNode);
-  const nextChapterNode = $findNextChapter(nodesInChapter, !!chapterNode);
   if (!chapterNode) return;
 
+  const nodesInChapter = removeNodesBeforeNode(children, chapterNode);
+  const nextChapterNode = $findNextChapter(nodesInChapter, true);
   removeNodeAndAfter(nodesInChapter, nextChapterNode);
   // $findVerseOrPara (shared-react) walks every verse node with the same unguarded isVerseInRange
   // used above; a malformed range there must likewise not throw out of this listener.

--- a/packages/platform/src/editor/ScriptureReferencePlugin.tsx
+++ b/packages/platform/src/editor/ScriptureReferencePlugin.tsx
@@ -2,14 +2,14 @@ import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext
 import { mergeRegister } from "@lexical/utils";
 import { SerializedVerseRef } from "@sillsdev/scripture";
 import {
-  $getNodeByKey,
   $getRoot,
   $getSelection,
   $isTextNode,
   COMMAND_PRIORITY_LOW,
+  LexicalEditor,
   SELECTION_CHANGE_COMMAND,
 } from "lexical";
-import { MutableRefObject, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import {
   $findChapter,
   $findNextChapter,
@@ -33,6 +33,298 @@ import {
   ImmutableVerseNode,
 } from "shared-react";
 
+/*
+ * ============================================================================================
+ * HOW THIS PLUGIN WORKS - READ BEFORE CHANGING ANYTHING
+ * ============================================================================================
+ *
+ * Contract: the host owns `scrRef`; this plugin (a) applies scrRef changes to the caret and
+ * (b) reports genuine user caret moves back via `onScrRefChange`. Exactly two emission shapes
+ * exist, both produced only by `report()`:
+ *   - position report: chapter + verse read from the loaded document in ONE snapshot, with the
+ *     book from that same snapshot's BookNode - falling back to the scrRef prop's book ONLY
+ *     when the document has no book code (a book-less document cannot name its own book, and
+ *     corrections never fire there, so the prop is the sole authority);
+ *   - book correction: { ...scrRef, book: <document's book> } - the one deliberate mixed-source
+ *     shape ("keep your position, fix the book"), for documents whose book differs from scrRef.
+ *
+ * Why this file is shaped the way it is - three async signals meet here, plus a feedback loop:
+ *   1. the scrRef prop (the host's intent - never wrong, but everything else lags it);
+ *   2. document content (arrives a USJ-load later than the intent it belongs to; a SUPERSEDED
+ *      navigation's document can land after a NEWER navigation started);
+ *   3. selection events (browser macrotasks; can describe positions that are already obsolete);
+ *   4. our own emissions return as the scrRef prop (the echo loop).
+ *
+ * The races these caused (regression tests exist for each):
+ *   R1 echo treated as navigation      -> caret yanked mid-typing
+ *   R2 settle reported as a user move  -> verse resets to 0 (e.g. 78:9 -> 78:0 on reattach)
+ *   R3 stale queued selectionchange    -> rapid navigation hijacked back to a previous target
+ *   R4 superseded document lands late  -> navigation hijacked to an abandoned target
+ *   R5 mixed-source emissions          -> references that describe no real position
+ *   R6 doc mutations mid-navigation    -> old book echoed during cross-book navigation
+ *
+ * The machine: phase is "idle" or "navigating" (see NavPhase). While "navigating", this plugin
+ * emits NOTHING (kills R2, R3, R4, R6). The window opens on any external scrRef change, after
+ * emitting a book correction, or on a document REPLACEMENT while idle (a same-book reload's own
+ * settle transiently resolves verse 0 - reporting it is the R2 clobber; pinned by test). It
+ * closes on real user input (pointerdown/keydown/beforeinput on the root - beforeinput catches
+ * IME/voice/paste input paths that move the selection without a pointerdown or keydown) or when
+ * one of our own emissions echoes back as the prop. `pendingEchoes` (a FIFO, deliberately not a
+ * boolean or a single slot) recognizes echoes (kills R1). `report()` enforces the two emission
+ * shapes and dedupes (kills R5). `$resolvePosition` refuses to describe positions the document
+ * cannot address; content before the first chapter of a loaded document addresses as chapter 1
+ * verse 0 by USFM convention - verse 0 is DATA here, never a sentinel.
+ *
+ * Invariants (each backed by a named test in ScriptureReferencePlugin.test.tsx):
+ *   I1 single-source        position reports come from one document snapshot (book falls back
+ *                           to the prop only when the document has no book code)
+ *   I2 navigating-silence   zero emissions while navigating
+ *   I3 echo-inert           echoed props never move the caret nor open a window
+ *   I4 user-report          after user input, the next differing selection reports (sole
+ *                           exception: the pending-echo dedupe trade-off below)
+ *   I5 resolved-position    never emit a position the document cannot address
+ *   I6 placement-book-gate  prop-driven placement never moves the caret in a different book's
+ *                           document; arrival-driven placement targets the arriving document only
+ *   I7 mount-correction     a mounted document with a mismatched book corrects the host once
+ *   I8 verse-0-is-data      verse 0 reports from idle and applies as a target
+ *
+ * Documented trade-offs (deliberate; do not "fix" one without weighing its counterpart):
+ *   - A late echo arriving after a newer external navigation cleared the queue is treated as a
+ *     real navigation (pinned: "treats an echo arriving after a newer external navigation...").
+ *   - A user selection equal to a STILL-PENDING echo of an earlier report is deduped, not
+ *     re-emitted - report() cannot distinguish it from the echo. The host may briefly hold a
+ *     newer ref than the caret; the next differing selection self-heals. Emitting instead would
+ *     leave a never-consumed echo in the FIFO that would later swallow a REAL navigation to that
+ *     ref - strictly worse. This is the sole exception to I4.
+ *   - A cross-editor paste or undo that (re)creates a BookNode while a document is already loaded
+ *     triggers neither placement nor a window: pastes must not teleport the caret (pinned).
+ *
+ * UNSAFE without re-running the full test suite AND the live Platform.Bible repros:
+ *   - re-registering any listener on chapter/verse deps (skipInitialization replay fires against
+ *     whatever document happens to be mounted - this exact mistake caused the NUM 27:1 bug);
+ *   - emitting anything while phase === "navigating" (no "genuine jump" carve-outs: every such
+ *     carve-out forces settle-shape classification, which is how verse-0 sentinels are born);
+ *   - collapsing pendingEchoes to a boolean or single slot (two reports can be in flight);
+ *   - building an emission from more than one source (except the book-correction shape and
+ *     I1's documented no-book fallback).
+ *
+ * SAFE (additive) changes:
+ *   - adding more events that close the window;
+ *   - placement internals ($moveCursorToVerseStart), as long as it stays a pure caret move;
+ *   - additional validity checks before report().
+ * ============================================================================================
+ */
+
+/** "idle": selection changes are the user's. "navigating": an external scrRef change (or a book
+ * correction we emitted) is still being applied; every emission is suppressed until real user
+ * input on the editor ends the window or our own echo returns. */
+type NavPhase = "idle" | "navigating";
+
+/** All plugin state plus the latest wiring values, one mutable object shared by the handlers. */
+interface Machine {
+  phase: NavPhase;
+  /** Emissions not yet seen back as the `scrRef` prop (FIFO, newest last). A queue, not a slot:
+   * two reports can be in flight before the first echo returns. */
+  pendingEchoes: SerializedVerseRef[];
+  scrRef: SerializedVerseRef;
+  onScrRefChange: (scrRef: SerializedVerseRef) => void;
+  /** Whether a BookNode-created mutation has ever been observed. Distinguishes the mount of a
+   * fresh editor (no window needed - a null selection or one already at scrRef) from a later
+   * pure-created BookNode arriving while a document is already loaded (paste/undo - must not
+   * teleport the caret). */
+  sawDocument: boolean;
+}
+
+const MAX_PENDING_ECHOES = 8;
+
+function refsEqual(a: SerializedVerseRef, b: SerializedVerseRef): boolean {
+  return (
+    a.book === b.book &&
+    a.chapterNum === b.chapterNum &&
+    a.verseNum === b.verseNum &&
+    (a.verse ?? undefined) === (b.verse ?? undefined)
+  );
+}
+
+/** Consume `ref` as an echo of an earlier emission. Consuming closes any open window: a returned
+ * echo means the host and editor agree. Returns false when `ref` is not ours. */
+function consumePendingEcho(machine: Machine, ref: SerializedVerseRef): boolean {
+  const index = machine.pendingEchoes.findIndex((echo) => refsEqual(echo, ref));
+  if (index < 0) return false;
+  machine.pendingEchoes.splice(0, index + 1);
+  machine.phase = "idle";
+  return true;
+}
+
+/** The only caller of `onScrRefChange`. Drops emissions equal to the current prop or to a
+ * pending echo. Returns whether an emission actually happened. */
+function report(machine: Machine, ref: SerializedVerseRef): boolean {
+  if (refsEqual(ref, machine.scrRef)) return false;
+  if (machine.pendingEchoes.some((echo) => refsEqual(echo, ref))) return false;
+  machine.pendingEchoes.push(ref);
+  if (machine.pendingEchoes.length > MAX_PENDING_ECHOES) machine.pendingEchoes.shift();
+  machine.onScrRefChange(ref);
+  return true;
+}
+
+interface ResolvedPosition {
+  /** The document's book code (first BookNode of the root); undefined when it has none. */
+  book: string | undefined;
+  chapterNum: number;
+  verseNum: number;
+  verse: string | undefined;
+}
+
+/** First BookNode of the root (documents put it first; strays after content are ignored). */
+function $getFirstBookNode(): BookNode | undefined {
+  let node = $getRoot().getFirstChild();
+  while (node) {
+    if ($isBookNode(node)) return node;
+    node = node.getNextSibling();
+  }
+  return undefined;
+}
+
+/** Resolve the selection to a position the document can address, or undefined (no selection, or
+ * an empty document). Content before the first chapter of a loaded document addresses as
+ * chapter 1 per USFM convention (its verse resolves to 0). */
+function $resolvePosition(): ResolvedPosition | undefined {
+  const selection = $getSelection();
+  const startNode = getSelectionStartNode(selection);
+  if (!startNode) return undefined;
+
+  // The unaddressable check needs the NODE's existence - a BookNode with an empty code still
+  // makes a document addressable.
+  const bookNode = $getFirstBookNode();
+  const chapterNode = $findThisChapter(startNode);
+  if (!chapterNode && !bookNode) return undefined;
+  const chapterNum = chapterNode ? parseInt(chapterNode.getNumber() ?? "1", 10) : 1;
+  if (Number.isNaN(chapterNum)) return undefined; // unaddressable - consistent with I5
+
+  const verseNode = $resolveVerseNode(startNode, selection);
+  const { verseNum, verse } = $getEffectiveVerseForBcv(verseNode ?? undefined, selection);
+  return { book: bookNode?.getCode() || undefined, chapterNum, verseNum, verse };
+}
+
+/** isVerseInRange throws on malformed ranges (reversed, 3-part) from imported USFM; a malformed
+ * range simply doesn't contain the verse. */
+function verseInRangeSafe(verseNum: number, verseRange: string): boolean {
+  try {
+    return isVerseInRange(verseNum, verseRange);
+  } catch {
+    return false;
+  }
+}
+
+/** Whether the resolved position is already what `scrRef` describes (verse-range aware). */
+function positionMatchesScrRef(position: ResolvedPosition, scrRef: SerializedVerseRef): boolean {
+  if (position.book && position.book !== scrRef.book) return false;
+  if (position.chapterNum !== scrRef.chapterNum) return false;
+  return position.verse
+    ? verseInRangeSafe(scrRef.verseNum, position.verse)
+    : scrRef.verseNum === position.verseNum;
+}
+
+function positionToScrRef(position: ResolvedPosition, fallbackBook: string): SerializedVerseRef {
+  const ref: SerializedVerseRef = {
+    book: position.book || fallbackBook,
+    chapterNum: position.chapterNum,
+    verseNum: position.verseNum,
+  };
+  if (position.verse != null) ref.verse = position.verse;
+  return ref;
+}
+
+/** `propChanged`: echo of our own report, or an external navigation. */
+function onPropChanged(machine: Machine, editor: LexicalEditor, newRef: SerializedVerseRef) {
+  if (consumePendingEcho(machine, newRef)) return; // echoes never move the caret
+
+  machine.phase = "navigating";
+  machine.pendingEchoes.length = 0;
+  // Prop-driven placement gate: never move the caret inside a different book's (stale) document.
+  const contentBook = editor
+    .getEditorState()
+    .read(() => $getFirstBookNode()?.getCode() || undefined);
+  if (!contentBook || contentBook === newRef.book) {
+    editor.update(() => $moveCursorToVerseStart(newRef.chapterNum, newRef.verseNum), {
+      tag: CURSOR_CHANGE_TAG,
+    });
+  }
+}
+
+/** `documentChanged`: the loaded document's book identity was established or changed. */
+function onDocumentChanged(
+  machine: Machine,
+  editor: LexicalEditor,
+  code: string | undefined,
+  batch: { hasCreated: boolean; hasDestroyed: boolean },
+) {
+  if (machine.phase === "navigating") {
+    // Silence - except the arrival of the document the navigation is waiting for.
+    if (batch.hasCreated && code && code === machine.scrRef.book) {
+      schedulePlacement(machine, editor);
+    }
+    if (batch.hasCreated) machine.sawDocument = true;
+    return;
+  }
+
+  if (batch.hasCreated && batch.hasDestroyed) {
+    // REPLACEMENT (LoadStatePlugin's setEditorState swap, in-editor book jump): the swap's own
+    // synthetic selection settle fires before the deferred placement and must be silenced -
+    // regardless of book match, since a same-book reload's transient chapter-top settle is the
+    // R2 clobber this branch exists to prevent. The correction below (d), if any, runs after.
+    schedulePlacement(machine, editor);
+    machine.phase = "navigating";
+  } else if (batch.hasCreated && !machine.sawDocument) {
+    // MOUNT: fresh editor, no window needed - a null selection or one already at scrRef.
+    schedulePlacement(machine, editor);
+  }
+  // else: a later pure-created BookNode (cross-editor paste, undo recreating a BookNode) while a
+  // document is already loaded - neither placement nor a window. A paste must not teleport the
+  // caret.
+  if (batch.hasCreated) machine.sawDocument = true;
+
+  // Book correction: "keep your position, fix the book". Emitting one opens a navigation window
+  // (the swap's own synthetic selection settle fires before the deferred placement and must be
+  // silenced); the correction's echo closes it. Runs after (a)-(c); under (a) phase is already
+  // "navigating" here, so this assignment is harmless.
+  if (code && code !== machine.scrRef.book) {
+    if (report(machine, { ...machine.scrRef, book: code })) machine.phase = "navigating";
+  }
+}
+
+/** Mutation listeners must not call editor.update synchronously (repo rule); defer one
+ * microtask, as LoadStatePlugin does. Reads the latest scrRef at execution time. */
+function schedulePlacement(machine: Machine, editor: LexicalEditor) {
+  queueMicrotask(() => {
+    editor.update(
+      () => $moveCursorToVerseStart(machine.scrRef.chapterNum, machine.scrRef.verseNum),
+      { tag: CURSOR_CHANGE_TAG },
+    );
+  });
+}
+
+/** `selectionSettled`: the caret is somewhere; the phase decides whose action that was.
+ * `position` must be resolved by the caller (inline in the SELECTION_CHANGE_COMMAND listener,
+ * not re-fetched in here via `editor.getEditorState()`): dispatchCommand always invokes that
+ * listener inside an active editor-state context - a fresh implicit update, or, for the native
+ * selectionchange path, the surrounding not-yet-committed update's pending state reused in place.
+ * Reading `editor.getEditorState()` from a plain helper like this one would instead see the
+ * *last committed* state, which on that nested/native path is one selection change stale - the
+ * very commit still in flight - so a genuine settle would compare against the old position and be
+ * silently dropped. */
+function onSelectionSettled(machine: Machine, position: ResolvedPosition | undefined) {
+  if (machine.phase === "navigating") return; // settles of an in-flight navigation are noise
+  if (!position) return; // never report a position the document cannot address
+  if (positionMatchesScrRef(position, machine.scrRef)) return;
+  report(machine, positionToScrRef(position, machine.scrRef.book));
+}
+
+/** `userInteracted`: real input ends settling; what follows is the user's. */
+function onUserInteracted(machine: Machine) {
+  machine.phase = "idle";
+}
+
 /**
  * A component (plugin) that keeps the Scripture reference updated.
  * @param scrRef - Scripture reference.
@@ -47,110 +339,61 @@ export default function ScriptureReferencePlugin({
   onScrRefChange: (scrRef: SerializedVerseRef) => void;
 }): null {
   const [editor] = useLexicalComposerContext();
-  /** Prevents the cursor being moved again after a selection has changed. */
-  const hasSelectionChangedRef = useRef(false);
-  /** Prevents the `scrRef` updating again after the cursor has moved. */
-  const hasCursorMovedRef = useRef(false);
-  const { book, chapterNum, verseNum } = scrRef;
-  /** Latest scrRef for book sync (avoids re-registering listeners when chapter/verse changes). */
-  const scrRefRef = useRef(scrRef);
-  const onScrRefChangeRef = useRef(onScrRefChange);
+  const machineRef = useRef<Machine>({
+    phase: "idle",
+    pendingEchoes: [],
+    scrRef,
+    onScrRefChange,
+    sawDocument: false,
+  });
+
+  // propChanged + keep wiring values fresh. Declared first so handlers below always see the
+  // latest scrRef/onScrRefChange within the same effects flush.
   useEffect(() => {
-    scrRefRef.current = scrRef;
-    onScrRefChangeRef.current = onScrRefChange;
-  }, [scrRef, onScrRefChange]);
+    const machine = machineRef.current;
+    const previous = machine.scrRef;
+    machine.scrRef = scrRef;
+    machine.onScrRefChange = onScrRefChange;
+    if (!refsEqual(previous, scrRef)) onPropChanged(machine, editor, scrRef);
+  }, [editor, scrRef, onScrRefChange]);
 
-  // Book node created: move cursor to the verse start once a new BookNode appears after the
-  // initial load (e.g. a different book's document has finished mounting). Re-registers on every
-  // chapterNum/verseNum change so the closure captures the latest target position; safe to
-  // re-register because skipInitialization: true means re-registering never replays existing
-  // BookNodes, only genuinely new "created" mutations going forward.
+  // documentChanged: the single BookNode listener, registered once per editor.
+  // skipInitialization: false replays the mounted document so mount-time placement and the
+  // mount-time book correction work. Reads the FIRST BookNode of the root only - stray extra
+  // BookNodes (malformed USJ, cross-editor paste) must not drive contradictory corrections.
   useEffect(
     () =>
       editor.registerMutationListener(
         BookNode,
         (nodeMutations) => {
-          editor.update(
-            () => {
-              for (const [nodeKey, mutation] of nodeMutations) {
-                const bookNode = $getNodeByKey<BookNode>(nodeKey);
-                if (bookNode && $isBookNode(bookNode) && mutation === "created") {
-                  $moveCursorToVerseStart(chapterNum, verseNum, hasCursorMovedRef);
-                }
-              }
-            },
-            { tag: CURSOR_CHANGE_TAG },
-          );
-        },
-        { skipInitialization: true },
-      ),
-    [editor, chapterNum, verseNum],
-  );
-
-  // Book node sync: correct scrRef.book to match the currently loaded document's BookNode.
-  // Fires on every non-destroyed BookNode mutation (initial-mount replay + later swaps); the
-  // `code !== current.book` guard below is what makes stray firings harmless. Registered once
-  // per editor ([editor] only), NOT re-registered on chapterNum/verseNum change: the refs
-  // already keep values fresh, and re-registering would replay skipInitialization: false against
-  // the still-mounted (stale) document on every navigation, echoing the OLD book with the NEW
-  // chapter/verse back to the host.
-  useEffect(
-    () =>
-      editor.registerMutationListener(
-        BookNode,
-        (nodeMutations) => {
-          editor.update(
-            () => {
-              for (const [nodeKey, mutation] of nodeMutations) {
-                if (mutation === "destroyed") continue;
-                const bookNode = $getNodeByKey<BookNode>(nodeKey);
-                if (!bookNode || !$isBookNode(bookNode)) continue;
-                const code = bookNode.getCode();
-                const current = scrRefRef.current;
-                if (code && code !== current.book) {
-                  onScrRefChangeRef.current({ ...current, book: code });
-                }
-              }
-            },
-            { tag: CURSOR_CHANGE_TAG },
-          );
+          const kinds = [...nodeMutations.values()];
+          if (kinds.every((kind) => kind === "destroyed")) return;
+          const code = editor
+            .getEditorState()
+            .read(() => $getFirstBookNode()?.getCode() || undefined);
+          onDocumentChanged(machineRef.current, editor, code, {
+            hasCreated: kinds.includes("created"),
+            hasDestroyed: kinds.includes("destroyed"),
+          });
         },
         { skipInitialization: false },
       ),
     [editor],
   );
 
-  // Scripture Reference changed
-  useEffect(() => {
-    if (hasSelectionChangedRef.current) hasSelectionChangedRef.current = false;
-    else {
-      editor.update(() => $moveCursorToVerseStart(chapterNum, verseNum, hasCursorMovedRef), {
-        tag: CURSOR_CHANGE_TAG,
-      });
-    }
-  }, [editor, chapterNum, verseNum]);
-
-  // Selection changed
+  // selectionSettled
   useEffect(
     () =>
       editor.registerCommand(
         SELECTION_CHANGE_COMMAND,
         () => {
-          if (hasCursorMovedRef.current) hasCursorMovedRef.current = false;
-          else {
-            $findAndSetChapterAndVerse(
-              book,
-              chapterNum,
-              verseNum,
-              onScrRefChange,
-              hasSelectionChangedRef,
-            );
-          }
+          const machine = machineRef.current;
+          if (machine.phase === "idle") onSelectionSettled(machine, $resolvePosition());
           return false;
         },
         COMMAND_PRIORITY_LOW,
       ),
-    [editor, book, chapterNum, verseNum, onScrRefChange],
+    [editor],
   );
 
   // Verse node destroyed - SELECTION_CHANGE_COMMAND won't fire if the cursor position didn't
@@ -169,26 +412,46 @@ export default function ScriptureReferencePlugin({
     );
   }, [editor]);
 
+  // userInteracted: pointer/keyboard/beforeinput on the editor root is the only reliable signal
+  // that programmatic settling is over and selection changes are the user's again. beforeinput
+  // catches IME/voice/paste input paths that move the selection without a pointerdown or keydown.
+  useEffect(() => {
+    const handleUserInput = () => onUserInteracted(machineRef.current);
+    return editor.registerRootListener((rootElement, prevRootElement) => {
+      prevRootElement?.removeEventListener("pointerdown", handleUserInput);
+      prevRootElement?.removeEventListener("keydown", handleUserInput);
+      prevRootElement?.removeEventListener("beforeinput", handleUserInput);
+      rootElement?.addEventListener("pointerdown", handleUserInput);
+      rootElement?.addEventListener("keydown", handleUserInput);
+      rootElement?.addEventListener("beforeinput", handleUserInput);
+    });
+  }, [editor]);
+
   return null;
 }
 
-function $moveCursorToVerseStart(
-  chapterNum: number,
-  verseNum: number,
-  hasCursorMovedRef: MutableRefObject<boolean>,
-) {
+function $moveCursorToVerseStart(chapterNum: number, verseNum: number) {
   const startNode = getSelectionStartNode($getSelection());
   const selectedVerse = $findThisVerse(startNode)?.getNumber();
-  if (isVerseRange(selectedVerse) && isVerseInRange(verseNum, selectedVerse)) return;
+  if (selectedVerse && isVerseRange(selectedVerse) && verseInRangeSafe(verseNum, selectedVerse)) {
+    return;
+  }
 
   const children = $getRoot().getChildren();
   const chapterNode = $findChapter(children, chapterNum);
   const nodesInChapter = removeNodesBeforeNode(children, chapterNode);
   const nextChapterNode = $findNextChapter(nodesInChapter, !!chapterNode);
-  if ((nextChapterNode && !chapterNode) || !chapterNode) return;
+  if (!chapterNode) return;
 
   removeNodeAndAfter(nodesInChapter, nextChapterNode);
-  const verseOrParaNode = $findVerseOrPara(nodesInChapter, verseNum);
+  // $findVerseOrPara (shared-react) walks every verse node with the same unguarded isVerseInRange
+  // used above; a malformed range there must likewise not throw out of this listener.
+  let verseOrParaNode;
+  try {
+    verseOrParaNode = $findVerseOrPara(nodesInChapter, verseNum);
+  } catch {
+    return;
+  }
   if (!verseOrParaNode) return;
 
   if ($isParaNode(verseOrParaNode)) {
@@ -196,45 +459,4 @@ function $moveCursorToVerseStart(
     if ($isTextNode(firstChild)) firstChild.select(0, 0);
     else verseOrParaNode.select(0, 0);
   } else verseOrParaNode.selectNext(0, 0);
-  hasCursorMovedRef.current = true;
-}
-
-function $findAndSetChapterAndVerse(
-  book: string,
-  chapterNum: number,
-  verseNum: number,
-  onScrRefChange: (scrRef: SerializedVerseRef) => void,
-  hasSelectionChangedRef: MutableRefObject<boolean>,
-) {
-  const selection = $getSelection();
-  const startNode = getSelectionStartNode(selection);
-  if (!startNode) return;
-
-  const chapterNode = $findThisChapter(startNode);
-  const selectedChapterNum = parseInt(chapterNode?.getNumber() ?? "1", 10);
-  const verseNode = $resolveVerseNode(startNode, selection);
-
-  const { verseNum: effectiveVerseNum, verse: effectiveVerse } = $getEffectiveVerseForBcv(
-    verseNode ?? undefined,
-    selection,
-  );
-  const isVerseInCurrentRange = effectiveVerse
-    ? isVerseInRange(verseNum, effectiveVerse)
-    : verseNum === effectiveVerseNum;
-
-  const hasChapterChanged = chapterNode && selectedChapterNum !== chapterNum;
-  const hasVerseChanged = !isVerseInCurrentRange;
-  hasSelectionChangedRef.current = !!(hasChapterChanged || hasVerseChanged);
-
-  if (hasSelectionChangedRef.current) {
-    const scrRef: SerializedVerseRef = {
-      book,
-      chapterNum: selectedChapterNum,
-      verseNum: effectiveVerseNum,
-    };
-    if (effectiveVerse != null && effectiveVerseNum.toString() !== effectiveVerse) {
-      scrRef.verse = effectiveVerse;
-    }
-    onScrRefChange(scrRef);
-  }
 }


### PR DESCRIPTION
## Problem

Navigation through the editor has been intermittently unreliable: verses reset to 0 (e.g. Psalms 78:9 -> 78:0 on scroll-group reattach, or on any view-option toggle), navigations land somewhere other than their target during rapid check-list movement, and scripture references get stuck or out of sync. #498 fixed one trigger, but a deep review found the causes were structural, spread across the whole plugin:

- plugin state smeared across interacting one-shot boolean refs (`hasCursorMovedRef` / `hasSelectionChangedRef`) whose protocols could be wedged, stolen, or double-consumed by event timing; and
- emissions built from sources with different freshness (the `book` prop paired with the stale document's chapter/verse, and vice versa), producing references that describe no real position.

Every symptom is one of six races among three async signals (the scrRef prop, document content arriving later than the intent it belongs to, and selection events trailing everything) plus the echo loop (our own reports returning as the prop).

## Fix

The plugin is rebuilt around an explicit, documented state machine (see the file header, which now carries the full contract, race table R1-R6, invariants I1-I8 each backed by a named test, deliberate trade-offs, and safe/unsafe change lists):

- **`phase: "idle" | "navigating"`** - while an external scrRef change (or a document replacement / book correction) is being applied, the plugin emits **nothing**. The window closes on real user input (`pointerdown`, `keydown`, `beforeinput`) or when one of the plugin's own reports echoes back as the prop. Settles are silenced by state, not by fingerprinting selection shapes - so verse 0 stays an ordinary, addressable reference (P9 semantics), never a sentinel.
- **`pendingEchoes` FIFO** - emissions not yet seen back as the prop. A prop change matching one is our own echo: consumed through the match (React batching means only the last of several in-flight reports returns) and never moves the caret. A queue rather than a boolean/slot: two reports can be in flight before the first echo returns.
- **One emission gate** (`report()`) with exactly two shapes: position reports (book + chapter + verse from a single document snapshot) and the book-correction contract (`{...scrRef, book}`) for documents whose book differs from the ref.
- **Book-gated cursor placement** - prop-driven placement never moves the caret inside a different book's stale document (no more visible jumps in the wrong book while a cross-book navigation loads); pure-created BookNodes while a document is already loaded (cross-editor paste, undo) trigger no placement at all.

Review hardening included: malformed verse ranges ("3-2") no longer throw inside the selection listener; empty chapter numbers resolve as unaddressable instead of emitting NaN; position resolution is gated on phase.

## Testing

- **Characterization first**: pins for the pre-existing intended behavior (mount-time book correction, genuine click reporting, echo-does-not-yank-caret, in-editor book jump, verse ranges, intro-content 1:0) were written against the OLD implementation and pass unmodified on the new one.
- **35 tests** in the plugin suite, including regression pins for every race: the reattach verse-0 clobber, rapid re-target hijack, stale-book echo, superseded document arriving late, mid-navigation BookNode mutations, read-only click swallowing, idle same-book reload (view-option toggle), batched-host echo consumption, and verse-0 targets/intro clicks. Several pins were adversarially mutation-tested (break the machine, confirm the test fails with the honest signal).
- jsdom fidelity shims (Range.getBoundingClientRect; selection-preserving focus()) are documented in the test file - both model real-browser behavior jsdom lacks.
- Suite run 15+ times consecutively with zero flakes; whole-monorepo test/lint/typecheck/format green.
- **Live-verified in Platform.Bible via yalc**: scroll-group reattach holds 78:9; NUM 1 -> previous chapter lands and stays on LEV 27:1; rapid check-list navigation (including A->B->A and verse-0 items) lands correctly; view-option toggles no longer reset the verse; read-only surfaces report the first click after navigation; in-editor verse clicks, book jumps, and typing across verse boundaries all behave.

## Notes for review

- The header comment is deliberately long: this file's history is people fixing one race and reintroducing another. It names what each rule defends and which test enforces it, and lists what is unsafe to change without re-running the live repros.
- Documented trade-offs (both pinned by tests): a late echo arriving after a newer external navigation is treated as a real navigation; a user selection equal to a still-pending echo is deduped (emitting instead would poison the echo FIFO and swallow a future real navigation).
- Follow-ups tracked, not in this PR: moving the malformed-range guard into shared-react's $findVerseInNode so all callers are protected; partial-document (chapter N only) intro-click chapter resolution.

AI-assisted (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGsAqgwChpCeCc8KW4o3HF

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/499)
<!-- Reviewable:end -->
