### PR TITLE
Fix chapter-number reinstatement: c-marker double-increment and applyUpdate undo loss

### DIFF
--- a/packages/platform/src/editor/Editor.test.tsx
+++ b/packages/platform/src/editor/Editor.test.tsx
@@ -283,15 +283,10 @@ const blankUsj: Usj = {
 };
 
 describe("applyUpdate('local') undo-history retention", () => {
-  // A chapter-scaffold insert via `EditorRef.applyUpdate(ops, 'local')` must participate in the
-  // undo stack like any other local edit. It previously did not: `LoadStatePlugin`'s reload effect
-  // depends on `viewOptions`, which `Editor` derived with a plain `useMemo(() => view ??
-  // defaultViewOptions, [view])` - a reference-only memo. A parent re-render that passes a
-  // fresh-but-value-equal `options.view` object (e.g. one triggered by `applyUpdate`'s own
-  // `onUsjChange` round-trip completing, moments after the insert) changed `viewOptions`'s
-  // identity without changing its value, re-firing `LoadStatePlugin` and its unconditional
-  // `CLEAR_HISTORY_COMMAND` dispatch - wiping the just-created undo entry with no document or view
-  // change to justify it.
+  // This test verifies that a value-equal (but reference-different) `view` object does NOT clear
+  // undo history; the next test verifies the complementary case - that a genuinely different
+  // `view` still does. See the comment on `viewOptions`'s memoization in Editor.tsx for why this
+  // matters.
   it("stays undoable across a re-render that passes a fresh-but-equal `options.view` object", async () => {
     const ref = createRef<EditorRef>();
     let editor: LexicalEditor | undefined;
@@ -352,5 +347,69 @@ describe("applyUpdate('local') undo-history retention", () => {
     await flushQueuedEvents();
 
     expect(canUndo).toBe(true);
+  });
+
+  it("clears undo history across a re-render that passes a genuinely different `view` object", async () => {
+    const ref = createRef<EditorRef>();
+    let editor: LexicalEditor | undefined;
+    const optionsA: EditorOptions = {
+      view: { markerMode: "visible", hasSpacing: true, isFormattedFont: false },
+    };
+    // A real view-mode switch - `markerMode` differs from `optionsA` - so the memoized
+    // `viewOptions` must produce a new value and let `LoadStatePlugin` reload as intended.
+    const optionsDifferentView: EditorOptions = {
+      view: { markerMode: "hidden", hasSpacing: true, isFormattedFont: false },
+    };
+
+    let rerender: ((element: React.ReactElement) => void) | undefined;
+    await act(async () => {
+      const result = render(
+        <Editor ref={ref} defaultUsj={blankUsj} options={optionsA}>
+          <GrabEditor onEditor={(e) => (editor = e)} />
+        </Editor>,
+      );
+      rerender = result.rerender;
+    });
+    await flushQueuedEvents();
+    if (!rerender) throw new Error("render did not return a rerender function");
+    const rerenderEditor = rerender;
+    if (!ref.current || !editor) throw new Error("EditorRef did not mount");
+
+    let canUndo = false;
+    editor.registerCommand<boolean>(
+      CAN_UNDO_COMMAND,
+      (payload) => {
+        canUndo = payload;
+        return false;
+      },
+      COMMAND_PRIORITY_CRITICAL,
+    );
+
+    await act(async () => {
+      ref.current?.applyUpdate(
+        [
+          { insert: { chapter: { number: "1", style: "c" } } },
+          { insert: { verse: { number: "1", style: "v" } } },
+        ],
+        "local",
+      );
+    });
+    await flushQueuedEvents();
+    expect(canUndo).toBe(true);
+
+    // A genuinely different `view` must still trigger LoadStatePlugin's reload and clear the
+    // undo stack it just built - proving the memo isn't short-circuiting real changes to always
+    // report "equal" (which would pass the previous test while breaking every real view-mode
+    // switch in the app).
+    await act(async () => {
+      rerenderEditor(
+        <Editor ref={ref} defaultUsj={blankUsj} options={optionsDifferentView}>
+          <GrabEditor onEditor={(e) => (editor = e)} />
+        </Editor>,
+      );
+    });
+    await flushQueuedEvents();
+
+    expect(canUndo).toBe(false);
   });
 });

--- a/packages/platform/src/editor/Editor.test.tsx
+++ b/packages/platform/src/editor/Editor.test.tsx
@@ -2,13 +2,18 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { usjGen1v1 } from "../../../utilities/src/converters/usj/converter-test.data";
 import Editor from "./Editor";
-import { EditorRef } from "./editor.model";
+import { EditorOptions, EditorRef } from "./editor.model";
 import Editorial from "../Editorial";
 import { flushQueuedEvents } from "./editor-test.utils";
 import { ContentJsonPath, Usj } from "@eten-tech-foundation/scripture-utilities";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { act, render } from "@testing-library/react";
-import { KEY_DOWN_COMMAND, LexicalEditor } from "lexical";
+import {
+  CAN_UNDO_COMMAND,
+  COMMAND_PRIORITY_CRITICAL,
+  KEY_DOWN_COMMAND,
+  LexicalEditor,
+} from "lexical";
 import { createRef, RefObject, useEffect } from "react";
 import { vi } from "vitest";
 
@@ -268,5 +273,84 @@ describe("undo after a verse-spanning delete (PT-4102 regression)", () => {
     expect(afterUndo).toContain("Alpha ");
     expect(afterUndo).toContain("Bravo");
     expect(afterUndo).toContain('"number":"2"');
+  });
+});
+
+const blankUsj: Usj = {
+  type: "USJ",
+  version: "3.1",
+  content: [{ type: "book", marker: "id", code: "GEN", content: ["Test Book"] }],
+};
+
+describe("applyUpdate('local') undo-history retention", () => {
+  // A chapter-scaffold insert via `EditorRef.applyUpdate(ops, 'local')` must participate in the
+  // undo stack like any other local edit. It previously did not: `LoadStatePlugin`'s reload effect
+  // depends on `viewOptions`, which `Editor` derived with a plain `useMemo(() => view ??
+  // defaultViewOptions, [view])` - a reference-only memo. A parent re-render that passes a
+  // fresh-but-value-equal `options.view` object (e.g. one triggered by `applyUpdate`'s own
+  // `onUsjChange` round-trip completing, moments after the insert) changed `viewOptions`'s
+  // identity without changing its value, re-firing `LoadStatePlugin` and its unconditional
+  // `CLEAR_HISTORY_COMMAND` dispatch - wiping the just-created undo entry with no document or view
+  // change to justify it.
+  it("stays undoable across a re-render that passes a fresh-but-equal `options.view` object", async () => {
+    const ref = createRef<EditorRef>();
+    let editor: LexicalEditor | undefined;
+    // Two different object references with the same content - simulates a parent re-render that
+    // recomputes `options`/`view` without (or despite) its own memoization.
+    const optionsA: EditorOptions = {
+      view: { markerMode: "visible", hasSpacing: true, isFormattedFont: false },
+    };
+    const optionsB: EditorOptions = {
+      view: { markerMode: "visible", hasSpacing: true, isFormattedFont: false },
+    };
+
+    let rerender: ((element: React.ReactElement) => void) | undefined;
+    await act(async () => {
+      const result = render(
+        <Editor ref={ref} defaultUsj={blankUsj} options={optionsA}>
+          <GrabEditor onEditor={(e) => (editor = e)} />
+        </Editor>,
+      );
+      rerender = result.rerender;
+    });
+    await flushQueuedEvents();
+    if (!rerender) throw new Error("render did not return a rerender function");
+    const rerenderEditor = rerender;
+    if (!ref.current || !editor) throw new Error("EditorRef did not mount");
+
+    let canUndo = false;
+    editor.registerCommand<boolean>(
+      CAN_UNDO_COMMAND,
+      (payload) => {
+        canUndo = payload;
+        return false;
+      },
+      COMMAND_PRIORITY_CRITICAL,
+    );
+
+    await act(async () => {
+      ref.current?.applyUpdate(
+        [
+          { insert: { chapter: { number: "1", style: "c" } } },
+          { insert: { verse: { number: "1", style: "v" } } },
+        ],
+        "local",
+      );
+    });
+    await flushQueuedEvents();
+    expect(canUndo).toBe(true);
+
+    // Mirror the paranext-core sequence: a later re-render (the PDP round-trip settling) passes a
+    // fresh `options` object whose `view` is value-equal to the original but a different reference.
+    await act(async () => {
+      rerenderEditor(
+        <Editor ref={ref} defaultUsj={blankUsj} options={optionsB}>
+          <GrabEditor onEditor={(e) => (editor = e)} />
+        </Editor>,
+      );
+    });
+    await flushQueuedEvents();
+
+    expect(canUndo).toBe(true);
   });
 });

