### PR TITLE
Fix Claude Code config: remove dead deny rules, un-ignore tracked .claude files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,15 +51,11 @@
       "Bash(git commit -n:*)",
       "Bash(HUSKY=0:*)",
       "Edit(.claude/settings.json)",
-      "Write(.claude/settings.json)",
       "Edit(.claude/settings.local.json)",
-      "Write(.claude/settings.local.json)",
       "Read(./.env)",
       "Read(./.env.*)",
       "Read(./secrets/**)",
-      "Read(**/dist/**)",
-      "Glob(**/dist/**)",
-      "Grep(**/dist/**)"
+      "Read(**/dist/**)"
     ],
     "ask": [
       "Bash(rm -rf:*)",

--- a/.gitignore
+++ b/.gitignore
@@ -64,5 +64,13 @@ vitest.config.*.timestamp*
 .cursor/
 .superpowers
 docs/superpowers
-.claude
+.claude/*
+# settings.json and skills/ are shared team config (tracked in git), so keep them out of the
+# .claude ignore above. The /* glob (rather than a bare `.claude`) is what lets these negations
+# re-include the paths.
+!.claude/settings.json
+!.claude/skills/
+# NOTE: contrary to the "reflect in .prettierignore" convention in this file's header, these
+# re-included .claude paths are intentionally NOT mirrored in .prettierignore — we want these
+# shared config files formatted by prettier/lint-staged.
 .review


### PR DESCRIPTION
## Summary

Two related fixes to this repo's Claude Code configuration.

### 1. Remove ineffective permission deny rules (`.claude/settings.json`)

Four permission `deny` rules were ignored by Claude Code and emitted a warning on every launch. Claude Code applies file-permission checks only through `Read(...)` and `Edit(...)` rules, which already cover their sibling file tools (`Write`/`NotebookEdit` fall under `Edit`; `Glob`/`Grep` fall under `Read`). So these never did anything:

- `Write(.claude/settings.json)` — covered by the existing `Edit(.claude/settings.json)`
- `Write(.claude/settings.local.json)` — covered by the existing `Edit(.claude/settings.local.json)`
- `Glob(**/dist/**)` — covered by the existing `Read(**/dist/**)`
- `Grep(**/dist/**)` — covered by the existing `Read(**/dist/**)`

Removing them stops the warnings without weakening protection.

### 2. Make the force-tracked `.claude` files behave normally in git (`.gitignore`)

The broad `.claude` ignore rule excluded the entire directory. Because `.claude/settings.json` and `.claude/skills/**` are force-tracked (shared team config), this caused two problems:

- `git add` on those files was refused with *"paths ignored: .claude"* (git won't re-include a file under a wholesale-excluded directory).
- `lint-staged` could silently drop a prettier reformat of them, since its post-format re-stage hit the same wall.

Fix: change the rule from `.claude` to `.claude/*` and add `!.claude/settings.json` and `!.claude/skills/`. This keeps local-only `.claude` contents ignored (`settings.local.json`, `todos/`, `memory/`, `worktrees`) while letting the shared, tracked files stage like any other tracked file.

## Changes

- `.claude/settings.json`: remove the two `Write(...)` and the `Glob`/`Grep(**/dist/**)` dead deny rules
- `.gitignore`: `.claude` → `.claude/*` plus `!.claude/settings.json` and `!.claude/skills/`

## AI Involvement

AI-assisted. Claude Code diagnosed the ineffective rules and the `.gitignore` interaction, and drafted the commit/PR. The human developer verified the warnings no longer appear on restart and confirmed the negations work.

## Testing

- Config-only change; no code affected
- Verified warnings no longer appear on Claude Code restart
- Verified via `git check-ignore`: `.claude/settings.json` and `.claude/skills/**` are no longer ignored, while `.claude/settings.local.json` remains ignored

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/506)
<!-- Reviewable:end -->
