### PR TITLE
Add controls for more editor options in platform demo

### DIFF
--- a/demos/platform/src/app/app.tsx
+++ b/demos/platform/src/app/app.tsx
@@ -28,6 +28,7 @@ import {
   MarkerMode,
   NoteMode,
   SelectionRange,
+  StructureProtectionMode,
   TextDirection,
   UsjNodeOptions,
   ViewOptions,
@@ -121,6 +122,8 @@ export default function App() {
   const [isNoteEditorVisible, setIsNoteEditorVisible] = useState(false);
   const [isOptionsDefined, setIsOptionsDefined] = useState(false);
   const [isReadonly, setIsReadonly] = useState(false);
+  const [structureProtectionMode, setStructureProtectionMode] =
+    useState<StructureProtectionMode>("off");
   const [hasExternalUI, setHasExternalUI] = useState(true);
   const [hasSpellCheck, setHasSpellCheck] = useState(false);
   const [textDirection, setTextDirection] = useState<TextDirection>("ltr");
@@ -129,6 +132,9 @@ export default function App() {
   const [noteMode, setNoteMode] = useState<NoteMode>("expandInline");
   const [hasSpacing, setHasSpacing] = useState(true);
   const [isFormattedFont, setIsFormattedFont] = useState(true);
+  const [showCharMarkerTitles, setShowCharMarkerTitles] = useState(true);
+  const [hasGutterParaMarkers, setHasGutterParaMarkers] = useState(false);
+  const [hasActiveTextFocusBox, setHasActiveTextFocusBox] = useState(false);
   const [nodesMode, setNodesMode] = useState<NodesMode>(CUSTOM_NODES_MODE);
   const [debug, setDebug] = useState(!isTesting);
   const [scrRef, setScrRef] = useState(defaultScrRef);
@@ -145,10 +151,28 @@ export default function App() {
 
   const viewOptions = useMemo<ViewOptions | undefined>(() => {
     if (viewMode === UNDEFINED_VIEW_MODE) return undefined;
-    if (viewMode === CUSTOM_VIEW_MODE) return { markerMode, noteMode, hasSpacing, isFormattedFont };
+    if (viewMode === CUSTOM_VIEW_MODE)
+      return {
+        markerMode,
+        noteMode,
+        hasSpacing,
+        isFormattedFont,
+        showCharMarkerTitles,
+        hasGutterParaMarkers,
+        hasActiveTextFocusBox,
+      };
 
     return getViewOptions(viewMode);
-  }, [viewMode, markerMode, noteMode, hasSpacing, isFormattedFont]);
+  }, [
+    viewMode,
+    markerMode,
+    noteMode,
+    hasSpacing,
+    isFormattedFont,
+    showCharMarkerTitles,
+    hasGutterParaMarkers,
+    hasActiveTextFocusBox,
+  ]);
 
   const customNodeOptions = useMemo<UsjNodeOptions>(
     () => ({
@@ -186,6 +210,7 @@ export default function App() {
       isOptionsDefined
         ? {
             isReadonly,
+            structureProtectionMode,
             hasExternalUI,
             hasSpellCheck,
             textDirection,
@@ -197,6 +222,7 @@ export default function App() {
     [
       isOptionsDefined,
       isReadonly,
+      structureProtectionMode,
       hasExternalUI,
       hasSpellCheck,
       textDirection,
@@ -448,82 +474,133 @@ export default function App() {
         {isOptionsDefined && (
           <>
             <div className="defined-options">
-              <div className="checkbox">
-                <input
-                  type="checkbox"
-                  id="isReadonlyCheckBox"
-                  checked={isReadonly}
-                  onChange={(e) => setIsReadonly(e.target.checked)}
-                />
-                <label htmlFor="isReadonlyCheckBox">Is readonly</label>
+              <div className="boolean-options">
+                <div className="checkbox">
+                  <input
+                    type="checkbox"
+                    id="isReadonlyCheckBox"
+                    checked={isReadonly}
+                    onChange={(e) => setIsReadonly(e.target.checked)}
+                  />
+                  <label htmlFor="isReadonlyCheckBox">Is readonly</label>
+                </div>
+                <div className="checkbox">
+                  <input
+                    type="checkbox"
+                    id="hasExternalUICheckBox"
+                    checked={hasExternalUI}
+                    onChange={(e) => setHasExternalUI(e.target.checked)}
+                  />
+                  <label htmlFor="hasExternalUICheckBox">Has external UI</label>
+                </div>
+                <div className="checkbox">
+                  <input
+                    type="checkbox"
+                    id="hasSpellCheckBox"
+                    checked={hasSpellCheck}
+                    onChange={(e) => setHasSpellCheck(e.target.checked)}
+                  />
+                  <label htmlFor="hasSpellCheckBox">Has spell check</label>
+                </div>
               </div>
-              <div className="checkbox">
-                <input
-                  type="checkbox"
-                  id="hasExternalUICheckBox"
-                  checked={hasExternalUI}
-                  onChange={(e) => setHasExternalUI(e.target.checked)}
-                />
-                <label htmlFor="hasExternalUICheckBox">Has external UI</label>
+              <div className="control">
+                <label htmlFor="structureProtectionModeSelect">Structure protection</label>
+                <select
+                  id="structureProtectionModeSelect"
+                  value={structureProtectionMode}
+                  onChange={(e) =>
+                    setStructureProtectionMode(e.target.value as StructureProtectionMode)
+                  }
+                >
+                  <option value="off">Off</option>
+                  <option value="guarded">Guarded</option>
+                  <option value="protected">Protected</option>
+                </select>
               </div>
-              <div className="checkbox">
-                <input
-                  type="checkbox"
-                  id="hasSpellCheckBox"
-                  checked={hasSpellCheck}
-                  onChange={(e) => setHasSpellCheck(e.target.checked)}
-                />
-                <label htmlFor="hasSpellCheckBox">Has spell check</label>
+              <div className="text-direction-options">
+                <TextDirectionDropDown textDirection={textDirection} onSelect={setTextDirection} />
+                <div className="load-buttons">
+                  <button onClick={handleLoadEnglish}>Load English</button>
+                  <button onClick={handleLoadArabic}>Load Arabic</button>
+                </div>
               </div>
-              <TextDirectionDropDown textDirection={textDirection} onSelect={setTextDirection} />
-              <button onClick={handleLoadEnglish}>Load English</button>
-              <button onClick={handleLoadArabic}>Load Arabic</button>
               <ViewModeDropDown viewMode={viewMode} onSelect={setViewMode} />
               <NodeOptionsDropDown nodesMode={nodesMode} onSelect={setNodesMode} />
             </div>
             {viewMode === CUSTOM_VIEW_MODE && (
               <div className="custom-view-options">
-                <div className="control">
-                  <label htmlFor="markerModeSelect">Marker mode</label>
-                  <select
-                    id="markerModeSelect"
-                    value={markerMode}
-                    onChange={(e) => setMarkerMode(e.target.value as MarkerMode)}
-                  >
-                    <option value="hidden">Hidden</option>
-                    <option value="visible">Visible</option>
-                    <option value="editable">Editable</option>
-                  </select>
+                <div className="select-options">
+                  <div className="control">
+                    <label htmlFor="markerModeSelect">Marker mode</label>
+                    <select
+                      id="markerModeSelect"
+                      value={markerMode}
+                      onChange={(e) => setMarkerMode(e.target.value as MarkerMode)}
+                    >
+                      <option value="hidden">Hidden</option>
+                      <option value="visible">Visible</option>
+                      <option value="editable">Editable</option>
+                    </select>
+                  </div>
+                  <div className="control">
+                    <label htmlFor="noteModeSelect">Note mode</label>
+                    <select
+                      id="noteModeSelect"
+                      value={noteMode}
+                      onChange={(e) => setNoteMode(e.target.value as NoteMode)}
+                    >
+                      <option value="collapsed">Collapsed</option>
+                      <option value="expandInline">Expand inline</option>
+                      <option value="expanded">Expanded</option>
+                    </select>
+                  </div>
                 </div>
-                <div className="control">
-                  <label htmlFor="noteModeSelect">Note mode</label>
-                  <select
-                    id="noteModeSelect"
-                    value={noteMode}
-                    onChange={(e) => setNoteMode(e.target.value as NoteMode)}
-                  >
-                    <option value="collapsed">Collapsed</option>
-                    <option value="expandInline">Expand inline</option>
-                    <option value="expanded">Expanded</option>
-                  </select>
-                </div>
-                <div className="control">
-                  <input
-                    type="checkbox"
-                    id="hasSpacingCheckBox"
-                    checked={hasSpacing}
-                    onChange={(e) => setHasSpacing(e.target.checked)}
-                  />
-                  <label htmlFor="hasSpacingCheckBox">Has spacing</label>
-                </div>
-                <div className="control">
-                  <input
-                    type="checkbox"
-                    id="isFormattedFontCheckBox"
-                    checked={isFormattedFont}
-                    onChange={(e) => setIsFormattedFont(e.target.checked)}
-                  />
-                  <label htmlFor="isFormattedFontCheckBox">Is formatted font</label>
+                <div className="boolean-options">
+                  <div className="control">
+                    <input
+                      type="checkbox"
+                      id="hasSpacingCheckBox"
+                      checked={hasSpacing}
+                      onChange={(e) => setHasSpacing(e.target.checked)}
+                    />
+                    <label htmlFor="hasSpacingCheckBox">Has spacing</label>
+                  </div>
+                  <div className="control">
+                    <input
+                      type="checkbox"
+                      id="isFormattedFontCheckBox"
+                      checked={isFormattedFont}
+                      onChange={(e) => setIsFormattedFont(e.target.checked)}
+                    />
+                    <label htmlFor="isFormattedFontCheckBox">Is formatted font</label>
+                  </div>
+                  <div className="control">
+                    <input
+                      type="checkbox"
+                      id="showCharMarkerTitlesCheckBox"
+                      checked={showCharMarkerTitles}
+                      onChange={(e) => setShowCharMarkerTitles(e.target.checked)}
+                    />
+                    <label htmlFor="showCharMarkerTitlesCheckBox">Show char marker titles</label>
+                  </div>
+                  <div className="control">
+                    <input
+                      type="checkbox"
+                      id="hasGutterParaMarkersCheckBox"
+                      checked={hasGutterParaMarkers}
+                      onChange={(e) => setHasGutterParaMarkers(e.target.checked)}
+                    />
+                    <label htmlFor="hasGutterParaMarkersCheckBox">Has gutter para markers</label>
+                  </div>
+                  <div className="control">
+                    <input
+                      type="checkbox"
+                      id="hasActiveTextFocusBoxCheckBox"
+                      checked={hasActiveTextFocusBox}
+                      onChange={(e) => setHasActiveTextFocusBox(e.target.checked)}
+                    />
+                    <label htmlFor="hasActiveTextFocusBoxCheckBox">Has active text focus box</label>
+                  </div>
                 </div>
               </div>
             )}

--- a/demos/platform/src/styles.css
+++ b/demos/platform/src/styles.css
@@ -88,12 +88,50 @@ body {
   margin-bottom: 10px;
 }
 
+.defined-options .boolean-options {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.defined-options .boolean-options .checkbox {
+  padding-block: 0;
+}
+
+.defined-options .control {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  width: 126px;
+}
+
+.defined-options .text-direction-options {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  width: 126px;
+}
+
+.defined-options .load-buttons {
+  display: flex;
+  flex-direction: row;
+  gap: 4px;
+  width: 100%;
+}
+
+.defined-options .load-buttons button {
+  flex: 1;
+  min-width: 0;
+}
+
 .custom-view-options {
   margin-bottom: 10px;
   display: flex;
   flex-direction: row;
   gap: 24px;
-  align-items: center;
+  align-items: flex-start;
   flex-wrap: wrap;
   justify-content: flex-end;
 
@@ -101,6 +139,17 @@ body {
     display: flex;
     align-items: center;
     gap: 4px;
+  }
+
+  .select-options {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .boolean-options {
+    display: flex;
+    flex-direction: column;
   }
 }
 


### PR DESCRIPTION
## Summary

Adds demo controls for editor options that previously had no UI in the platform demo app, and tidies the options-panel layout.

### New controls
- **`structureProtectionMode`** — tri-state select (Off / Guarded / Protected), replacing what would have been the old `isStructureProtected` checkbox (matches the API from PR #492).
- **`ViewOptions`** (in the Custom view panel): `showCharMarkerTitles`, `hasGutterParaMarkers`, `hasActiveTextFocusBox` checkboxes.

`markerMenuTrigger` and `contextMenu` are intentionally deferred.

### Layout tweaks
- **Define options panel**: boolean checkboxes stacked vertically (tight spacing); Text direction and its two Load buttons grouped, buttons side-by-side beneath the dropdown; Structure protection select sits below its label. Both narrow controls sized to 126px.
- **Custom view panel**: the two selects grouped in a vertical column; the five booleans grouped in a vertical column with no vertical gap.

  <img width="651" height="837" alt="image" src="https://github.com/user-attachments/assets/1065ec73-18f6-4126-888b-f31e2f512518" />

## Testing
- `nx typecheck platform` ✅
- `nx lint platform` ✅
- Verified live in the running dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/503)
<!-- Reviewable:end -->