--- a/packages/platform/src/editor/Editor.test.tsx
+++ b/packages/platform/src/editor/Editor.test.tsx
@@ -14,7 +14,7 @@ import {
   KEY_DOWN_COMMAND,
   LexicalEditor,
 } from "lexical";
-import { createRef, RefObject, useEffect } from "react";
+import { createRef, RefObject, useEffect, useState } from "react";
 import { vi } from "vitest";
 
 /** USJ with book PSA for Editor sync effect test (clone of usjGen1v1 with book code changed) */
@@ -411,5 +411,64 @@ describe("applyUpdate('local') undo-history retention", () => {
     await flushQueuedEvents();
 
     expect(canUndo).toBe(false);
+  });
+
+  // The two tests above prove the memo comparator itself works, by manually rerendering with a
+  // hand-constructed `options` object. This test instead exercises the actual integration that
+  // motivated the fix: `applyUpdate` invokes `onUsjChange` directly (see the call in
+  // `applyUpdate`'s imperative handle above), and a parent that reacts to it - the real
+  // paranext-core round trip is `applyUpdate` -> PDP save -> PDP echo -> parent re-render - can
+  // recompute `options.view` as a fresh object with no memoization at all. `Wrapper` below
+  // deliberately does not memoize `view`, so every one of its re-renders (including the one
+  // `onUsjChange` triggers) constructs a brand new, value-equal object - reproducing the actual
+  // bug shape rather than simulating its end state.
+  it("stays undoable through a real onUsjChange-triggered parent re-render with an unmemoized `view`", async () => {
+    const ref = createRef<EditorRef>();
+    let editor: LexicalEditor | undefined;
+
+    function Wrapper() {
+      const [, forceParentRerender] = useState(0);
+      return (
+        <Editor
+          ref={ref}
+          defaultUsj={blankUsj}
+          options={{ view: { markerMode: "visible", hasSpacing: true, isFormattedFont: false } }}
+          onUsjChange={() => forceParentRerender((n) => n + 1)}
+        >
+          <GrabEditor onEditor={(e) => (editor = e)} />
+        </Editor>
+      );
+    }
+
+    await act(async () => {
+      render(<Wrapper />);
+    });
+    await flushQueuedEvents();
+    if (!ref.current || !editor) throw new Error("EditorRef did not mount");
+
+    let canUndo = false;
+    editor.registerCommand<boolean>(
+      CAN_UNDO_COMMAND,
+      (payload) => {
+        canUndo = payload;
+        return false;
+      },
+      COMMAND_PRIORITY_CRITICAL,
+    );
+
+    // This alone triggers the full round trip: `applyUpdate` calls `onUsjChange`, which updates
+    // `Wrapper`'s state, which re-renders `Wrapper` and `Editor` with a fresh `options.view`.
+    await act(async () => {
+      ref.current?.applyUpdate(
+        [
+          { insert: { chapter: { number: "1", style: "c" } } },
+          { insert: { verse: { number: "1", style: "v" } } },
+        ],
+        "local",
+      );
+    });
+    await flushQueuedEvents();
+
+    expect(canUndo).toBe(true);
   });
 });

