### PR TITLE
Fix marker-dropdown verse-number inference (T-A items 2+3)

### DIFF
--- a/libs/shared-react/src/nodes/usj/node-react-utils.test.ts
+++ b/libs/shared-react/src/nodes/usj/node-react-utils.test.ts
@@ -262,7 +262,7 @@ describe("$findNextVerseAfter()", () => {
     );
 
     editor.getEditorState().read(() => {
-      expect($findNextVerseAfter(verse1).getNumber()).toBe("2");
+      expect($findNextVerseAfter(verse1)?.getNumber()).toBe("2");
     });
   });
 

--- a/libs/shared-react/src/nodes/usj/node-react-utils.test.ts
+++ b/libs/shared-react/src/nodes/usj/node-react-utils.test.ts
@@ -5,6 +5,7 @@ import { ViewOptions } from "../../views/view-options.utils";
 import { $isImmutableNoteCallerNode, ImmutableNoteCallerNode } from "./ImmutableNoteCallerNode";
 import { ImmutableVerseNode, $createImmutableVerseNode } from "./ImmutableVerseNode";
 import {
+  $findNextVerseAfter,
   $findPreviousVerseInSiblings,
   $findVerseInNode,
   $findVerseOrPara,
@@ -242,6 +243,81 @@ describe("$findPreviousVerseInSiblings()", () => {
       const verseNode = $findPreviousVerseInSiblings(p, 2);
 
       expect(verseNode?.getNumber()).toBe("1");
+    });
+  });
+});
+
+describe("$findNextVerseAfter()", () => {
+  it("finds the next verse sibling within the same parent", () => {
+    let verse1: VerseNode;
+    const { editor } = createBasicTestEnvironment([ParaNode, VerseNode]);
+    editor.update(
+      () => {
+        verse1 = $createVerseNode("1");
+        $getRoot().append(
+          $createParaNode().append(verse1, $createTextNode("text1"), $createVerseNode("2")),
+        );
+      },
+      { discrete: true },
+    );
+
+    editor.getEditorState().read(() => {
+      expect($findNextVerseAfter(verse1).getNumber()).toBe("2");
+    });
+  });
+
+  it("finds the next verse in a following paragraph", () => {
+    let verse1: VerseNode;
+    const { editor } = createBasicTestEnvironment([ParaNode, VerseNode]);
+    editor.update(
+      () => {
+        verse1 = $createVerseNode("1");
+        $getRoot().append(
+          $createParaNode().append(verse1, $createTextNode("text1")),
+          $createParaNode().append($createVerseNode("2"), $createTextNode("text2")),
+        );
+      },
+      { discrete: true },
+    );
+
+    editor.getEditorState().read(() => {
+      expect($findNextVerseAfter(verse1)?.getNumber()).toBe("2");
+    });
+  });
+
+  it("returns undefined when a chapter boundary is reached before another verse", () => {
+    let verse1: VerseNode;
+    const { editor } = createBasicTestEnvironment([ParaNode, VerseNode, ImmutableChapterNode]);
+    editor.update(
+      () => {
+        verse1 = $createVerseNode("1");
+        $getRoot().append(
+          $createParaNode().append(verse1, $createTextNode("text1")),
+          $createImmutableChapterNode("2"),
+          $createParaNode().append($createVerseNode("1"), $createTextNode("text2")),
+        );
+      },
+      { discrete: true },
+    );
+
+    editor.getEditorState().read(() => {
+      expect($findNextVerseAfter(verse1)).toBeUndefined();
+    });
+  });
+
+  it("returns undefined when there is no next verse anywhere", () => {
+    let verse1: VerseNode;
+    const { editor } = createBasicTestEnvironment([ParaNode, VerseNode]);
+    editor.update(
+      () => {
+        verse1 = $createVerseNode("1");
+        $getRoot().append($createParaNode().append(verse1, $createTextNode("text1")));
+      },
+      { discrete: true },
+    );
+
+    editor.getEditorState().read(() => {
+      expect($findNextVerseAfter(verse1)).toBeUndefined();
     });
   });
 });

