### PR TITLE
Clean up ScriptureReferencePlugin after PR #499

### DIFF
--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -5,7 +5,7 @@ import { EditorOptions, EditorProps, EditorRef } from "./editor.model";
 import editorTheme from "./editor.theme";
 import { ActiveTextPlugin } from "./ActiveTextPlugin";
 import { ParaMarkerPrefixGuardPlugin } from "./ParaMarkerPrefixGuardPlugin";
-import ScriptureReferencePlugin from "./ScriptureReferencePlugin";
+import { ScriptureReferencePlugin } from "./ScriptureReferencePlugin";
 import TreeViewPlugin from "./TreeViewPlugin";
 import { ToolbarPlugin } from "./toolbar/ToolbarPlugin";
 import { InitialConfigType, LexicalComposer } from "@lexical/react/LexicalComposer";

--- a/packages/platform/src/editor/ScriptureReferencePlugin.test.tsx
+++ b/packages/platform/src/editor/ScriptureReferencePlugin.test.tsx
@@ -4,7 +4,7 @@ import {
   $expectSelectionToBe,
   updateSelection,
 } from "../../../../libs/shared/src/nodes/usj/test.utils";
-import ScriptureReferencePlugin from "./ScriptureReferencePlugin";
+import { ScriptureReferencePlugin } from "./ScriptureReferencePlugin";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
@@ -43,7 +43,7 @@ beforeAll(() => {
   // resolves `selectionTarget` to either an element child (offset lookup) or, when the native
   // DOM selection doesn't resolve to an element boundary, `domSelection.getRangeAt(0)` - a Range
   // over a Text node, which is what the plugin's document-swap cursor placement
-  // (`verseOrParaNode.select(0, 0)` in $moveCursorToVerseStart) produces here. Without this shim
+  // (`verseOrParaNode.select(0, 0)` in $moveCaretToVerseStart) produces here. Without this shim
   // that call throws "selectionTarget.getBoundingClientRect is not a function" from inside
   // Lexical's async $commitPendingUpdates (see node_modules/lexical/Lexical.dev.mjs:7931),
   // outside any test's promise chain, so it surfaces as an unhandled error rather than a test

--- a/packages/platform/src/editor/ScriptureReferencePlugin.test.tsx
+++ b/packages/platform/src/editor/ScriptureReferencePlugin.test.tsx
@@ -5,27 +5,27 @@ import {
   updateSelection,
 } from "../../../../libs/shared/src/nodes/usj/test.utils";
 import { ScriptureReferencePlugin } from "./ScriptureReferencePlugin";
+import type { BookCode } from "@eten-tech-foundation/scripture-utilities";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
 import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
-import type { BookCode } from "@eten-tech-foundation/scripture-utilities";
 import { SerializedVerseRef } from "@sillsdev/scripture";
 import { act, render } from "@testing-library/react";
 import {
-  TextNode,
-  $getRoot,
-  $isElementNode,
   $createPoint,
   $createRangeSelection,
-  $setSelection,
-  SELECTION_CHANGE_COMMAND,
   $createTextNode,
-  LexicalEditor,
+  $getRoot,
   $getSelection,
+  $isElementNode,
+  $setSelection,
+  BaseSelection,
+  LexicalEditor,
+  SELECTION_CHANGE_COMMAND,
+  TextNode,
 } from "lexical";
-import type { BaseSelection } from "lexical";
 import { useEffect, useState } from "react";
 import {
   $createBookNode,

--- a/packages/platform/src/editor/ScriptureReferencePlugin.tsx
+++ b/packages/platform/src/editor/ScriptureReferencePlugin.tsx
@@ -151,8 +151,6 @@ interface ResolvedPosition {
   verse: string | undefined;
 }
 
-const MAX_PENDING_ECHOES = 8;
-
 /**
  * A component (plugin) that keeps the Scripture reference updated.
  * @param scrRef - Scripture reference.
@@ -200,8 +198,8 @@ export function ScriptureReferencePlugin({
         (nodeMutations) => {
           const kinds = [...nodeMutations.values()];
           if (kinds.every((kind) => kind === "destroyed")) return;
-          const code = getCommittedBookCode(editor);
-          onDocumentChanged(machineRef.current, editor, code, {
+          const bookCode = getCommittedBookCode(editor);
+          onDocumentChanged(machineRef.current, editor, bookCode, {
             hasCreated: kinds.includes("created"),
             hasDestroyed: kinds.includes("destroyed"),
           });
@@ -218,6 +216,8 @@ export function ScriptureReferencePlugin({
         SELECTION_CHANGE_COMMAND,
         () => {
           const machine = machineRef.current;
+          // $resolvePosition MUST be called inline here, in the command's active editor-state
+          // context - see onSelectionSettled's doc before folding it into the helper.
           if (machine.phase === "idle") onSelectionSettled(machine, $resolvePosition());
           return false;
         },
@@ -322,52 +322,50 @@ function getCommittedBookCode(editor: LexicalEditor): string | undefined {
 
 /** First BookNode of the root (documents put it first; strays after content are ignored). */
 function $getFirstBookNode(): BookNode | undefined {
-  let node = $getRoot().getFirstChild();
-  while (node) {
-    if ($isBookNode(node)) return node;
-    node = node.getNextSibling();
-  }
-  return undefined;
+  return $getRoot().getChildren().find($isBookNode);
 }
 
 /** `documentChanged`: the loaded document's book identity was established or changed. */
 function onDocumentChanged(
   machine: Machine,
   editor: LexicalEditor,
-  code: string | undefined,
+  bookCode: string | undefined,
   batch: { hasCreated: boolean; hasDestroyed: boolean },
 ) {
+  // Captured before the write below so the MOUNT branch (b) sees the pre-batch value.
+  const isFirstDocument = batch.hasCreated && !machine.sawDocument;
+  if (batch.hasCreated) machine.sawDocument = true;
+
   if (machine.phase === "navigating") {
     // Silence - except the arrival of the document the navigation is waiting for.
-    if (batch.hasCreated && code && code === machine.scrRef.book) {
+    if (batch.hasCreated && bookCode && bookCode === machine.scrRef.book) {
       schedulePlacingCaretAtVerseStart(machine, editor);
     }
-    if (batch.hasCreated) machine.sawDocument = true;
     return;
   }
 
   if (batch.hasCreated && batch.hasDestroyed) {
-    // REPLACEMENT (LoadStatePlugin's setEditorState swap, in-editor book jump): the swap's own
+    // (a) REPLACEMENT (LoadStatePlugin's setEditorState swap, in-editor book jump): the swap's own
     // synthetic selection settle fires before the deferred placement and must be silenced -
     // regardless of book match, since a same-book reload's transient chapter-top settle is the
     // R2 clobber this branch exists to prevent. The correction below (d), if any, runs after.
     schedulePlacingCaretAtVerseStart(machine, editor);
     machine.phase = "navigating";
-  } else if (batch.hasCreated && !machine.sawDocument) {
-    // MOUNT: fresh editor, no navigation window needed - a null selection or one already at scrRef.
+  } else if (isFirstDocument) {
+    // (b) MOUNT: fresh editor, no navigation window needed - a null selection or one already at
+    // scrRef.
     schedulePlacingCaretAtVerseStart(machine, editor);
   }
-  // else: a later pure-created BookNode (cross-editor paste, undo recreating a BookNode) while a
-  // document is already loaded - neither placement nor a navigation window. A paste must not
+  // (c) else: a later pure-created BookNode (cross-editor paste, undo recreating a BookNode) while
+  // a document is already loaded - neither placement nor a navigation window. A paste must not
   // teleport the caret to verse start.
-  if (batch.hasCreated) machine.sawDocument = true;
 
-  // Book correction: "keep your position, fix the book". Emitting one opens a navigation window
-  // (the swap's own synthetic selection settle fires before the deferred placement and must be
-  // silenced); the correction's echo closes it. Runs after (a)-(c); under (a) phase is already
+  // (d) Book correction: "keep your position, fix the book". Emitting one opens a navigation
+  // window (the swap's own synthetic selection settle fires before the deferred placement and must
+  // be silenced); the correction's echo closes it. Runs after (a)-(c); under (a) phase is already
   // "navigating" here, so this assignment is harmless.
-  if (code && code !== machine.scrRef.book) {
-    if (report(machine, { ...machine.scrRef, book: code })) machine.phase = "navigating";
+  if (bookCode && bookCode !== machine.scrRef.book) {
+    if (report(machine, { ...machine.scrRef, book: bookCode })) machine.phase = "navigating";
   }
 }
 
@@ -385,6 +383,8 @@ function schedulePlacingCaretAtVerseStart(machine: Machine, editor: LexicalEdito
   });
 }
 
+/** Moves the caret to the start of `verseNum` in `chapterNum`. No-op when the caret is already
+ * inside a verse range containing `verseNum` (a range is one location), or the target is absent. */
 function $moveCaretToVerseStart(chapterNum: number, verseNum: number) {
   const startNode = getSelectionStartNode($getSelection());
   const selectedVerse = $findThisVerse(startNode)?.getNumber();
@@ -467,6 +467,10 @@ function positionToScrRef(
   if (hostRef.versificationStr != null) ref.versificationStr = hostRef.versificationStr;
   return ref;
 }
+
+/** Bound on the pendingEchoes FIFO: an echo that hasn't returned within this many subsequent
+ * emissions is presumed lost and dropped (oldest first). */
+const MAX_PENDING_ECHOES = 8;
 
 /** The only caller of `onScrRefChange`. Drops emissions equal to the current prop or to a
  * pending echo. Returns whether an emission actually happened. */

--- a/packages/platform/src/editor/ScriptureReferencePlugin.tsx
+++ b/packages/platform/src/editor/ScriptureReferencePlugin.tsx
@@ -1,3 +1,89 @@
+/*
+ * ============================================================================================
+ * HOW THIS PLUGIN WORKS - READ BEFORE CHANGING ANYTHING
+ * ============================================================================================
+ *
+ * Contract: the host owns `scrRef`; this plugin (a) applies scrRef changes to the caret and
+ * (b) reports genuine user caret moves back via `onScrRefChange`. Exactly two emission shapes
+ * exist, both produced only by `report()`:
+ *   - position report: chapter + verse read from the loaded document in ONE snapshot, with the
+ *     book from that same snapshot's BookNode - falling back to the scrRef prop's book ONLY
+ *     when the document has no book code (a book-less document cannot name its own book, and
+ *     corrections never fire there, so the prop is the sole authority) - and the prop's
+ *     versificationStr riding along (a document states no versification);
+ *   - book correction: { ...scrRef, book: <document's book> } - the one deliberate mixed-source
+ *     shape ("keep your position, fix the book"), for documents whose book differs from scrRef.
+ *
+ * Why this file is shaped the way it is - three async signals meet here, plus a feedback loop:
+ *   1. the scrRef prop (the host's intent - never wrong, but everything else lags it);
+ *   2. document content (arrives a USJ-load later than the intent it belongs to; a SUPERSEDED
+ *      navigation's document can land after a NEWER navigation started);
+ *   3. selection events (browser macrotasks; can describe positions that are already obsolete);
+ *   4. our own emissions return as the scrRef prop (the echo loop).
+ *
+ * The races these caused (regression tests exist for each):
+ *   R1 echo treated as navigation      -> caret yanked mid-typing
+ *   R2 settle reported as a user move  -> verse resets to 0 (e.g. 78:9 -> 78:0 on reattach)
+ *   R3 stale queued selectionchange    -> rapid navigation hijacked back to a previous target
+ *   R4 superseded document lands late  -> navigation hijacked to an abandoned target
+ *   R5 mixed-source emissions          -> references that describe no real position
+ *   R6 doc mutations mid-navigation    -> old book echoed during cross-book navigation
+ *
+ * The machine: phase is "idle" or "navigating" (see NavPhase). We call the span where
+ * phase === "navigating" the "navigation window". While "navigating", this plugin emits NOTHING
+ * (kills R2, R3, R4, R6). The navigation window opens on any external scrRef change, after emitting
+ * a book correction, or on a document REPLACEMENT while idle (a same-book reload's own settle
+ * transiently resolves verse 0 - reporting it is the R2 clobber; pinned by test). It closes on real
+ * user input (pointerdown/keydown/beforeinput on the root - beforeinput catches IME/voice/paste
+ * input paths that move the selection without a pointerdown or keydown) or when one of our own
+ * emissions echoes back as the prop. `pendingEchoes` (a FIFO, deliberately not a
+ * boolean or a single slot) recognizes echoes (kills R1). `report()` enforces the two emission
+ * shapes and dedupes (kills R5). `$resolvePosition` refuses to describe positions the document
+ * cannot address; content before the first chapter of a loaded document addresses as chapter 1
+ * verse 0 by USFM convention - verse 0 is DATA here, never a sentinel.
+ *
+ * Invariants (each backed by a named test in ScriptureReferencePlugin.test.tsx):
+ *   I1 single-source        position reports come from one document snapshot (book falls back
+ *                           to the prop only when the document has no book code;
+ *                           versificationStr always rides from the prop - a document has none)
+ *   I2 navigating-silence   zero emissions while navigating
+ *   I3 echo-inert           echoed props never move the caret nor open a navigation window
+ *   I4 user-report          after user input, the next differing selection reports (sole
+ *                           exception: the pending-echo dedupe trade-off below)
+ *   I5 resolved-position    never emit a position the document cannot address
+ *   I6 placement-book-gate  prop-driven placement never moves the caret in a different book's
+ *                           document; arrival-driven placement targets the arriving document only
+ *   I7 mount-correction     a mounted document with a mismatched book corrects the host once
+ *   I8 verse-0-is-data      verse 0 reports from idle and applies as a target
+ *
+ * Documented trade-offs (deliberate; do not "fix" one without weighing its counterpart):
+ *   - A late echo arriving after a newer external navigation cleared the queue is treated as a
+ *     real navigation (pinned: "treats an echo arriving after a newer external navigation...").
+ *   - A user selection equal to a STILL-PENDING echo of an earlier report is deduped, not
+ *     re-emitted - report() cannot distinguish it from the echo. The host may briefly hold a
+ *     newer ref than the caret; the next differing selection self-heals. Emitting instead would
+ *     leave a never-consumed echo in the FIFO that would later swallow a REAL navigation to that
+ *     ref - strictly worse. This is the sole exception to I4.
+ *   - A cross-editor paste or undo that (re)creates a BookNode while a document is already loaded
+ *     triggers neither placement nor a navigation window: pastes must not teleport the caret to
+ *     verse start (pinned).
+ *
+ * UNSAFE without re-running the full test suite AND the live Platform.Bible repros:
+ *   - re-registering any listener on chapter/verse deps (skipInitialization replay fires against
+ *     whatever document happens to be mounted - this exact mistake caused the NUM 27:1 bug);
+ *   - emitting anything while phase === "navigating" (no "genuine jump" carve-outs: every such
+ *     carve-out forces settle-shape classification, which is how verse-0 sentinels are born);
+ *   - collapsing pendingEchoes to a boolean or single slot (two reports can be in flight);
+ *   - building an emission from more than one source (except the book-correction shape and
+ *     I1's documented no-book fallback).
+ *
+ * SAFE (additive) changes:
+ *   - adding more events that close the navigation window;
+ *   - placement internals ($moveCaretToVerseStart), as long as it stays a pure caret move;
+ *   - additional validity checks before report().
+ * ============================================================================================
+ */
+
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { mergeRegister } from "@lexical/utils";
 import { SerializedVerseRef } from "@sillsdev/scripture";
@@ -33,96 +119,12 @@ import {
   ImmutableVerseNode,
 } from "shared-react";
 
-/*
- * ============================================================================================
- * HOW THIS PLUGIN WORKS - READ BEFORE CHANGING ANYTHING
- * ============================================================================================
- *
- * Contract: the host owns `scrRef`; this plugin (a) applies scrRef changes to the caret and
- * (b) reports genuine user caret moves back via `onScrRefChange`. Exactly two emission shapes
- * exist, both produced only by `report()`:
- *   - position report: chapter + verse read from the loaded document in ONE snapshot, with the
- *     book from that same snapshot's BookNode - falling back to the scrRef prop's book ONLY
- *     when the document has no book code (a book-less document cannot name its own book, and
- *     corrections never fire there, so the prop is the sole authority) - and the prop's
- *     versificationStr riding along (a document states no versification);
- *   - book correction: { ...scrRef, book: <document's book> } - the one deliberate mixed-source
- *     shape ("keep your position, fix the book"), for documents whose book differs from scrRef.
- *
- * Why this file is shaped the way it is - three async signals meet here, plus a feedback loop:
- *   1. the scrRef prop (the host's intent - never wrong, but everything else lags it);
- *   2. document content (arrives a USJ-load later than the intent it belongs to; a SUPERSEDED
- *      navigation's document can land after a NEWER navigation started);
- *   3. selection events (browser macrotasks; can describe positions that are already obsolete);
- *   4. our own emissions return as the scrRef prop (the echo loop).
- *
- * The races these caused (regression tests exist for each):
- *   R1 echo treated as navigation      -> caret yanked mid-typing
- *   R2 settle reported as a user move  -> verse resets to 0 (e.g. 78:9 -> 78:0 on reattach)
- *   R3 stale queued selectionchange    -> rapid navigation hijacked back to a previous target
- *   R4 superseded document lands late  -> navigation hijacked to an abandoned target
- *   R5 mixed-source emissions          -> references that describe no real position
- *   R6 doc mutations mid-navigation    -> old book echoed during cross-book navigation
- *
- * The machine: phase is "idle" or "navigating" (see NavPhase). While "navigating", this plugin
- * emits NOTHING (kills R2, R3, R4, R6). The window opens on any external scrRef change, after
- * emitting a book correction, or on a document REPLACEMENT while idle (a same-book reload's own
- * settle transiently resolves verse 0 - reporting it is the R2 clobber; pinned by test). It
- * closes on real user input (pointerdown/keydown/beforeinput on the root - beforeinput catches
- * IME/voice/paste input paths that move the selection without a pointerdown or keydown) or when
- * one of our own emissions echoes back as the prop. `pendingEchoes` (a FIFO, deliberately not a
- * boolean or a single slot) recognizes echoes (kills R1). `report()` enforces the two emission
- * shapes and dedupes (kills R5). `$resolvePosition` refuses to describe positions the document
- * cannot address; content before the first chapter of a loaded document addresses as chapter 1
- * verse 0 by USFM convention - verse 0 is DATA here, never a sentinel.
- *
- * Invariants (each backed by a named test in ScriptureReferencePlugin.test.tsx):
- *   I1 single-source        position reports come from one document snapshot (book falls back
- *                           to the prop only when the document has no book code;
- *                           versificationStr always rides from the prop - a document has none)
- *   I2 navigating-silence   zero emissions while navigating
- *   I3 echo-inert           echoed props never move the caret nor open a window
- *   I4 user-report          after user input, the next differing selection reports (sole
- *                           exception: the pending-echo dedupe trade-off below)
- *   I5 resolved-position    never emit a position the document cannot address
- *   I6 placement-book-gate  prop-driven placement never moves the caret in a different book's
- *                           document; arrival-driven placement targets the arriving document only
- *   I7 mount-correction     a mounted document with a mismatched book corrects the host once
- *   I8 verse-0-is-data      verse 0 reports from idle and applies as a target
- *
- * Documented trade-offs (deliberate; do not "fix" one without weighing its counterpart):
- *   - A late echo arriving after a newer external navigation cleared the queue is treated as a
- *     real navigation (pinned: "treats an echo arriving after a newer external navigation...").
- *   - A user selection equal to a STILL-PENDING echo of an earlier report is deduped, not
- *     re-emitted - report() cannot distinguish it from the echo. The host may briefly hold a
- *     newer ref than the caret; the next differing selection self-heals. Emitting instead would
- *     leave a never-consumed echo in the FIFO that would later swallow a REAL navigation to that
- *     ref - strictly worse. This is the sole exception to I4.
- *   - A cross-editor paste or undo that (re)creates a BookNode while a document is already loaded
- *     triggers neither placement nor a window: pastes must not teleport the caret (pinned).
- *
- * UNSAFE without re-running the full test suite AND the live Platform.Bible repros:
- *   - re-registering any listener on chapter/verse deps (skipInitialization replay fires against
- *     whatever document happens to be mounted - this exact mistake caused the NUM 27:1 bug);
- *   - emitting anything while phase === "navigating" (no "genuine jump" carve-outs: every such
- *     carve-out forces settle-shape classification, which is how verse-0 sentinels are born);
- *   - collapsing pendingEchoes to a boolean or single slot (two reports can be in flight);
- *   - building an emission from more than one source (except the book-correction shape and
- *     I1's documented no-book fallback).
- *
- * SAFE (additive) changes:
- *   - adding more events that close the window;
- *   - placement internals ($moveCursorToVerseStart), as long as it stays a pure caret move;
- *   - additional validity checks before report().
- * ============================================================================================
- */
-
 /** "idle": selection changes are the user's. "navigating": an external scrRef change (or a book
  * correction we emitted) is still being applied; every emission is suppressed until real user
- * input on the editor ends the window or our own echo returns. */
+ * input on the editor ends the navigation window or our own echo returns. */
 type NavPhase = "idle" | "navigating";
 
-/** All plugin state plus the latest wiring values, one mutable object shared by the handlers. */
+/** All plugin state plus the latest props. One mutable object shared by the handlers. */
 interface Machine {
   phase: NavPhase;
   /** Emissions not yet seen back as the `scrRef` prop (FIFO, newest last). A queue, not a slot:
@@ -131,42 +133,10 @@ interface Machine {
   scrRef: SerializedVerseRef;
   onScrRefChange: (scrRef: SerializedVerseRef) => void;
   /** Whether a BookNode-created mutation has ever been observed. Distinguishes the mount of a
-   * fresh editor (no window needed - a null selection or one already at scrRef) from a later
-   * pure-created BookNode arriving while a document is already loaded (paste/undo - must not
-   * teleport the caret). */
+   * fresh editor (no navigation window needed - a null selection or one already at scrRef) from a
+   * later pure-created BookNode arriving while a document is already loaded (paste/undo - must
+   * not teleport the caret to verse start). */
   sawDocument: boolean;
-}
-
-const MAX_PENDING_ECHOES = 8;
-
-function refsEqual(a: SerializedVerseRef, b: SerializedVerseRef): boolean {
-  return (
-    a.book === b.book &&
-    a.chapterNum === b.chapterNum &&
-    a.verseNum === b.verseNum &&
-    (a.verse ?? undefined) === (b.verse ?? undefined)
-  );
-}
-
-/** Consume `ref` as an echo of an earlier emission. Consuming closes any open window: a returned
- * echo means the host and editor agree. Returns false when `ref` is not ours. */
-function consumePendingEcho(machine: Machine, ref: SerializedVerseRef): boolean {
-  const index = machine.pendingEchoes.findIndex((echo) => refsEqual(echo, ref));
-  if (index < 0) return false;
-  machine.pendingEchoes.splice(0, index + 1);
-  machine.phase = "idle";
-  return true;
-}
-
-/** The only caller of `onScrRefChange`. Drops emissions equal to the current prop or to a
- * pending echo. Returns whether an emission actually happened. */
-function report(machine: Machine, ref: SerializedVerseRef): boolean {
-  if (refsEqual(ref, machine.scrRef)) return false;
-  if (machine.pendingEchoes.some((echo) => refsEqual(echo, ref))) return false;
-  machine.pendingEchoes.push(ref);
-  if (machine.pendingEchoes.length > MAX_PENDING_ECHOES) machine.pendingEchoes.shift();
-  machine.onScrRefChange(ref);
-  return true;
 }
 
 interface ResolvedPosition {
@@ -177,166 +147,7 @@ interface ResolvedPosition {
   verse: string | undefined;
 }
 
-/** First BookNode of the root (documents put it first; strays after content are ignored). */
-function $getFirstBookNode(): BookNode | undefined {
-  let node = $getRoot().getFirstChild();
-  while (node) {
-    if ($isBookNode(node)) return node;
-    node = node.getNextSibling();
-  }
-  return undefined;
-}
-
-/** Resolve the selection to a position the document can address, or undefined (no selection, or
- * an empty document). Content before the first chapter of a loaded document addresses as
- * chapter 1 per USFM convention (its verse resolves to 0). */
-function $resolvePosition(): ResolvedPosition | undefined {
-  const selection = $getSelection();
-  const startNode = getSelectionStartNode(selection);
-  if (!startNode) return undefined;
-
-  // The unaddressable check needs the NODE's existence - a BookNode with an empty code still
-  // makes a document addressable.
-  const bookNode = $getFirstBookNode();
-  const chapterNode = $findThisChapter(startNode);
-  if (!chapterNode && !bookNode) return undefined;
-  const chapterNum = chapterNode ? parseInt(chapterNode.getNumber() ?? "1", 10) : 1;
-  if (Number.isNaN(chapterNum)) return undefined; // unaddressable - consistent with I5
-
-  const verseNode = $resolveVerseNode(startNode, selection);
-  const { verseNum, verse } = $getEffectiveVerseForBcv(verseNode ?? undefined, selection);
-  if (Number.isNaN(verseNum)) return undefined; // unaddressable - consistent with I5
-  return { book: bookNode?.getCode() || undefined, chapterNum, verseNum, verse };
-}
-
-/** isVerseInRange throws on malformed ranges (reversed, 3-part) from imported USFM; a malformed
- * range simply doesn't contain the verse. */
-function verseInRangeSafe(verseNum: number, verseRange: string): boolean {
-  try {
-    return isVerseInRange(verseNum, verseRange);
-  } catch {
-    return false;
-  }
-}
-
-/** Whether the resolved position is already what `scrRef` describes (verse-range aware). */
-function positionMatchesScrRef(position: ResolvedPosition, scrRef: SerializedVerseRef): boolean {
-  if (position.book && position.book !== scrRef.book) return false;
-  if (position.chapterNum !== scrRef.chapterNum) return false;
-  return position.verse
-    ? verseInRangeSafe(scrRef.verseNum, position.verse)
-    : scrRef.verseNum === position.verseNum;
-}
-
-function positionToScrRef(
-  position: ResolvedPosition,
-  hostRef: SerializedVerseRef,
-): SerializedVerseRef {
-  const ref: SerializedVerseRef = {
-    book: position.book || hostRef.book,
-    chapterNum: position.chapterNum,
-    verseNum: position.verseNum,
-  };
-  if (position.verse != null) ref.verse = position.verse;
-  // A document states no versification, so the host's rides along on every position report;
-  // stripping it could map the reference to the wrong physical verse under a divergent
-  // versification. refsEqual ignores it, so echo detection is unaffected.
-  if (hostRef.versificationStr != null) ref.versificationStr = hostRef.versificationStr;
-  return ref;
-}
-
-/** `propChanged`: echo of our own report, or an external navigation. */
-function onPropChanged(machine: Machine, editor: LexicalEditor, newRef: SerializedVerseRef) {
-  if (consumePendingEcho(machine, newRef)) return; // echoes never move the caret
-
-  machine.phase = "navigating";
-  machine.pendingEchoes.length = 0;
-  // Prop-driven placement gate: never move the caret inside a different book's (stale) document.
-  const contentBook = editor
-    .getEditorState()
-    .read(() => $getFirstBookNode()?.getCode() || undefined);
-  if (!contentBook || contentBook === newRef.book) {
-    editor.update(() => $moveCursorToVerseStart(newRef.chapterNum, newRef.verseNum), {
-      tag: CURSOR_CHANGE_TAG,
-    });
-  }
-}
-
-/** `documentChanged`: the loaded document's book identity was established or changed. */
-function onDocumentChanged(
-  machine: Machine,
-  editor: LexicalEditor,
-  code: string | undefined,
-  batch: { hasCreated: boolean; hasDestroyed: boolean },
-) {
-  if (machine.phase === "navigating") {
-    // Silence - except the arrival of the document the navigation is waiting for.
-    if (batch.hasCreated && code && code === machine.scrRef.book) {
-      schedulePlacement(machine, editor);
-    }
-    if (batch.hasCreated) machine.sawDocument = true;
-    return;
-  }
-
-  if (batch.hasCreated && batch.hasDestroyed) {
-    // REPLACEMENT (LoadStatePlugin's setEditorState swap, in-editor book jump): the swap's own
-    // synthetic selection settle fires before the deferred placement and must be silenced -
-    // regardless of book match, since a same-book reload's transient chapter-top settle is the
-    // R2 clobber this branch exists to prevent. The correction below (d), if any, runs after.
-    schedulePlacement(machine, editor);
-    machine.phase = "navigating";
-  } else if (batch.hasCreated && !machine.sawDocument) {
-    // MOUNT: fresh editor, no window needed - a null selection or one already at scrRef.
-    schedulePlacement(machine, editor);
-  }
-  // else: a later pure-created BookNode (cross-editor paste, undo recreating a BookNode) while a
-  // document is already loaded - neither placement nor a window. A paste must not teleport the
-  // caret.
-  if (batch.hasCreated) machine.sawDocument = true;
-
-  // Book correction: "keep your position, fix the book". Emitting one opens a navigation window
-  // (the swap's own synthetic selection settle fires before the deferred placement and must be
-  // silenced); the correction's echo closes it. Runs after (a)-(c); under (a) phase is already
-  // "navigating" here, so this assignment is harmless.
-  if (code && code !== machine.scrRef.book) {
-    if (report(machine, { ...machine.scrRef, book: code })) machine.phase = "navigating";
-  }
-}
-
-/** Mutation listeners must not call editor.update synchronously (repo rule); defer one
- * microtask, as LoadStatePlugin does. Reads the latest scrRef at execution time. Deliberately
- * NOT book-gated at fire time: on an idle cross-book REPLACEMENT the book correction's echo is
- * still in flight when this fires, so scrRef.book still names the old book and a gate here
- * would skip the placement that makes the caret match the just-emitted correction. */
-function schedulePlacement(machine: Machine, editor: LexicalEditor) {
-  queueMicrotask(() => {
-    editor.update(
-      () => $moveCursorToVerseStart(machine.scrRef.chapterNum, machine.scrRef.verseNum),
-      { tag: CURSOR_CHANGE_TAG },
-    );
-  });
-}
-
-/** `selectionSettled`: the caret is somewhere; the phase decides whose action that was.
- * `position` must be resolved by the caller (inline in the SELECTION_CHANGE_COMMAND listener,
- * not re-fetched in here via `editor.getEditorState()`): dispatchCommand always invokes that
- * listener inside an active editor-state context - a fresh implicit update, or, for the native
- * selectionchange path, the surrounding not-yet-committed update's pending state reused in place.
- * Reading `editor.getEditorState()` from a plain helper like this one would instead see the
- * *last committed* state, which on that nested/native path is one selection change stale - the
- * very commit still in flight - so a genuine settle would compare against the old position and be
- * silently dropped. */
-function onSelectionSettled(machine: Machine, position: ResolvedPosition | undefined) {
-  if (machine.phase === "navigating") return; // settles of an in-flight navigation are noise
-  if (!position) return; // never report a position the document cannot address
-  if (positionMatchesScrRef(position, machine.scrRef)) return;
-  report(machine, positionToScrRef(position, machine.scrRef));
-}
-
-/** `userInteracted`: real input ends settling; what follows is the user's. */
-function onUserInteracted(machine: Machine) {
-  machine.phase = "idle";
-}
+const MAX_PENDING_ECHOES = 8;
 
 /**
  * A component (plugin) that keeps the Scripture reference updated.
@@ -344,7 +155,7 @@ function onUserInteracted(machine: Machine) {
  * @param onScrRefChange - Callback function when the Scripture reference has changed.
  * @returns null, i.e. no DOM elements.
  */
-export default function ScriptureReferencePlugin({
+export function ScriptureReferencePlugin({
   scrRef,
   onScrRefChange,
 }: {
@@ -360,7 +171,7 @@ export default function ScriptureReferencePlugin({
     sawDocument: false,
   });
 
-  // propChanged + keep wiring values fresh. Declared first so handlers below always see the
+  // propChanged + keep props fresh. Declared first so handlers below always see the
   // latest scrRef/onScrRefChange within the same effects flush.
   useEffect(() => {
     const machine = machineRef.current;
@@ -385,9 +196,7 @@ export default function ScriptureReferencePlugin({
         (nodeMutations) => {
           const kinds = [...nodeMutations.values()];
           if (kinds.every((kind) => kind === "destroyed")) return;
-          const code = editor
-            .getEditorState()
-            .read(() => $getFirstBookNode()?.getCode() || undefined);
+          const code = editor.read(() => $getFirstBookNode()?.getCode() || undefined);
           onDocumentChanged(machineRef.current, editor, code, {
             hasCreated: kinds.includes("created"),
             hasDestroyed: kinds.includes("destroyed"),
@@ -433,8 +242,8 @@ export default function ScriptureReferencePlugin({
   // userInteracted: pointer/keyboard/beforeinput on the editor root is the only reliable signal
   // that programmatic settling is over and selection changes are the user's again. beforeinput
   // catches IME/voice/paste input paths that move the selection without a pointerdown or keydown.
-  // ANY keydown counts, including pure modifiers and Escape: closing the window early fails
-  // toward user control (worst case, one stale settle reports), while filtering keys fails
+  // ANY keydown counts, including pure modifiers and Escape: closing the navigation window early
+  // fails toward user control (worst case, one stale settle reports), while filtering keys fails
   // toward suppressing a real user move - eager close is the deliberate choice.
   useEffect(() => {
     const handleUserInput = () => onUserInteracted(machineRef.current);
@@ -451,7 +260,119 @@ export default function ScriptureReferencePlugin({
   return null;
 }
 
-function $moveCursorToVerseStart(chapterNum: number, verseNum: number) {
+/** `propChanged`: echo of our own report, or an external navigation. */
+function onPropChanged(machine: Machine, editor: LexicalEditor, newRef: SerializedVerseRef) {
+  if (consumePendingEcho(machine, newRef)) return; // echoes never move the caret
+
+  machine.phase = "navigating";
+  machine.pendingEchoes.length = 0;
+  // Prop-driven placement gate: never move the caret inside a different book's (stale) document.
+  const bookCode = editor.read(() => $getFirstBookNode()?.getCode() || undefined);
+  if (!bookCode || bookCode === newRef.book) {
+    editor.update(() => $moveCaretToVerseStart(newRef.chapterNum, newRef.verseNum), {
+      tag: CURSOR_CHANGE_TAG,
+    });
+  }
+}
+
+/** Consume `ref` as an echo of an earlier emission. Consuming closes any open navigation window:
+ * a returned echo means the host and editor agree. Returns false when `ref` is not ours. */
+function consumePendingEcho(machine: Machine, ref: SerializedVerseRef): boolean {
+  const index = machine.pendingEchoes.findIndex((echo) => refsEqual(echo, ref));
+  if (index < 0) return false;
+  machine.pendingEchoes.splice(0, index + 1);
+  machine.phase = "idle";
+  return true;
+}
+
+/** Resolve the selection to a position the document can address, or undefined (no selection, or
+ * an empty document). Content before the first chapter of a loaded document addresses as
+ * chapter 1 per USFM convention (its verse resolves to 0). */
+function $resolvePosition(): ResolvedPosition | undefined {
+  const selection = $getSelection();
+  const startNode = getSelectionStartNode(selection);
+  if (!startNode) return undefined;
+
+  // The unaddressable check needs the NODE's existence - a BookNode with an empty code still
+  // makes a document addressable.
+  const bookNode = $getFirstBookNode();
+  const chapterNode = $findThisChapter(startNode);
+  if (!chapterNode && !bookNode) return undefined;
+  const chapterNum = chapterNode ? parseInt(chapterNode.getNumber() ?? "1", 10) : 1;
+  if (Number.isNaN(chapterNum)) return undefined; // unaddressable - consistent with I5
+
+  const verseNode = $resolveVerseNode(startNode, selection);
+  const { verseNum, verse } = $getEffectiveVerseForBcv(verseNode ?? undefined, selection);
+  if (Number.isNaN(verseNum)) return undefined; // unaddressable - consistent with I5
+  return { book: bookNode?.getCode() || undefined, chapterNum, verseNum, verse };
+}
+
+/** First BookNode of the root (documents put it first; strays after content are ignored). */
+function $getFirstBookNode(): BookNode | undefined {
+  let node = $getRoot().getFirstChild();
+  while (node) {
+    if ($isBookNode(node)) return node;
+    node = node.getNextSibling();
+  }
+  return undefined;
+}
+
+/** `documentChanged`: the loaded document's book identity was established or changed. */
+function onDocumentChanged(
+  machine: Machine,
+  editor: LexicalEditor,
+  code: string | undefined,
+  batch: { hasCreated: boolean; hasDestroyed: boolean },
+) {
+  if (machine.phase === "navigating") {
+    // Silence - except the arrival of the document the navigation is waiting for.
+    if (batch.hasCreated && code && code === machine.scrRef.book) {
+      schedulePlacingCaretAtVerseStart(machine, editor);
+    }
+    if (batch.hasCreated) machine.sawDocument = true;
+    return;
+  }
+
+  if (batch.hasCreated && batch.hasDestroyed) {
+    // REPLACEMENT (LoadStatePlugin's setEditorState swap, in-editor book jump): the swap's own
+    // synthetic selection settle fires before the deferred placement and must be silenced -
+    // regardless of book match, since a same-book reload's transient chapter-top settle is the
+    // R2 clobber this branch exists to prevent. The correction below (d), if any, runs after.
+    schedulePlacingCaretAtVerseStart(machine, editor);
+    machine.phase = "navigating";
+  } else if (batch.hasCreated && !machine.sawDocument) {
+    // MOUNT: fresh editor, no navigation window needed - a null selection or one already at scrRef.
+    schedulePlacingCaretAtVerseStart(machine, editor);
+  }
+  // else: a later pure-created BookNode (cross-editor paste, undo recreating a BookNode) while a
+  // document is already loaded - neither placement nor a navigation window. A paste must not
+  // teleport the caret to verse start.
+  if (batch.hasCreated) machine.sawDocument = true;
+
+  // Book correction: "keep your position, fix the book". Emitting one opens a navigation window
+  // (the swap's own synthetic selection settle fires before the deferred placement and must be
+  // silenced); the correction's echo closes it. Runs after (a)-(c); under (a) phase is already
+  // "navigating" here, so this assignment is harmless.
+  if (code && code !== machine.scrRef.book) {
+    if (report(machine, { ...machine.scrRef, book: code })) machine.phase = "navigating";
+  }
+}
+
+/** Mutation listeners must not call editor.update synchronously (repo rule); defer one
+ * microtask, as LoadStatePlugin does. Reads the latest scrRef at execution time. Deliberately
+ * NOT book-gated at fire time: on an idle cross-book REPLACEMENT the book correction's echo is
+ * still in flight when this fires, so scrRef.book still names the old book and a gate here
+ * would skip the placement that makes the caret match the just-emitted correction. */
+function schedulePlacingCaretAtVerseStart(machine: Machine, editor: LexicalEditor) {
+  queueMicrotask(() => {
+    editor.update(
+      () => $moveCaretToVerseStart(machine.scrRef.chapterNum, machine.scrRef.verseNum),
+      { tag: CURSOR_CHANGE_TAG },
+    );
+  });
+}
+
+function $moveCaretToVerseStart(chapterNum: number, verseNum: number) {
   const startNode = getSelectionStartNode($getSelection());
   const selectedVerse = $findThisVerse(startNode)?.getNumber();
   if (selectedVerse && isVerseRange(selectedVerse) && verseInRangeSafe(verseNum, selectedVerse)) {
@@ -480,4 +401,81 @@ function $moveCursorToVerseStart(chapterNum: number, verseNum: number) {
     if ($isTextNode(firstChild)) firstChild.select(0, 0);
     else verseOrParaNode.select(0, 0);
   } else verseOrParaNode.selectNext(0, 0);
+}
+
+/** `selectionSettled`: the caret is somewhere; the phase decides whose action that was.
+ * `position` must be resolved by the caller (inline in the SELECTION_CHANGE_COMMAND listener,
+ * not re-fetched in here via `editor.getEditorState()`): dispatchCommand always invokes that
+ * listener inside an active editor-state context - a fresh implicit update, or, for the native
+ * selectionchange path, the surrounding not-yet-committed update's pending state reused in place.
+ * Reading `editor.getEditorState()` from a plain helper like this one would instead see the
+ * *last committed* state, which on that nested/native path is one selection change stale - the
+ * very commit still in flight - so a genuine settle would compare against the old position and be
+ * silently dropped. */
+function onSelectionSettled(machine: Machine, position: ResolvedPosition | undefined) {
+  if (machine.phase === "navigating") return; // settles of an in-flight navigation are noise
+  if (!position) return; // never report a position the document cannot address
+  if (positionMatchesScrRef(position, machine.scrRef)) return;
+  report(machine, positionToScrRef(position, machine.scrRef));
+}
+
+/** Whether the resolved position is already what `scrRef` describes (verse-range aware). */
+function positionMatchesScrRef(position: ResolvedPosition, scrRef: SerializedVerseRef): boolean {
+  if (position.book && position.book !== scrRef.book) return false;
+  if (position.chapterNum !== scrRef.chapterNum) return false;
+  return position.verse
+    ? verseInRangeSafe(scrRef.verseNum, position.verse)
+    : scrRef.verseNum === position.verseNum;
+}
+
+/** isVerseInRange throws on malformed ranges (reversed, 3-part) from imported USFM; a malformed
+ * range simply doesn't contain the verse. */
+function verseInRangeSafe(verseNum: number, verseRange: string): boolean {
+  try {
+    return isVerseInRange(verseNum, verseRange);
+  } catch {
+    return false;
+  }
+}
+
+function positionToScrRef(
+  position: ResolvedPosition,
+  hostRef: SerializedVerseRef,
+): SerializedVerseRef {
+  const ref: SerializedVerseRef = {
+    book: position.book || hostRef.book,
+    chapterNum: position.chapterNum,
+    verseNum: position.verseNum,
+  };
+  if (position.verse != null) ref.verse = position.verse;
+  // A document states no versification, so the host's rides along on every position report;
+  // stripping it could map the reference to the wrong physical verse under a divergent
+  // versification. refsEqual ignores it, so echo detection is unaffected.
+  if (hostRef.versificationStr != null) ref.versificationStr = hostRef.versificationStr;
+  return ref;
+}
+
+/** The only caller of `onScrRefChange`. Drops emissions equal to the current prop or to a
+ * pending echo. Returns whether an emission actually happened. */
+function report(machine: Machine, ref: SerializedVerseRef): boolean {
+  if (refsEqual(ref, machine.scrRef)) return false;
+  if (machine.pendingEchoes.some((echo) => refsEqual(echo, ref))) return false;
+  machine.pendingEchoes.push(ref);
+  if (machine.pendingEchoes.length > MAX_PENDING_ECHOES) machine.pendingEchoes.shift();
+  machine.onScrRefChange(ref);
+  return true;
+}
+
+function refsEqual(a: SerializedVerseRef, b: SerializedVerseRef): boolean {
+  return (
+    a.book === b.book &&
+    a.chapterNum === b.chapterNum &&
+    a.verseNum === b.verseNum &&
+    (a.verse ?? undefined) === (b.verse ?? undefined)
+  );
+}
+
+/** `userInteracted`: real input ends settling; what follows is the user's. */
+function onUserInteracted(machine: Machine) {
+  machine.phase = "idle";
 }

--- a/packages/platform/src/editor/ScriptureReferencePlugin.tsx
+++ b/packages/platform/src/editor/ScriptureReferencePlugin.tsx
@@ -75,7 +75,11 @@
  *     carve-out forces settle-shape classification, which is how verse-0 sentinels are born);
  *   - collapsing pendingEchoes to a boolean or single slot (two reports can be in flight);
  *   - building an emission from more than one source (except the book-correction shape and
- *     I1's documented no-book fallback).
+ *     I1's documented no-book fallback);
+ *   - calling `editor.read()` anywhere in this file: it runs `$commitPendingUpdates` - a full
+ *     synchronous commit that installs any pending document swap and fires every listener,
+ *     including ours - and NO test catches it (all 37 stay green). Use
+ *     `editor.getEditorState().read()` (see getCommittedBookCode) for the committed snapshot.
  *
  * SAFE (additive) changes:
  *   - adding more events that close the navigation window;
@@ -196,7 +200,7 @@ export function ScriptureReferencePlugin({
         (nodeMutations) => {
           const kinds = [...nodeMutations.values()];
           if (kinds.every((kind) => kind === "destroyed")) return;
-          const code = editor.read(() => $getFirstBookNode()?.getCode() || undefined);
+          const code = getCommittedBookCode(editor);
           onDocumentChanged(machineRef.current, editor, code, {
             hasCreated: kinds.includes("created"),
             hasDestroyed: kinds.includes("destroyed"),
@@ -267,7 +271,7 @@ function onPropChanged(machine: Machine, editor: LexicalEditor, newRef: Serializ
   machine.phase = "navigating";
   machine.pendingEchoes.length = 0;
   // Prop-driven placement gate: never move the caret inside a different book's (stale) document.
-  const bookCode = editor.read(() => $getFirstBookNode()?.getCode() || undefined);
+  const bookCode = getCommittedBookCode(editor);
   if (!bookCode || bookCode === newRef.book) {
     editor.update(() => $moveCaretToVerseStart(newRef.chapterNum, newRef.verseNum), {
       tag: CURSOR_CHANGE_TAG,
@@ -305,6 +309,15 @@ function $resolvePosition(): ResolvedPosition | undefined {
   const { verseNum, verse } = $getEffectiveVerseForBcv(verseNode ?? undefined, selection);
   if (Number.isNaN(verseNum)) return undefined; // unaddressable - consistent with I5
   return { book: bookNode?.getCode() || undefined, chapterNum, verseNum, verse };
+}
+
+/** The loaded document's book code, from COMMITTED state (empty code means no book). Deliberately
+ * `editor.getEditorState().read()`, never `editor.read()` - the latter runs `$commitPendingUpdates`
+ * first, a full synchronous commit that installs any pending document swap (defeating the I6 gate,
+ * which must judge the document the user is looking at) and fires every listener - re-entering
+ * the BookNode mutation listener that calls this. */
+function getCommittedBookCode(editor: LexicalEditor): string | undefined {
+  return editor.getEditorState().read(() => $getFirstBookNode()?.getCode() || undefined);
 }
 
 /** First BookNode of the root (documents put it first; strays after content are ignored). */


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: cleanup

**Base**: origin/main

**Date**: 2026-07-14

**Review model**: Claude Sonnet 5

**Files changed**: 3

## Overview

This branch is a cleanup pass following PR #499 ("rebuild ScriptureReferencePlugin as a navigation state machine"), touching only `packages/platform/src/editor/Editor.tsx`, `ScriptureReferencePlugin.tsx`, and `ScriptureReferencePlugin.test.tsx`. It reorganizes helper functions to sit below the main plugin export (matching the convention used elsewhere in the package), renames a couple of helpers for clarity (`$moveCursorToVerseStart` → `$moveCaretToVerseStart`, `schedulePlacement` → `schedulePlacingCaretAtVerseStart`), switches the plugin from a `default` export to a named export, and replaces `editor.getEditorState().read()` with `editor.read()` at the two sites where that's the correct pattern. It also restores a chunk of pre-PR-#499 logic in `$moveCaretToVerseStart`, described in the commit message as restoring "affordance for more than one chapter in USJ."

That last item turned out to be the one substantive discussion point: three independent analysis passes, followed by a detailed manual trace (including reading `$findNextChapter`'s actual implementation and diffing all three historical versions of the function — pre-#499, PR #499, and this cleanup), confirmed the "restored" guard was behaviorally identical to the PR #499 code it replaced — it didn't deliver the stated affordance, just reordered computation. The author agreed and had this hunk reverted to the PR #499 form during the review (see Findings). A genuine but unrelated pre-existing edge-case bug in `$findNextChapter` was surfaced along the way (see Suggested Review Focus) but is not part of this diff and was intentionally left alone.

## API Changes

None. `ScriptureReferencePlugin.tsx` is an internal editor-implementation file, not re-exported through `packages/platform/src/index.ts`, and is not tracked by the package's `api-extractor` report (`packages/platform/etc/platform-editor.api.md`), which has no diff versus the merge base. `Editor.tsx` only changed one import line to match the new named export. No changes touch `libs/shared/`, `libs/shared-react/`, `packages/utilities/`, or any package's public surface.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] **The "restored" guard in `$moveCaretToVerseStart` (lines 375–389) didn't deliver its stated purpose** — it was logically/behaviorally equivalent to the simpler PR #499 form it replaced, confirmed via truth-table analysis and a three-way diff of pre-#499/PR-#499/cleanup versions of the function, including tracing `$findNextChapter`'s `isCurrentChapterAtFirstNode` argument through both branches. _(fixed during review: reverted to the PR #499 form — early `if (!chapterNode) return;` followed by a hardcoded `true` argument to `$findNextChapter`, removing the redundant combined condition and the wasted pre-guard computation.)_
- [x] **Stale references to the pre-rename function name `$moveCursorToVerseStart`** in the top-of-file "HOW THIS PLUGIN WORKS" doc comment (`ScriptureReferencePlugin.tsx`, under "SAFE (additive) changes") and in a comment in `ScriptureReferencePlugin.test.tsx`, left over after the rename to `$moveCaretToVerseStart` elsewhere in this same diff. _(fixed during review: both updated to `$moveCaretToVerseStart`.)_

Author confirmed the guard restoration was "probably more restore to match old code" than an intentional behavior fix, and asked a substantive follow-up question about `$findNextChapter`'s second argument before agreeing to revert it — see Interview Notes.

### Minor — Consider

None.

### Template Propagation

#### Shared Regions Modified

None. No `#region shared with <url>` markers in any changed file.

#### Extension Config Changes

Not applicable — this repository has no `extensions/`-directory/template-propagation convention.

## Positive Observations

- The reorg (helpers moved below the exported component) matches the established convention elsewhere in the package (`ArrowNavigationPlugin.tsx`, `NoteNodePlugin.tsx`, `ParaMarkerPrefixGuardPlugin.tsx`, `ActiveTextPlugin.tsx`, `TreeViewPlugin.tsx`).
- `default export` → named `export function ScriptureReferencePlugin` matches how other plugins in this codebase are exported/consumed; confirmed no other file imports the old default export.
- `editor.read(...)` replacing `editor.getEditorState().read(...)` was applied at exactly the two correct sites, and the one site that must *not* use this pattern (`$resolvePosition`, inline in the `SELECTION_CHANGE_COMMAND` handler) was correctly left alone, with its explanatory comment about why intact.
- Renames (`schedulePlacement` → `schedulePlacingCaretAtVerseStart`, `$moveCursorToVerseStart` → `$moveCaretToVerseStart`, "window" → "navigation window" in prose) were applied consistently everywhere except the two stale spots noted above (now fixed).
- All 37 existing tests in `ScriptureReferencePlugin.test.tsx` pass unchanged; `nx lint`/`nx typecheck` clean for the package — confirmed both before and after the in-review fixes.

## Interview Notes

Author's stated purpose (from the branch's commit message): "cleanup after PR #499" — reorg, doc clarity, renames, named export, `editor.read()` adoption, and restoring the multi-chapter guard.

The one substantive discussion was around the restored guard in `$moveCaretToVerseStart`. When asked whether it fixed a real observed bug or was a "restore to match old code" move, the author said it was probably the latter. When told the guard reorder appeared to be behaviorally inert, the author pushed back with a sharp, specific technical question — whether moving the return check to after computing `nextChapterNode` could matter given what `$findNextChapter`'s second argument does. That was a good challenge and led to tracing the actual implementations of `removeNodesBeforeNode` and `$findNextChapter`, and diffing all three historical versions of the function (pre-#499 commit `6bb03956`, PR #499 commit `b315cac9`, and this cleanup). That trace confirmed no behavioral difference in either branch of the guard, but surfaced a real, pre-existing edge case: when the current chapter has zero verses (immediately followed by another chapter node), `$findNextChapter`'s hardcoded `isCurrentChapterAtFirstNode=true` skips index 0 of the sliced node array and misses that next chapter node, causing verse lookup to leak into the following chapter's content. This bug exists identically in both PR #499 and pre-#499 code — it predates this diff and is unrelated to it, so it was intentionally not fixed here (see Suggested Review Focus for a follow-up).

Based on this, the author agreed to revert the guard hunk to the PR #499 form, and separately asked for the two stale `$moveCursorToVerseStart` references to be fixed. Both were done during the review (see Findings).

No unresolved items — the author engaged directly and substantively with the one non-trivial technical question raised, rather than deferring or expressing uncertainty. No areas where the author did not understand their own changes.

Separately: the branch's commit was amended and pushed to `origin/cleanup` mid-review by the author directly (not by any action taken during this review) — confirmed by the author and by the subagent that ran quality checks, which reported it took no `git commit`/`git commit --amend`/`git push` actions of its own.

## In-Review Quality Check

After the two in-review fixes (guard revert, stale-name fixes), a subagent ran the package's checks against `@eten-tech-foundation/platform-editor` (the Nx project for `packages/platform`):

- **Typecheck** (`nx typecheck`) — passed, no errors.
- **Lint** (`nx lint`) — passed clean, no auto-fix needed.
- **Format** (`prettier --write` on the two edited files) — both already correctly formatted, no changes.
- **Tests** (`nx test`) — 148 passed, 3 skipped (unrelated data-generation tests), 0 failed. All 37 tests in `ScriptureReferencePlugin.test.tsx` passed.

No unfixable failures. No issues found that need the author's attention.

## Suggested Review Focus

- [x] Confirm the guard revert to the PR #499 form (already applied during this review) reads correctly — it's a pure simplification with no behavior change.
- [x] Pre-existing edge-case bug surfaced during review (not part of this diff, not fixed here): in `$findNextChapter` (libs/shared/src/nodes/usj/node.utils.ts), a current chapter with zero verses immediately followed by another chapter node causes the hardcoded `isCurrentChapterAtFirstNode=true` skip-index-0 behavior to miss that next chapter node, letting verse lookup leak into the following chapter's content. Exists identically in both PR #499 and pre-#499 code. Worth a follow-up ticket/test if empty chapters are a real scenario in production USJ documents.
- [x] Sanity-check the two stale-name fixes (doc comment + test comment) for correctness — both were mechanical, low-risk changes.
<!-- review-paratext:summary:end -->

AI-assisted — [session](<session URL>)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/500)
<!-- Reviewable:end -->