--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -156,7 +156,23 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
   // a fresh `options` object every render. Pairs with the per-instance `initialConfig` below -
   // any state derived from `options` should follow the same pattern to avoid cross-instance
   // surprises with multiple Editor instances in one WebView.
-  const viewOptions = useMemo(() => view ?? defaultViewOptions, [view]);
+  //
+  // `viewOptions` needs a VALUE-based (not just reference-based) memo: it's a dependency of
+  // `LoadStatePlugin`'s reload effect, which unconditionally calls `setEditorState` +
+  // `CLEAR_HISTORY_COMMAND` on every fire. A plain `useMemo(() => view ?? defaultViewOptions,
+  // [view])` only helps once `view` itself is referentially stable, which the caller is not
+  // guaranteed to provide - a parent re-render that passes a fresh-but-equal `options.view` object
+  // (e.g. one triggered by `applyUpdate`'s own `onUsjChange` round-trip) would otherwise re-fire
+  // `LoadStatePlugin` and silently wipe the undo/redo stacks moments after an edit, with no
+  // document or view change to justify it. Comparing by value keeps the reference stable across
+  // such re-renders while still producing a new one - correctly triggering a reload - when a view
+  // option genuinely changes.
+  const resolvedViewOptions = view ?? defaultViewOptions;
+  const viewOptionsRef = useRef(resolvedViewOptions);
+  if (!deepEqual(viewOptionsRef.current, resolvedViewOptions)) {
+    viewOptionsRef.current = resolvedViewOptions;
+  }
+  const viewOptions = viewOptionsRef.current;
   const nodeOptions = useMemo(() => nodes ?? defaultNodeOptions, [nodes]);
   const contextMenuOptions = useMemo(() => contextMenu, [contextMenu]);
 