--- a/libs/shared-react/src/nodes/usj/node-react.utils.ts
+++ b/libs/shared-react/src/nodes/usj/node-react.utils.ts
@@ -426,6 +426,32 @@ export function $findPreviousVerseInSiblings(
 }
 
 /**
+ * Find the next verse node after `verseNode` in document order, stopping at the next chapter
+ * boundary (or the end of the document). Forward counterpart to `$findPreviousVerseInSiblings` /
+ * the backward walk in `$findThisVerse`.
+ * @param verseNode - The verse node to search forward from.
+ * @returns The next verse node, or `undefined` if none exists before the next chapter/document end.
+ */
+export function $findNextVerseAfter(verseNode: SomeVerseNode): SomeVerseNode | undefined {
+  const parent = verseNode.getParent();
+  if (parent && $isElementNode(parent)) {
+    const children = parent.getChildren();
+    for (let i = verseNode.getIndexWithinParent() + 1; i < children.length; i++) {
+      const child = children[i];
+      if ($isSomeVerseNode(child)) return child;
+    }
+  }
+
+  let nextPara = parent?.getNextSibling();
+  while (nextPara && !$isSomeChapterNode(nextPara)) {
+    const verse = $findNextVerseInNode(nextPara);
+    if (verse) return verse;
+    nextPara = nextPara.getNextSibling();
+  }
+  return undefined;
+}
+
+/**
  * Find the last verse in the children of the node.
  * @param node - Node with potential verses in children.
  * @returns the verse node if found, `undefined` otherwise.

--- a/libs/shared-react/src/plugins/usj/StructureKeyboardPlugin.test.tsx
+++ b/libs/shared-react/src/plugins/usj/StructureKeyboardPlugin.test.tsx
@@ -3,6 +3,7 @@
 
 import { $createImmutableVerseNode, ImmutableVerseNode } from "../../nodes/usj";
 import { StructureKeyboardPlugin } from "./StructureKeyboardPlugin";
+import { HistoryPlugin } from "../History/HistoryPlugin";
 import { baseTestEnvironment, pressKey, updateSelection } from "./react-test.utils";
 import { act } from "@testing-library/react";
 import {
@@ -19,8 +20,10 @@ import {
   DRAGSTART_COMMAND,
   DROP_COMMAND,
   PASTE_COMMAND,
+  UNDO_COMMAND,
+  REDO_COMMAND,
 } from "lexical";
-import { $createParaNode, $isParaNode, ParaNode } from "shared";
+import { $createParaNode, $isParaNode, createEmptyHistoryState, ParaNode } from "shared";
 
 // NOTE: jsdom cannot drive collapsed mid-text deletes (domSelection.modify) or printable-char
 // insertion via dispatchCommand, and IS_APPLE is false so Alt+Backspace is a no-op. Those cases
@@ -593,6 +596,89 @@ describe("StructureKeyboardPlugin — two-step delete for range selections with 
       expect(para.getChildren().some((n) => n instanceof ImmutableVerseNode)).toBe(true); // survived
       expect(para.getTextContent()).toBe("abcd");
     });
+  });
+});
+
+describe("StructureKeyboardPlugin — per-edit undo/redo for a run of verse deletions", () => {
+  it("restores and re-deletes verses one at a time via Undo/Redo, with no data loss", async () => {
+    let tailText: TextNode;
+    const historyState = createEmptyHistoryState();
+    const { editor } = await baseTestEnvironment(
+      () => {
+        tailText = $createTextNode("text");
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createImmutableVerseNode("1"),
+            $createImmutableVerseNode("2"),
+            $createImmutableVerseNode("3"),
+            tailText,
+          ),
+        );
+      },
+      <>
+        <StructureKeyboardPlugin structureProtectionMode="guarded" />
+        <HistoryPlugin externalHistoryState={historyState} />
+      </>,
+    );
+    updateSelection(editor, tailText!, 0);
+
+    // Delete verse 3, then verse 2, then verse 1 - each via the two-step Backspace gesture.
+    await pressKey(editor, "Backspace", 0); // arm verse 3
+    await pressKey(editor, "Backspace", 0); // fire: verse 3 removed
+    await pressKey(editor, "Backspace", 0); // arm verse 2
+    await pressKey(editor, "Backspace", 0); // fire: verse 2 removed
+    await pressKey(editor, "Backspace", 0); // arm verse 1
+    await pressKey(editor, "Backspace", 0); // fire: verse 1 removed
+
+    const readVerseNumbers = () =>
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getChildren()[0] as ParaNode;
+        return para
+          .getChildren()
+          .filter((n): n is ImmutableVerseNode => n instanceof ImmutableVerseNode)
+          .map((n) => n.getNumber());
+      });
+
+    expect(readVerseNumbers()).toEqual([]);
+
+    // Each Undo press restores exactly the deletion it corresponds to, LIFO - proving no deletion
+    // (including the FIRST one, verse 3) is ever permanently lost from the undo stack.
+    await act(async () => {
+      editor.dispatchCommand(UNDO_COMMAND, undefined);
+    });
+    expect(readVerseNumbers()).toEqual(["1"]);
+
+    await act(async () => {
+      editor.dispatchCommand(UNDO_COMMAND, undefined);
+    });
+    expect(readVerseNumbers()).toEqual(["1", "2"]);
+
+    await act(async () => {
+      editor.dispatchCommand(UNDO_COMMAND, undefined);
+    });
+    expect(readVerseNumbers()).toEqual(["1", "2", "3"]);
+
+    // A further Undo is a no-op - nothing left to undo.
+    await act(async () => {
+      editor.dispatchCommand(UNDO_COMMAND, undefined);
+    });
+    expect(readVerseNumbers()).toEqual(["1", "2", "3"]);
+
+    // Redo walks back through the same sequence in reverse, fully symmetric.
+    await act(async () => {
+      editor.dispatchCommand(REDO_COMMAND, undefined);
+    });
+    expect(readVerseNumbers()).toEqual(["1", "2"]);
+
+    await act(async () => {
+      editor.dispatchCommand(REDO_COMMAND, undefined);
+    });
+    expect(readVerseNumbers()).toEqual(["1"]);
+
+    await act(async () => {
+      editor.dispatchCommand(REDO_COMMAND, undefined);
+    });
+    expect(readVerseNumbers()).toEqual([]);
   });
 });
 

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -29,6 +29,9 @@ const nodes = usjReactNodes;
 const reference = { book: "GEN", chapterNum: 1, verseNum: 1 };
 
 let secondVerseTextNode: TextNode;
+let noVerseText: TextNode;
+let verse1Text: TextNode;
+let insertedVerse2Text: TextNode;
 
 function $defaultInitialEditorState() {
   secondVerseTextNode = $createTextNode("second verse text ");
@@ -145,7 +148,6 @@ describe("USJ Marker Action Utils", () => {
 
   describe("verse-number inference", () => {
     it("inserts verse 1 with no highlight when no verse precedes the caret", () => {
-      let noVerseText: TextNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         noVerseText = $createTextNode("no verse yet");
         $getRoot().append($createImmutableChapterNode("1"), $createParaNode().append(noVerseText));
@@ -173,7 +175,6 @@ describe("USJ Marker Action Utils", () => {
     });
 
     it("increments across a gap with no highlight", () => {
-      let verse1Text: TextNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         verse1Text = $createTextNode("verse one ");
         $getRoot().append(
@@ -206,7 +207,6 @@ describe("USJ Marker Action Utils", () => {
     });
 
     it("increments and highlights when preceding and following verses are adjacent (no numeric slot)", () => {
-      let verse1Text: TextNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         verse1Text = $createTextNode("first verse text ");
         $getRoot().append(
@@ -244,7 +244,6 @@ describe("USJ Marker Action Utils", () => {
     });
 
     it("does not repeat/garble verse numbers when re-adding into a gap (Build 223 regression)", () => {
-      let verse1Text: TextNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         // "verse one " (10 chars) + "text" (4 chars): caret splits after the first part, leaving
         // "text" as a trailing node so a second insertion can be anchored right after the first.
@@ -266,7 +265,6 @@ describe("USJ Marker Action Utils", () => {
       updateSelection(editor, verse1Text, 10);
       markerAction.action({ editor, reference });
 
-      let insertedVerse2Text: TextNode;
       editor.getEditorState().read(() => {
         const para = $getRoot().getChildren()[1];
         if (!$isParaNode(para)) throw new Error("Expected a ParaNode");

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -6,7 +6,14 @@ import {
   updateSelection,
 } from "../../../../../libs/shared/src/nodes/usj/test.utils";
 import { getUsjMarkerAction, isUsjMarkerSupported } from "./usj-marker-action.utils";
-import { $createTextNode, $getRoot, $isTextNode, TextNode } from "lexical";
+import {
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isNodeSelection,
+  $isTextNode,
+  TextNode,
+} from "lexical";
 import { $createImmutableVerseNode, $isImmutableVerseNode, usjReactNodes } from "shared-react";
 import {
   $createImmutableChapterNode,
@@ -96,7 +103,9 @@ describe("USJ Marker Action Utils", () => {
         const insertedNode = secondVerseTextNode.getNextSibling();
         if (!$isImmutableVerseNode(insertedNode)) throw new Error("Inserted node is not a verse");
         expect(insertedNode.getMarker()).toBe("v");
-        expect(insertedNode.getNumber()).toBe("2");
+        // Verse 2 is the chapter's last verse (no following verse): inferred from the actual
+        // tree, not the stale reference.verseNum=1 this test's fixture reference carries.
+        expect(insertedNode.getNumber()).toBe("3");
         const tailTextNode = insertedNode.getNextSibling();
         if (!$isTextNode(tailTextNode)) throw new Error("Tail node is not text");
         expect(tailTextNode.getTextContent()).toBe("verse text ");
@@ -125,11 +134,164 @@ describe("USJ Marker Action Utils", () => {
         const insertedNode = secondVerseTextNode.getNextSibling();
         if (!$isImmutableVerseNode(insertedNode)) throw new Error("Inserted node is not a verse");
         expect(insertedNode.getMarker()).toBe("v");
-        expect(insertedNode.getNumber()).toBe("2");
+        expect(insertedNode.getNumber()).toBe("3"); // last verse in chapter: increment from tree
         const tailTextNode = insertedNode.getNextSibling();
         if (!$isTextNode(tailTextNode)) throw new Error("Tail node is not text");
         expect(tailTextNode.getTextContent()).toBe("verse text ");
         $expectSelectionToBe(tailTextNode, 0);
+      });
+    });
+  });
+
+  describe("verse-number inference", () => {
+    it("inserts verse 1 with no highlight when no verse precedes the caret", () => {
+      let noVerseText: TextNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        noVerseText = $createTextNode("no verse yet");
+        $getRoot().append($createImmutableChapterNode("1"), $createParaNode().append(noVerseText));
+      });
+      const markerAction = getUsjMarkerAction(
+        "v",
+        expandedNoteKeyRef,
+        undefined,
+        undefined,
+        undefined,
+        { discrete: true },
+      );
+      updateSelection(editor, noVerseText!, 0);
+
+      markerAction.action({ editor, reference });
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getChildren()[1];
+        if (!$isParaNode(para)) throw new Error("Expected a ParaNode");
+        const insertedNode = para.getChildren().find($isImmutableVerseNode);
+        if (!insertedNode) throw new Error("Expected an inserted verse node");
+        expect(insertedNode.getNumber()).toBe("1");
+        expect($isNodeSelection($getSelection())).toBe(false); // not highlighted
+      });
+    });
+
+    it("increments across a gap with no highlight", () => {
+      let verse1Text: TextNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        verse1Text = $createTextNode("verse one ");
+        $getRoot().append(
+          $createImmutableChapterNode("1"),
+          $createParaNode().append($createImmutableVerseNode("1"), verse1Text),
+          $createParaNode().append($createImmutableVerseNode("4"), $createTextNode("verse four")),
+        );
+      });
+      const markerAction = getUsjMarkerAction(
+        "v",
+        expandedNoteKeyRef,
+        undefined,
+        undefined,
+        undefined,
+        { discrete: true },
+      );
+      updateSelection(editor, verse1Text!);
+
+      markerAction.action({ editor, reference });
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getChildren()[1];
+        if (!$isParaNode(para)) throw new Error("Expected a ParaNode");
+        // findLast: the pre-existing verse 1 is also a child of this paragraph and comes first.
+        const insertedNode = para.getChildren().findLast($isImmutableVerseNode);
+        if (!insertedNode) throw new Error("Expected an inserted verse node");
+        expect(insertedNode.getNumber()).toBe("2"); // gap between 1 and 4: increment, not garbled
+        expect($isNodeSelection($getSelection())).toBe(false);
+      });
+    });
+
+    it("increments and highlights when preceding and following verses are adjacent (no numeric slot)", () => {
+      let verse1Text: TextNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        verse1Text = $createTextNode("first verse text ");
+        $getRoot().append(
+          $createImmutableChapterNode("1"),
+          $createParaNode().append($createImmutableVerseNode("1"), verse1Text),
+          $createParaNode().append(
+            $createImmutableVerseNode("2"),
+            $createTextNode("second verse text"),
+          ),
+        );
+      });
+      const markerAction = getUsjMarkerAction(
+        "v",
+        expandedNoteKeyRef,
+        undefined,
+        undefined,
+        undefined,
+        { discrete: true },
+      );
+      updateSelection(editor, verse1Text!);
+
+      markerAction.action({ editor, reference });
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getChildren()[1];
+        if (!$isParaNode(para)) throw new Error("Expected a ParaNode");
+        // findLast: the pre-existing verse 1 is also a child of this paragraph and comes first.
+        const insertedNode = para.getChildren().findLast($isImmutableVerseNode);
+        if (!insertedNode) throw new Error("Expected an inserted verse node");
+        expect(insertedNode.getNumber()).toBe("2");
+        const sel = $getSelection();
+        expect($isNodeSelection(sel)).toBe(true);
+        if ($isNodeSelection(sel)) expect(sel.has(insertedNode.getKey())).toBe(true); // highlighted
+      });
+    });
+
+    it("does not repeat/garble verse numbers when re-adding into a gap (Build 223 regression)", () => {
+      let verse1Text: TextNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        // "verse one " (10 chars) + "text" (4 chars): caret splits after the first part, leaving
+        // "text" as a trailing node so a second insertion can be anchored right after the first.
+        verse1Text = $createTextNode("verse one text");
+        $getRoot().append(
+          $createImmutableChapterNode("1"),
+          $createParaNode().append($createImmutableVerseNode("1"), verse1Text),
+          $createParaNode().append($createImmutableVerseNode("4"), $createTextNode("verse four")),
+        );
+      });
+      const markerAction = getUsjMarkerAction(
+        "v",
+        expandedNoteKeyRef,
+        undefined,
+        undefined,
+        undefined,
+        { discrete: true },
+      );
+      updateSelection(editor, verse1Text!, 10);
+      markerAction.action({ editor, reference });
+
+      let insertedVerse2Text: TextNode;
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getChildren()[1];
+        if (!$isParaNode(para)) throw new Error("Expected a ParaNode");
+        // findLast: the pre-existing verse 1 is also a child of this paragraph and comes first.
+        const insertedNode = para.getChildren().findLast($isImmutableVerseNode);
+        if (!insertedNode) throw new Error("Expected inserted verse");
+        expect(insertedNode.getNumber()).toBe("2"); // not "11" or garbled
+        const tail = insertedNode.getNextSibling();
+        if (!$isTextNode(tail)) throw new Error("Expected trailing text node");
+        insertedVerse2Text = tail;
+      });
+
+      // Re-add the next missing verse immediately after, simulating the user manually recovering
+      // from an incomplete undo.
+      updateSelection(editor, insertedVerse2Text!, 0);
+      markerAction.action({ editor, reference });
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getChildren()[1];
+        if (!$isParaNode(para)) throw new Error("Expected a ParaNode");
+        const verseNumbers = para
+          .getChildren()
+          .filter($isImmutableVerseNode)
+          .map((v) => v.getNumber());
+        expect(verseNumbers).toEqual(["1", "2", "3"]); // clean sequence, no repeats
       });
     });
   });

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -158,7 +158,7 @@ describe("USJ Marker Action Utils", () => {
         undefined,
         { discrete: true },
       );
-      updateSelection(editor, noVerseText!, 0);
+      updateSelection(editor, noVerseText, 0);
 
       markerAction.action({ editor, reference });
 
@@ -190,7 +190,7 @@ describe("USJ Marker Action Utils", () => {
         undefined,
         { discrete: true },
       );
-      updateSelection(editor, verse1Text!);
+      updateSelection(editor, verse1Text);
 
       markerAction.action({ editor, reference });
 
@@ -226,7 +226,7 @@ describe("USJ Marker Action Utils", () => {
         undefined,
         { discrete: true },
       );
-      updateSelection(editor, verse1Text!);
+      updateSelection(editor, verse1Text);
 
       markerAction.action({ editor, reference });
 
@@ -263,7 +263,7 @@ describe("USJ Marker Action Utils", () => {
         undefined,
         { discrete: true },
       );
-      updateSelection(editor, verse1Text!, 10);
+      updateSelection(editor, verse1Text, 10);
       markerAction.action({ editor, reference });
 
       let insertedVerse2Text: TextNode;
@@ -281,7 +281,7 @@ describe("USJ Marker Action Utils", () => {
 
       // Re-add the next missing verse immediately after, simulating the user manually recovering
       // from an incomplete undo.
-      updateSelection(editor, insertedVerse2Text!, 0);
+      updateSelection(editor, insertedVerse2Text, 0);
       markerAction.action({ editor, reference });
 
       editor.getEditorState().read(() => {

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -89,14 +89,10 @@ const markerActions: { [marker: string]: UsjMarkerAction } = {
         const precedingVerseString = precedingVerse.getNumber();
         nextVerseNumber = getNextVerse(parseInt(precedingVerseString, 10), precedingVerseString);
         const followingVerse = $findNextVerseAfter(precedingVerse);
-        if (followingVerse) {
-          const precedingNum = parseInt(precedingVerseString, 10);
-          const followingNum = parseInt(followingVerse.getNumber(), 10);
-          highlightInserted =
-            !Number.isNaN(precedingNum) &&
-            !Number.isNaN(followingNum) &&
-            followingNum - precedingNum === 1;
-        }
+        // Compare the actual inserted number against the following verse's number directly
+        // (not a parsed-integer diff), so segments ("5b" -> "5c") and bridges ("5-6" -> "7")
+        // are judged by whether they truly collide, not by their leading digit's distance.
+        highlightInserted = !!followingVerse && nextVerseNumber === followingVerse.getNumber();
       }
 
       const content: MarkerContent = {

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -1,11 +1,13 @@
 import { MarkerContent } from "@eten-tech-foundation/scripture-utilities";
 import { SerializedVerseRef } from "@sillsdev/scripture";
 import {
+  $createNodeSelection,
   $createTextNode,
   $getSelection,
   $isElementNode,
   $isRangeSelection,
   $isTextNode,
+  $setSelection,
   EditorUpdateOptions,
   LexicalEditor,
   LexicalNode,
@@ -21,6 +23,7 @@ import {
   CharNode,
   createLexicalUsjNode,
   getNextVerse,
+  getSelectionStartNode,
   LoggerBasic,
   MarkerAction,
   NBSP,
@@ -30,6 +33,8 @@ import {
 } from "shared";
 import {
   $addTrailingSpace,
+  $findNextVerseAfter,
+  $findThisVerse,
   $insertNote,
   $isSomeVerseNode,
   $removeLeadingSpace,
@@ -39,6 +44,13 @@ import {
 } from "shared-react";
 import usjEditorAdaptor from "./usj-editor.adaptor";
 
+interface UsjMarkerActionResult {
+  content: MarkerContent[];
+  /** When true, the outer handler selects the freshly-inserted node (`NodeSelection`) instead of
+   * placing the caret after it - used by the verse action's "no numeric slot" highlight cue. */
+  highlightInserted?: boolean;
+}
+
 interface UsjMarkerAction {
   label?: string;
   action: (currentEditor: {
@@ -47,7 +59,7 @@ interface UsjMarkerAction {
     autoNumbering?: boolean;
     newVerseRChapterNum?: number;
     noteText?: string;
-  }) => MarkerContent[];
+  }) => UsjMarkerActionResult;
 }
 
 const markerActions: { [marker: string]: UsjMarkerAction } = {
@@ -60,19 +72,39 @@ const markerActions: { [marker: string]: UsjMarkerAction } = {
         marker: "c",
         number: `${nextChapter}`,
       };
-      return [content];
+      return { content: [content] };
     },
   },
   v: {
-    action: (currentEditor) => {
-      const { verseNum, verse } = currentEditor.reference;
-      const nextVerse = getNextVerse(verseNum, verse);
+    action: () => {
+      const selection = $getSelection();
+      const anchorNode = getSelectionStartNode(selection);
+      const precedingVerse = $findThisVerse(anchorNode);
+
+      let nextVerseNumber: string;
+      let highlightInserted = false;
+      if (!precedingVerse) {
+        nextVerseNumber = "1";
+      } else {
+        const precedingVerseString = precedingVerse.getNumber();
+        nextVerseNumber = getNextVerse(parseInt(precedingVerseString, 10), precedingVerseString);
+        const followingVerse = $findNextVerseAfter(precedingVerse);
+        if (followingVerse) {
+          const precedingNum = parseInt(precedingVerseString, 10);
+          const followingNum = parseInt(followingVerse.getNumber(), 10);
+          highlightInserted =
+            !Number.isNaN(precedingNum) &&
+            !Number.isNaN(followingNum) &&
+            followingNum - precedingNum === 1;
+        }
+      }
+
       const content: MarkerContent = {
         type: "verse",
         marker: "v",
-        number: `${nextVerse}`,
+        number: nextVerseNumber,
       };
-      return [content];
+      return { content: [content], highlightInserted };
     },
   },
 };
