### PR TITLE
fix(platform-editor): remove duplicate $getSelection import breaking typecheck

### DIFF
--- a/packages/platform/src/editor/ScriptureReferencePlugin.test.tsx
+++ b/packages/platform/src/editor/ScriptureReferencePlugin.test.tsx
@@ -27,7 +27,6 @@ import {
   SELECTION_CHANGE_COMMAND,
   $createTextNode,
   LexicalEditor,
-  $getSelection,
 } from "lexical";
 import type { BaseSelection } from "lexical";
 import { useEffect, useState } from "react";


### PR DESCRIPTION
## Summary

PT-4200 (WI-13 CI watch): the first CI run on `standard-view` ([run 29366526597](https://github.com/eten-tech-foundation/scripture-editors/actions/runs/29366526597)) failed in **Check types**: `ScriptureReferencePlugin.test.tsx` lists `$getSelection` twice in its `lexical` import block (TS2300, a rebase artifact from the WI-1 branch re-home). Vitest's transpiler tolerates the duplicate, so tests pass, but `tsc --build` does not — which also skipped the downstream test/build CI steps.

One-line fix: drop the duplicate import specifier.

## Verification

- `pnpm nx run-many -t typecheck` — green for all 10 projects (was: platform-editor failing, demos/platform skipped)
- `pnpm nx run @eten-tech-foundation/platform-editor:test` — 406 passed / 3 skipped (31 files)
- `pnpm nx run-many -t build` — green for all 10 projects
- Format/lint steps already passed in the failed CI run (they run before typecheck)

## AI Involvement

AI-assisted — generated with Claude Code (Fable 5); reviewed and verified by the developer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/502)
<!-- Reviewable:end -->