--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -181,6 +181,19 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
   const nodeOptions = useMemo(() => nodes ?? defaultNodeOptions, [nodes]);
   const contextMenuOptions = useMemo(() => contextMenu, [contextMenu]);
 
+  // `logger` is also a dependency of `LoadStatePlugin`'s reload effect (see the `viewOptions`
+  // comment above for what that effect does on every fire), so the same reference-instability
+  // risk applies here if a caller ever passes a fresh-but-equivalent logger object. Deep-equality
+  // is still the right comparison for an object whose properties are mostly methods: two
+  // genuinely different loggers won't have the same function references and will correctly be
+  // treated as different, while a caller that re-wraps the same underlying stable methods in a
+  // new object each render will correctly be treated as unchanged.
+  const loggerRef = useRef(logger);
+  if (!deepEqual(loggerRef.current, logger)) {
+    loggerRef.current = logger;
+  }
+  const stableLogger = loggerRef.current;
+
   // `showCharMarkerTitles` rides on the Lexical theme so `CharNode.createDOM` can read it via
   // `EditorConfig.theme`. Theme is the channel because its map permits arbitrary keys and is the
   // lowest-friction way to thread a node-rendering flag through `EditorConfig` without
@@ -199,7 +212,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
     }),
     [isReadonly, viewOptions.showCharMarkerTitles],
   );
-  editorUsjAdaptor.initialize(logger);
+  editorUsjAdaptor.initialize(stableLogger);
 
   useImperativeHandle(ref, () => ({
     focus() {
@@ -239,7 +252,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
       editorRef.current?.update(
         () => {
           if (source === "remote") $addUpdateTag(DELTA_CHANGE_TAG);
-          $applyUpdate(ops, viewOptions, nodeOptions, logger);
+          $applyUpdate(ops, viewOptions, nodeOptions, stableLogger);
         },
         { discrete: true },
       );
@@ -341,7 +354,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
         expandedNoteKeyRef,
         viewOptions,
         nodeOptions,
-        logger,
+        stableLogger,
       );
       markerAction.action({ editor: editorRef.current, reference: scrRef });
     },
@@ -354,7 +367,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
           scrRef,
           viewOptions,
           nodeOptions,
-          logger,
+          stableLogger,
         );
         if (noteNode && !noteNode.getIsCollapsed()) expandedNoteKeyRef.current = noteNode.getKey();
       });
@@ -449,7 +462,13 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
               scrRef={scrRef}
               contextMarker={contextMarker}
               getMarkerAction={(marker) =>
-                getUsjMarkerAction(marker, expandedNoteKeyRef, viewOptions, nodeOptions, logger)
+                getUsjMarkerAction(
+                  marker,
+                  expandedNoteKeyRef,
+                  viewOptions,
+                  nodeOptions,
+                  stableLogger,
+                )
               }
             />
           )}
@@ -460,7 +479,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
             nodeOptions={nodeOptions}
             editorAdaptor={usjEditorAdaptor}
             viewOptions={viewOptions}
-            logger={logger}
+            logger={stableLogger}
           />
           <OnSelectionChangePlugin onChange={onSelectionChange} />
           <DeltaOnChangePlugin
@@ -470,19 +489,19 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
             ignoreTags={blackListedChangeTags}
           />
           <ActiveTextPlugin viewOptions={viewOptions} />
-          <AnnotationPlugin ref={annotationRef} logger={logger} />
+          <AnnotationPlugin ref={annotationRef} logger={stableLogger} />
           <ArrowNavigationPlugin viewOptions={viewOptions} />
           <CharNodePlugin />
           <ClipboardPlugin />