@@ -127,7 +159,7 @@ export function getUsjMarkerAction(
     currentEditor.editor.update(() => {
       const selection = $getSelection();
       if ($isRangeSelection(selection)) currentEditor.noteText = selection.getTextContent();
-      const content = markerAction.action(currentEditor);
+      const { content, highlightInserted } = markerAction.action(currentEditor);
 
       const serializedLexicalNode = createLexicalUsjNode(content, usjEditorAdaptor, viewOptions);
       const nodeToInsert = $createNodeFromSerializedNode(serializedLexicalNode);
@@ -176,9 +208,15 @@ export function getUsjMarkerAction(
         } else {
           selection.insertNodes([nodeToInsert]);
           $moveVerseFollowingSpaceToPreviousNode(nodeToInsert);
-          const nextNode = nodeToInsert.getNextSibling();
-          if (nextNode) nextNode.selectStart();
-          else nodeToInsert.selectStart();
+          if (highlightInserted) {
+            const nodeSelection = $createNodeSelection();
+            nodeSelection.add(nodeToInsert.getKey());
+            $setSelection(nodeSelection);
+          } else {
+            const nextNode = nodeToInsert.getNextSibling();
+            if (nextNode) nextNode.selectStart();
+            else nodeToInsert.selectStart();
+          }
         }
       } else {
         // Insert the node directly
@@ -196,14 +234,14 @@ function getMarkerAction(marker: string): UsjMarkerAction | undefined {
       markerAction = {
         action: () => {
           const content: MarkerContent = { type: ParaNode.getType(), marker, content: [] };
-          return [content];
+          return { content: [content] };
         },
       };
     } else if (CharNode.isValidMarker(marker)) {
       markerAction = {
         action: () => {
           const content: MarkerContent = { type: CharNode.getType(), marker };
-          return [content];
+          return { content: [content] };
         },
       };
     }


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: fix-verse-marker-restoration-and-inference

**Base**: origin/main

**Date**: 2026-08-05

**Review model**: Claude Sonnet 5

**Files changed**: 5

## Overview

This branch addresses T-A items 2+3 from the design spec (verse-marker restoration reliability and verse-number inference). Two distinct pieces:

1. **Undo reliability** — investigated whether a run of verse-marker deletions could lose data on Undo/Redo (Build 223's complaint). Reproduced the scenario against unfixed code and found nothing is ever permanently lost: each deletion is already independently undo/redo-able, and pressing Undo the matching number of times fully restores everything, including the first-deleted verse, with Redo mirroring it exactly. No production fix was made; a regression test (`StructureKeyboardPlugin.test.tsx`) pins this behavior so a future refactor can't silently reintroduce data loss.
2. **Verse-number inference** — the marker-dropdown's `v` action previously derived the inserted verse number from a caller-supplied `reference.verseNum`/`.verse`, which can drift from the actual document and was producing garbled sequences ("1114"/"1244" per Build 223). Reworked to scan the real `VerseNode` sequence via a new `$findNextVerseAfter` helper plus the existing `$findThisVerse`, applying the PRD's inference rules (no preceding → 1; gap → increment; adjacent → increment + highlight; no following → increment).

## API Changes

- `libs/shared-react` (internal workspace lib, not published to npm): added new export `$findNextVerseAfter(verseNode: SomeVerseNode): SomeVerseNode | undefined` — a forward-search counterpart to the existing `$findPreviousVerseInSiblings`.
- `packages/platform` (published as `@eten-tech-foundation/platform-editor`): in the internal (non-exported) `usj-marker-action.utils.ts`, the internal `UsjMarkerAction.action` return type changed from `MarkerContent[]` to `{ content: MarkerContent[]; highlightInserted?: boolean }`.
- Neither of the above is re-exported from `packages/platform/src/index.ts` or `packages/scribe/src/index.ts` — the published npm surfaces of `@eten-tech-foundation/platform-editor` and `@eten-tech-foundation/scribe-editor` are unchanged.
- No changes to `packages/utilities` (`@eten-tech-foundation/scripture-utilities`) or any `.d.ts` files.

## Findings

### Critical — Must address before merge

- [x] **`libs/shared-react/src/nodes/usj/node-react-utils.test.ts:265` was missing the `?.` that the other three assertions in the same `describe("$findNextVerseAfter()", ...)` block have** (`$findNextVerseAfter(verse1).getNumber()` instead of `$findNextVerseAfter(verse1)?.getNumber()`), which fails `tsc` with `TS2532: Object is possibly 'undefined'` since the helper returns `SomeVerseNode | undefined`. This would have failed CI's typecheck step. _(fixed during review: added the missing `?.`)_

Author confirmed and asked me to fix it immediately — verified independently by running `tsc` before and after (`TS2532` reproduced, then cleared).

### Important — Should address before merge

- [x] **`packages/platform/src/editor/adaptors/usj-marker-action.utils.ts`: `highlightInserted` was computed via `parseInt`-truncated preceding/following verse numbers and a numeric diff (`followingNum - precedingNum === 1`), rather than comparing the actual computed `nextVerseNumber` to the following verse's number.** This breaks for verse segments and bridges, which `getNextVerse` explicitly supports:
  - Segment false positive: preceding `"5b"`, following `"6"` → `nextVerseNumber` computes to `"5c"` (no collision), but the parseInt diff (`5` vs `6`, diff `1`) wrongly set `highlightInserted = true`.
  - Bridge false negative: preceding `"5-6"`, following `"7"` → `nextVerseNumber` computes to `"7"` (a real collision with the following verse), but `parseInt("5-6")` truncates to `5`, diff `2` → wrongly set `highlightInserted = false`, silently missing a real collision.
  _(fixed during review: `highlightInserted` now computed as `!!followingVerse && nextVerseNumber === followingVerse.getNumber()` — simpler and correct for plain numbers, segments, and bridges alike. Verified against all four existing "verse-number inference" test cases plus the two edge cases above; full test suite re-run, 30/30 passing.)_

  This finding was independently reported by two of the four analysis passes (API and compliance), which is a strong corroborating signal.

- [ ] ~~`libs/shared-react/src/nodes/usj/node-react.utils.ts`: the new `$findNextVerseAfter` duplicates a tree-walk already inlined in `$selectNextVerse` in the same file (forward-scan remaining siblings, then cross paragraphs via `$findNextVerseInNode` until a chapter boundary). `$selectNextVerse` is live code, called from `ArrowNavigationPlugin.tsx` — not dead code. Consider refactoring `$selectNextVerse` to call `$findNextVerseAfter` instead of maintaining two copies of the same traversal.~~ _(Author: skipped for now — real duplication, but it touches a separately-tested, live arrow-key navigation path that's outside this branch's stated scope. Left as a follow-up opportunity rather than refactored here.)_

Author response: fixed the highlight-logic bug immediately upon hearing it explained (with the concrete segment/bridge counterexamples); explicitly deferred the `$selectNextVerse` duplication as out of scope for this branch.

### Minor — Consider

- [ ] ~~`packages/scribe/src/editor/adaptors/usj-marker-action.utils.ts` (pre-existing, untouched by this branch): scribe's own copy of the verse marker action has the same code shape (derives the next verse number from `currentEditor.reference.verseNum`/`.verse` when `autoNumbering` is true) that this branch fixes in `packages/platform`.~~ _(Author: skipped. On investigation, this is not a confirmed reproduced bug — unlike platform's, which had concrete evidence (the "1114"/"1244" reproduction) — just a similar code shape; I haven't traced scribe's own callers (`Toolbar.tsx`, `Editor.tsx`) to confirm they feed a stale reference the same way. It's also not a quick fix: scribe's `getUsjMarkerAction` still returns a plain `MarkerContent[]`, not the `{content, highlightInserted}` shape introduced here, so porting the fix would mean reworking scribe's interface too, plus preserving its separate `autoNumbering`/`newVerseRChapterNum` explicit-number-entry mechanism. It's also a different package/UI surface (`packages/scribe`) that T-A's ticket doesn't reference at all. Left as a candidate follow-up ticket, not pulled into this branch.)_
- [x] **`parseInt(precedingVerseString, 10)` was computed twice in the `v` action** — once for `nextVerseNumber`, again for the highlight-gap check. _(fixed during review: resolved automatically as a side effect of the Important #1 fix above, which removed the redundant `precedingNum`/`followingNum` computation entirely — only one `parseInt` call remains.)_

Author response: declined to expand scope to the scribe package; the double-`parseInt` finding turned out to already be resolved by the Important #1 fix.

### Template Propagation

Not applicable. This repo (`eten-tech-foundation/scripture-editors`) has no `#region shared with <url>` marker convention and no `extensions/` directory / template-repo propagation concept — these are paranext-core-specific compliance checks with no equivalent structure here.

#### Shared Regions Modified

N/A — convention doesn't exist in this repo.

#### Extension Config Changes

N/A — this repo has no `extensions/` directory.

## Positive Observations

- The verse-number-inference fix correctly moves from a stale external `reference` to walking the live Lexical tree, matching the stated purpose.
- `$findNextVerseAfter` has solid, focused test coverage: same-parent sibling, cross-paragraph, chapter-boundary stop, and no-next-verse-anywhere cases — mirroring the existing pattern used for `$findPreviousVerseInSiblings`.
- The "Build 223 regression" test is a well-targeted regression test tied to a concretely described real-world bug (re-adding a verse into a gap without repeating/garbling numbers).
- The undo/redo investigation was handled well: rather than churning production code on a hunch, a targeted per-edit LIFO undo/redo test was added to pin the existing (already-correct) behavior — consistent with "investigated, no fix needed" rather than a speculative production change.
- No published package surface (`packages/platform`, `packages/scribe`, `packages/utilities` `index.ts` files) was touched — the changes are internal-only, keeping blast radius low.
- Existing tests were updated in place (not just added to) where the underlying expected verse number changed (`"2"` → `"3"`), each with an explanatory inline comment, making the diff's intent easy to verify against the code.
- The verse-highlight mechanism (`$createNodeSelection()` / `.add(key)` / `$setSelection()`) exactly mirrors the existing "arm" pattern in `StructureKeyboardPlugin.tsx`, reusing an established selection mechanism rather than inventing a new one.
- New/modified imports are correctly alphabetized within their `$`-prefixed and non-`$`-prefixed groups, consistent with the rest of the codebase.
- All four call sites that build a `UsjMarkerAction.action` return value (`c`, `v`, para-marker, char-marker) were updated consistently to the new `{ content, highlightInserted? }` shape — no call site was missed.

## Interview Notes

**Stated purpose**: Fix undo reliability (investigated, no fix needed) and verse-number inference in the marker dropdown for T-A items 2+3.

**Key decisions and reasoning**:
- The undo-reliability "fix" is a regression test, not a production change — confirmed via direct reproduction (3 deletions → 3 Undo presses → full restoration in LIFO order; 3 Redo presses → full re-deletion, symmetric) that nothing is lost under today's code.
- The Critical typecheck failure and the Important highlight-logic bug were both fixed immediately once explained, with concrete before/after verification (re-running `tsc` and the affected test suite).
- Two findings (the `$selectNextVerse`/`$findNextVerseAfter` duplication, and the scribe package's similar-shaped code) were deliberately left as follow-ups rather than folded into this branch, on the reasoning that both would expand scope beyond this branch's stated purpose — one into a separately-tested live navigation path, the other into a different package with its own interface shape that isn't referenced by the T-A ticket.
- No areas of uncertainty or AI-deferred understanding were raised — all findings were resolved with direct, specific responses.

**Unresolved items**: None.

## In-Review Quality Check

- **Typecheck**: initially found a **new regression** not flagged by any of the four analysis passes — `TS2454: Variable '...' is used before being assigned` on 5 lines in `usj-marker-action-utils.test.ts`. This was a latent consequence of an earlier (already-committed, pre-interview) lint-fix commit that removed non-null assertions (`!`) from test fixtures to satisfy `@typescript-eslint/no-non-null-assertion` — that fix satisfied ESLint but broke `tsc`'s definite-assignment analysis for `let` variables declared and assigned inside a nested closure within the same test function. (This differs from the file's pre-existing `secondVerseTextNode` pattern, which is module-scoped and not subject to the same flow-sensitive check — the two situations look similar but aren't, which is how this slipped through.) Fixed by hoisting the affected fixtures (`noVerseText`, `verse1Text`, `insertedVerse2Text`) to module scope, matching the file's own established convention. Re-verified: `tsc` clean, ESLint clean, 30/30 tests in the file passing.
- **Full repo-wide typecheck** (`nx run-many -t typecheck`, all 10 projects): clean.
- **Lint** (targeted at the 5 changed files' directories): clean, no errors.
- **Full test suite** (`vitest run`, repo-wide): 1627 passed, 6 skipped (pre-existing, unrelated), 45 files passed / 1 skipped.

## Suggested Review Focus

- [ ] Confirm the undo/redo investigation's conclusion (no production fix needed) matches the reviewer's own expectation from the original Build 223 report — the regression test in `StructureKeyboardPlugin.test.tsx` is the durable artifact of that investigation.
- [ ] Spot-check the corrected `highlightInserted` logic (`usj-marker-action.utils.ts`) against a real segment/bridge verse scenario in the live editor if one is easy to set up, since the fix was verified against unit tests but not manually in the running app.
- [ ] Decide whether the `$selectNextVerse`/`$findNextVerseAfter` duplication and the scribe package's similar-shaped stale-reference code are worth their own follow-up tickets, or can be left for whoever next touches those areas.
<!-- review-paratext:summary:end -->

AI-assisted — [session](<session URL>)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/527)
<!-- Reviewable:end -->
