### PR TITLE
docs: use prettier directly, not nx format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,18 @@
 
 <!-- nx configuration end-->
 
+# Formatting
+
+**Don't run formatting as a verification step, and don't hand-format.** The pre-commit hook runs
+`prettier --write` over staged files (see `lint-staged.config.js`), so anything you commit is
+formatted for you.
+
+If you need to format explicitly, use `prettier` directly, not `nx format:write`. `nx format:check`
+exists in CI only as a historical backstop against commits that bypassed the hook.
+
+`.prettierignore` excludes some staged files, notably `pnpm-lock.yaml` and `**/tsconfig*.json` —
+prettier leaves those alone, so don't reformat them by hand.
+
 # Code Style
 
 - Prefer `undefined` over `null` when representing missing values unless an API explicitly requires `null`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,9 @@ nx test <package-name> --watch     # Run tests in watch mode
 # Linting and Type Checking
 nx run-many -t lint                # Lint all packages
 nx run-many -t typecheck           # Type check all packages
-nx format:check                    # Check formatting
-nx format:write                    # Fix formatting
+
+# Formatting — you normally never run this; see "Formatting" below
+npx prettier --write <files>       # Use prettier directly, NOT `nx format:write`
 
 # API extraction (run after changing a package's public API)
 nx extract-api <package-name>      # Update API report for specific package
@@ -216,6 +217,22 @@ When working with scripture data:
 - The `nx-generate` skill handles generator discovery internally - don't call nx_docs just to look up generator syntax
 
 <!-- nx configuration end-->
+
+# Formatting
+
+**Don't run formatting as a verification step, and don't hand-format.** The pre-commit hook runs
+`prettier --write` over staged files (see `lint-staged.config.js`), so anything you commit is
+formatted for you. Adding a format check to your own workflow is wasted work.
+
+If you do need to format explicitly, **use `prettier` directly, not `nx format:write`**. `nx format`
+exists in CI (`nx format:check` in `test-publish.yml`) only as a historical backstop: Nx once
+resolved a prettier configuration that didn't quite match invoking prettier directly, and the check
+guards against commits that bypassed the hook. It has not caught a real failure in a long time, and
+several Nx majors have passed since, but the mismatch has never been reconfirmed either way — so
+prefer the tool the hook uses.
+
+Note `.prettierignore` excludes some files that are otherwise staged, notably `pnpm-lock.yaml` and
+`**/tsconfig*.json`. Prettier leaves those alone; don't reformat them by hand to "fix" them.
 
 # Code Style
 

--- a/README.md
+++ b/README.md
@@ -197,16 +197,19 @@ The generated API report files should be committed alongside your changes.
 
 ## Formatting, Linting and Typechecking
 
-Formatting happens automatically when you commit. If you use VS Code with this repo's recommended extensions, files will be formatted when you save.
+Formatting happens automatically when you commit — the pre-commit hook runs Prettier over your staged files, and that is the gate. If you use VS Code with this repo's recommended extensions, files will also be formatted when you save. You shouldn't normally need to format anything by hand.
 
-To check TypeScript for readability, maintainability, and functionality errors, and to check a few other files for proper formatting, run the following from the repo root (or just use VS Code with this repo's recommended extensions).
+To check TypeScript for readability, maintainability, and functionality errors, run the following from the repo root (or just use VS Code with this repo's recommended extensions).
 
 ```bash
-nx format:check # to check formatting
-nx format:write # to fix formatting
 nx run-many -t lint # to check linting
 nx run-many -t typecheck # to check types
+npx prettier --write <files> # only if you need to format something by hand
 ```
+
+Use Prettier directly rather than `nx format:write`. CI runs `nx format:check` purely as a backstop for commits that bypassed the hook; it exists because `nx format` once resolved a Prettier configuration that didn't quite match invoking Prettier directly. Several Nx majors have passed and that may well be fixed, but it has never been reconfirmed — so prefer the tool the hook uses.
+
+Note `.prettierignore` excludes some files that still get staged, notably `pnpm-lock.yaml` and `**/tsconfig*.json`. Prettier leaves those alone by design; that isn't the hook failing.
 
 ## TypeScript Code Intelligence
 


### PR DESCRIPTION
`CLAUDE.md` listed `nx format:check` / `nx format:write` under its development commands, so every agent session was being pointed at the wrong tool. `README.md` said the same to humans.

## The rule

Formatting is already handled. The pre-commit hook runs `prettier --write` over staged files (`lint-staged.config.js`), so anything committed is formatted. **Running a format check as part of your own verification is wasted work, and hand-formatting is worse than wasted.**

Where an explicit format is genuinely needed, use `prettier` directly.

## Why not `nx format`

`nx format:check` exists in CI (`test-publish.yml`) as a backstop against commits that bypassed the hook. The reason it was originally added is that `nx format` once resolved a Prettier configuration that didn't quite match invoking Prettier directly.

Several Nx majors have passed since and that may well be fixed — but it has never been reconfirmed either way, so the safe default is the tool the hook actually uses. **The CI check is worth keeping regardless:** it costs nothing and catches bypassed hooks, which is a real failure mode a local convention can't cover.

## Also recorded

`.prettierignore` excludes some files that still get staged, notably `pnpm-lock.yaml` and `**/tsconfig*.json`. Prettier skipping those is by design, not a broken hook. Worth stating explicitly, because it reads as a failure right after you've hand-edited a lockfile — I made exactly that mistake while writing #510 and asserted the hook formats the lockfile when it doesn't.

## Scope

Applied to `CLAUDE.md`, `AGENTS.md` and `README.md`, so it reaches Claude Code, other agent tooling (`opencode.json`, Codex), and humans. `AGENTS.md` changes sit below the nx-managed markers, so they survive regeneration.

This surfaced while writing the dependency sweep procedure in #510, where two trial agents independently inferred from CI that the docs ought to tell you to run `nx format:check` — a reasonable inference from outside the repo, and wrong. Since it applies to all work rather than that one procedure, it's a separate PR. #510 correspondingly has no format step.

`nx format:check` and `cspell` pass. One pre-existing cspell hit remains in `README.md` (British "recognises" against the default US dictionary), untouched here as it's unrelated and cspell isn't wired into CI or the hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/519)
<!-- Reviewable:end -->