-          <CommandMenuPlugin logger={logger} />
+          <CommandMenuPlugin logger={stableLogger} />
           <ContextMenuPlugin options={contextMenuOptions} />
           <NoteNodePlugin
             expandedNoteKeyRef={expandedNoteKeyRef}
             nodeOptions={nodeOptions}
             viewOptions={viewOptions}
-            logger={logger}
+            logger={stableLogger}
           />
-          <ParaMarkerPrefixGuardPlugin viewOptions={viewOptions} logger={logger} />
+          <ParaMarkerPrefixGuardPlugin viewOptions={viewOptions} logger={stableLogger} />
           <ParaNodePlugin />
           <StructureKeyboardPlugin structureProtectionMode={structureProtectionMode} />
           <TextDirectionPlugin textDirection={textDirection} />

--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -167,6 +167,11 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
   // document or view change to justify it. Comparing by value keeps the reference stable across
   // such re-renders while still producing a new one - correctly triggering a reload - when a view
   // option genuinely changes.
+  //
+  // `nodeOptions` and `contextMenuOptions`, destructured just below, don't need this treatment:
+  // `nodeOptions` is only a dependency of `LoadStatePlugin`'s separate adaptor-*initialize* effect,
+  // not its reload effect, and `contextMenuOptions` isn't passed to `LoadStatePlugin` at all - so
+  // of the three, only `viewOptions`'s identity can trigger the spurious reload this fix addresses.
   const resolvedViewOptions = view ?? defaultViewOptions;
   const viewOptionsRef = useRef(resolvedViewOptions);
   if (!deepEqual(viewOptionsRef.current, resolvedViewOptions)) {

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -74,6 +74,44 @@ describe("USJ Marker Action Utils", () => {
     });
   });
 
