### PR TITLE
PT-4125: Regression test for native (Power-mode) verse delete undo

### DIFF
--- a/packages/platform/src/editor/Editor.test.tsx
+++ b/packages/platform/src/editor/Editor.test.tsx
@@ -2,13 +2,14 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { usjGen1v1 } from "../../../utilities/src/converters/usj/converter-test.data";
 import Editor from "./Editor";
-import { EditorRef } from "./editor.model";
+import { EditorOptions, EditorRef } from "./editor.model";
 import Editorial from "../Editorial";
 import { flushQueuedEvents } from "./editor-test.utils";
 import { ContentJsonPath, Usj } from "@eten-tech-foundation/scripture-utilities";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { SerializedVerseRef } from "@sillsdev/scripture";
 import { act, render } from "@testing-library/react";
-import { KEY_DOWN_COMMAND, LexicalEditor } from "lexical";
+import { KEY_DELETE_COMMAND, KEY_DOWN_COMMAND, LexicalCommand, LexicalEditor } from "lexical";
 import { createRef, RefObject, useEffect } from "react";
 import { vi } from "vitest";
 
@@ -191,10 +192,44 @@ function GrabEditor({ onEditor }: { onEditor: (editor: LexicalEditor) => void })
   return null;
 }
 
-async function pressDelete(editor: LexicalEditor): Promise<void> {
+/** Renders the platform <Editor> and returns both the public ref and the underlying Lexical editor
+ * (needed to dispatch key commands). Covers the setup every delete/undo test repeats. */
+async function mountEditorForUndo(config: {
+  usj: Usj;
+  scrRef: SerializedVerseRef;
+  structureProtectionMode: EditorOptions["structureProtectionMode"];
+}): Promise<{ editorRef: EditorRef; lexicalEditor: LexicalEditor }> {
+  const ref = createRef<EditorRef>();
+  let editor: LexicalEditor | undefined;
+  await act(async () => {
+    render(
+      <Editor
+        ref={ref}
+        defaultUsj={config.usj}
+        scrRef={config.scrRef}
+        onScrRefChange={vi.fn()}
+        options={{ structureProtectionMode: config.structureProtectionMode }}
+      >
+        <GrabEditor onEditor={(e) => (editor = e)} />
+      </Editor>,
+    );
+  });
+  await flushQueuedEvents();
+  if (!ref.current || !editor) throw new Error("EditorRef did not mount");
+  return { editorRef: ref.current, lexicalEditor: editor };
+}
+
+/** Dispatches a synthetic Delete keydown as `command`. Guarded mode listens on KEY_DOWN_COMMAND
+ * (StructureKeyboardPlugin drives the two-step delete from there); Power mode ("off") has no such
+ * listener, so its native delete must go straight to KEY_DELETE_COMMAND — jsdom can't carry a real
+ * DOM keydown far enough to reach RichTextPlugin on its own. */
+async function pressDeleteKey(
+  editor: LexicalEditor,
+  command: LexicalCommand<KeyboardEvent>,
+): Promise<void> {
   await act(async () => {
     editor.dispatchCommand(
-      KEY_DOWN_COMMAND,
+      command,
       new KeyboardEvent("keydown", { key: "Delete", bubbles: true, cancelable: true }),
     );
   });
@@ -220,25 +255,14 @@ describe("undo after a verse-spanning delete (PT-4102 regression)", () => {
   // synchronously mid-commit, corrupting the history stack. A single deletion must be a single
   // undoable step that a single undo fully restores.
   it("restores the deleted text and verse marker with a single undo", async () => {
-    const ref = createRef<EditorRef>();
-    let editor: LexicalEditor | undefined;
-    await act(async () => {
-      render(
-        <Editor
-          ref={ref}
-          defaultUsj={usjWithVerseInParagraphMiddle}
-          scrRef={{ book: "GEN", chapterNum: 1, verseNum: 1 }}
-          onScrRefChange={vi.fn()}
-          options={{ structureProtectionMode: "guarded" }}
-        >
-          <GrabEditor onEditor={(e) => (editor = e)} />
-        </Editor>,
-      );
+    const { editorRef, lexicalEditor } = await mountEditorForUndo({
+      usj: usjWithVerseInParagraphMiddle,
+      scrRef: { book: "GEN", chapterNum: 1, verseNum: 1 },
+      structureProtectionMode: "guarded",
     });
-    await flushQueuedEvents();
-    if (!ref.current || !editor) throw new Error("EditorRef did not mount");
-    const lexicalEditor = editor;
-    const editorRef = ref.current;
+    // Snapshot the loaded document; a single undo must return to exactly this.
+    const original = editorRef.getUsj();
+    if (!original) throw new Error("editor did not load USJ");
 
     // Select "pha " + verse marker + "Bra" — a range that spans the verse marker.
     await act(async () => {
@@ -249,8 +273,8 @@ describe("undo after a verse-spanning delete (PT-4102 regression)", () => {
     });
 
     // Guarded two-step delete: the first Delete arms the range, the second removes it.
-    await pressDelete(lexicalEditor);
-    await pressDelete(lexicalEditor);
+    await pressDeleteKey(lexicalEditor, KEY_DOWN_COMMAND);
+    await pressDeleteKey(lexicalEditor, KEY_DOWN_COMMAND);
     await flushQueuedEvents();
 
     // Precondition: the range (verse marker + surrounding text) was actually deleted.
@@ -258,15 +282,78 @@ describe("undo after a verse-spanning delete (PT-4102 regression)", () => {
     expect(afterDelete).not.toContain('"number":"2"');
     expect(afterDelete).not.toContain("Alpha ");
 
-    // A single undo must bring the text and the verse marker back.
     await act(async () => {
       editorRef.undo();
     });
     await flushQueuedEvents();
 
-    const afterUndo = JSON.stringify(editorRef.getUsj());
-    expect(afterUndo).toContain("Alpha ");
-    expect(afterUndo).toContain("Bravo");
-    expect(afterUndo).toContain('"number":"2"');
+    expect(editorRef.getUsj()).toEqual(original);
+  });
+});
+
+/** Mark 1 with two adjacent verses (7 and 8) inside one paragraph — the PT-4125 repro shape. */
+const usjWithTwoAdjacentVerses: Usj = {
+  type: "USJ",
+  version: "3.1",
+  content: [
+    { type: "book", marker: "id", code: "MRK", content: ["Test Book"] },
+    { type: "chapter", marker: "c", number: "1" },
+    {
+      type: "para",
+      marker: "p",
+      content: [
+        "Six ",
+        { type: "verse", marker: "v", number: "7" },
+        "Seven ",
+        { type: "verse", marker: "v", number: "8" },
+        "Eight ",
+      ],
+    },
+  ],
+};
+
+describe("undo after a native verse delete (PT-4125 regression)", () => {
+  // PT-4125 reproduced in PT10 Power mode, which maps to structureProtectionMode "off": the
+  // StructureKeyboardPlugin registers nothing and deletion is fully native Lexical — not the guarded
+  // two-step delete the PT-4102 test above exercises. The fix (deferring ScriptureReferencePlugin's
+  // SELECTION_CHANGE dispatch off the verse mutation listener with queueMicrotask) is gesture-
+  // agnostic, so native deletes must stay undoable too. This locks in the native path, previously
+  // covered only for the guarded path.
+  //
+  // We delete a range, not a collapsed-caret backspace: the collapsed path routes through Lexical's
+  // deleteCharacter, which needs domSelection.modify (unimplemented in jsdom). A range delete drives
+  // the same verse-destruction -> mutation-listener -> history path.
+  it("restores both deleted verse markers with a single undo (Mark 1:7-8 scenario)", async () => {
+    const { editorRef, lexicalEditor } = await mountEditorForUndo({
+      usj: usjWithTwoAdjacentVerses,
+      scrRef: { book: "MRK", chapterNum: 1, verseNum: 6 },
+      structureProtectionMode: "off",
+    });
+    // Snapshot the loaded document; a single undo must return to exactly this.
+    const original = editorRef.getUsj();
+    if (!original) throw new Error("editor did not load USJ");
+
+    // Select from inside "Six " through the start of "Eight " — spans both verse markers (7 and 8).
+    await act(async () => {
+      editorRef.setSelection({
+        start: { jsonPath: "$.content[2].content[0]", offset: 4 },
+        end: { jsonPath: "$.content[2].content[4]", offset: 0 },
+      });
+    });
+
+    await pressDeleteKey(lexicalEditor, KEY_DELETE_COMMAND);
+    await flushQueuedEvents();
+
+    // Precondition: both verse markers were actually deleted.
+    const afterDelete = JSON.stringify(editorRef.getUsj());
+    expect(afterDelete).not.toContain('"number":"7"');
+    expect(afterDelete).not.toContain('"number":"8"');
+
+    await act(async () => {
+      editorRef.undo();
+    });
+    await flushQueuedEvents();
+
+    expect(editorRef.getUsj()).toEqual(original);
   });
 });


### PR DESCRIPTION
## What

Adds a regression test covering **native (Power-mode) verse deletion + undo** in the platform editor, and hardens both verse-delete undo tests.

Fixes [PT-4125](https://paratextstudio.atlassian.net/browse/PT-4125).

## Why

PT-4125 reported that deleting verses in **PT10 Power mode** couldn't be undone (Undo / CTRL+Z did nothing). Power mode maps to `structureProtectionMode: "off"`, where `StructureKeyboardPlugin` registers nothing and deletion is fully **native Lexical** — a different path from the guarded two-step delete covered by the existing PT-4102 test.

Investigation found the reported bug is **already fixed** on `main` by PT-4102 (#505): deferring `ScriptureReferencePlugin`'s `SELECTION_CHANGE` dispatch off the verse mutation listener with `queueMicrotask`. That fix is mutation-listener based and therefore **gesture-agnostic**, so it covers the native path too. The original report was against Pkg 217, which predates the fix.

This PR closes the **test-coverage gap**: the native path had no regression test, even though it's the exact path the ticket reproduces.

## Changes

- New test: deletes a range spanning two adjacent verse markers (the Mark 1:7–8 shape) via `KEY_DELETE_COMMAND` in `"off"` mode, and asserts a single Undo restores the document.
- Extracted a shared `mountEditorForUndo()` helper and a single parameterized `pressDeleteKey()`, removing ~18 lines of duplicated mount boilerplate across both undo tests.
- Strengthened **both** undo tests (this and the PT-4102 sibling) to assert exact restoration — `getUsj()` `toEqual` a pre-delete snapshot — instead of loose substring checks, so a reordered / duplicated / partial undo now fails.

## Verification

- `nx test @eten-tech-foundation/platform-editor` — full suite green; lint + typecheck clean.
- **Protective:** both tests were confirmed to go **red** when the `queueMicrotask` fix is reverted, failing with the exact PT-4125 symptom (undo restores nothing).
- **Not brittle:** the `toEqual` snapshot assertion was verified against the actual USJ round-trip (stable) — it passes on fixed code and fails only on real corruption.

## Note

The collapsed-caret Backspace gesture can't be exercised in jsdom (it routes through Lexical's `deleteCharacter`, which needs `domSelection.modify`, unimplemented in jsdom). That gesture was **verified manually in-app**; the range-delete test drives the same verse-destruction → mutation-listener → history path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/524)
<!-- Reviewable:end -->