+  function $initialEditorStateWithNoChapterNode() {
+    secondVerseTextNode = $createTextNode("second verse text ");
+    $getRoot().append(
+      $createParaNode().append(
+        $createImmutableVerseNode("1"),
+        $createTextNode("first verse text "),
+      ),
+      $createParaNode().append($createImmutableVerseNode("2"), secondVerseTextNode),
+    );
+  }
+
+  it("should insert the current chapter number (not incremented) when no chapter node exists yet", () => {
+    const { editor } = createBasicTestEnvironment(nodes, $initialEditorStateWithNoChapterNode);
+    const markerAction = getUsjMarkerAction(
+      "c",
+      expandedNoteKeyRef,
+      undefined,
+      undefined,
+      undefined,
+      {
+        discrete: true,
+      },
+    );
+    updateSelection(editor, secondVerseTextNode);
+
+    markerAction.action({ editor, reference });
+
+    editor.getEditorState().read(() => {
+      const children = $getRoot().getChildren();
+      expect(children.length).toBe(4);
+      if (!$isImmutableChapterNode(children[2])) throw new Error("Inserted node is not a chapter");
+      // reference.chapterNum is 1 — must be inserted as-is, not incremented to 2.
+      expect(children[2].getNumber()).toBe("1");
+      if (!$isParaNode(children[3]))
+        throw new Error("Inserted node after inserted chapter is not a ParaNode");
+    });
+  });
+
   describe("should insert a verse", () => {
     it("with no leading space", () => {
       const { editor } = createBasicTestEnvironment(nodes, $defaultInitialEditorState);

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -56,6 +56,11 @@ const markerActions: { [marker: string]: UsjMarkerAction } = {
   c: {
     action: (currentEditor) => {
       const { chapterNum } = currentEditor.reference;
+      // Chapter node already present → next chapter; none present (reinstating a missing `\c`
+      // in an otherwise-blank chapter) → keep the current number, don't increment. Intentionally
+      // narrow: this doesn't check whether `chapterNum + 1` already exists elsewhere before
+      // incrementing into it, so the pre-existing duplicate-`\c` case in that scenario is
+      // unchanged by this fix.
       const hasChapterNode = $findChapter($getRoot().getChildren(), chapterNum) !== undefined;
       const targetChapter = hasChapterNode ? chapterNum + 1 : chapterNum;
       const content: MarkerContent = {

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -2,6 +2,7 @@ import { MarkerContent } from "@eten-tech-foundation/scripture-utilities";
 import { SerializedVerseRef } from "@sillsdev/scripture";
 import {
   $createTextNode,
+  $getRoot,
   $getSelection,
   $isElementNode,
   $isRangeSelection,
@@ -14,6 +15,7 @@ import {
 } from "lexical";
 import {
   $createNodeFromSerializedNode,
+  $findChapter,
   $isMarkerNode,
   $isNoteNode,
   $isTypedMarkNode,
@@ -54,11 +56,12 @@ const markerActions: { [marker: string]: UsjMarkerAction } = {
   c: {
     action: (currentEditor) => {
       const { chapterNum } = currentEditor.reference;
-      const nextChapter = chapterNum + 1;
+      const hasChapterNode = $findChapter($getRoot().getChildren(), chapterNum) !== undefined;
+      const targetChapter = hasChapterNode ? chapterNum + 1 : chapterNum;
       const content: MarkerContent = {
         type: "chapter",
         marker: "c",
-        number: `${nextChapter}`,
+        number: `${targetChapter}`,
       };
       return [content];
     },


### PR DESCRIPTION
## Summary

Two fixes supporting Platform.Bible's chapter-number reinstatement feature (paranext-core PR #2645), which lets a user re-add a missing `\c` marker to an effectively-blank chapter via `EditorRef.applyUpdate('local')`.

- **`\c` marker action double-increment**: the marker-action handler for inserting a chapter marker unconditionally incremented the chapter number, even when no `\c` node existed yet in the current chapter (the reinstatement case). Now it only increments when a chapter node is already present (`$findChapter(...) !== undefined`), matching the existing insert-a-chapter test's behavior while adding a regression test for the reinstatement path.
- **`applyUpdate('local')` inserts silently lost undo history**: `Editor.tsx`'s `viewOptions` was recomputed by reference on every render (`view ?? defaultViewOptions`), so `LoadStatePlugin`'s reload effect — which unconditionally dispatches `CLEAR_HISTORY_COMMAND` whenever any of its dependencies change by reference — fired on effectively every render, wiping Lexical's undo stack shortly after an `applyUpdate('local')` insert landed. Fixed by memoizing `viewOptions` against its own previous value via deep-equality (`Editor.tsx`), so the reload effect only re-fires when `view` is genuinely different. The same reload effect also depends on `logger`, which was passed through unmemoized — stabilized it the same way. Added a regression test (stable `view` across renders preserves history), a reverse-direction test (a genuinely different `view` object still triggers reload/history-clear), and an integration test that exercises the real `applyUpdate` → `onUsjChange` → parent-re-render round trip with a genuinely unmemoized `view` (verified it fails without the fix), plus a rationale comment for why `nodeOptions`/`contextMenuOptions` are intentionally left reference-only (not consumed by the reload effect).

## Known follow-up (not fixed here)

- A second, separate cause of undo-history loss was identified but not chased down in this branch: `paranext-core`'s `use-editor-pdp-sync.hook.ts` calls `EditorRef.setUsj()` on the PDP-echo success path after certain inserts, which also clears Lexical's undo history. This is tracked in the paranext-core PR and documented as a deliberate, decided-upon follow-up rather than a merge blocker for either PR.
- **This fix stabilizes `viewOptions`/`logger` at the `platform` package's `Editor.tsx` only — it does not touch the root cause.** `LoadStatePlugin`'s reload effect unconditionally clears undo history on every fire, with no check that the resulting state actually differs from what's loaded; per-consumer stabilization treats the symptom. `packages/scribe/src/editor/Editor.tsx` and `NoteEditor.tsx` also consume `LoadStatePlugin` and pass `viewOptions` through unmemoized — the identical exposure, in a package this PR deliberately doesn't touch. A real fix inside `LoadStatePlugin` itself (gate `CLEAR_HISTORY_COMMAND` on an actual document/state change) would close this for every consumer, including scribe, at once — left as a follow-up given its scope (a shared plugin used across packages) rather than expanding this PR.

## Test plan

- [x] `npx nx run @eten-tech-foundation/platform-editor:lint` — clean
- [x] `npx nx run @eten-tech-foundation/platform-editor:typecheck` — clean
- [x] `npx vitest run packages/platform/src/editor` — 155 passed, 3 skipped (pre-existing skips, unrelated)
- [x] Manually verified in a running Platform.Bible instance (via the paranext-core branch's yalc-vendored build) that reinstating a chapter number no longer double-inserts `\c`, and that a single `applyUpdate('local')` insert is now undoable immediately after insert.

AI-assisted — session generated by Claude Code (Claude Sonnet 5).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/526)
<!-- Reviewable:end -->

