### PR TITLE
feat(platform): ship a usable editor stylesheet

### DIFF
--- a/packages/platform/README.md
+++ b/packages/platform/README.md
@@ -140,17 +140,38 @@ export default function App() {
 
 ## Styling
 
-This npm package does not include styling so you need to style the editor component to suit your application. A good place to start is to copy the **CSS** from this repo:
+The package ships a bundled stylesheet covering the Scripture nodes, the editor chrome and the marker menu. Import it once, wherever your app imports CSS:
+
+```ts
+import "@eten-tech-foundation/platform-editor/styles.css";
+```
+
+The toolbar icons `editor.css` references are inlined into that stylesheet as data URIs, so **no asset copying is required**. Two things worth knowing:
+
+- Importing it from a **bundler-processed stylesheet** works too (`@import "@eten-tech-foundation/platform-editor/styles.css";`), but a browser loading a plain `<link>`ed file cannot resolve a bare package specifier.
+- If your host page sets a Content Security Policy, `img-src` must allow `data:` or the icons silently disappear — which looks like the stylesheet failed to load.
+
+If using the **commenting features** in the deprecated `<Marginal />` component, also import:
+
+```ts
+import "@eten-tech-foundation/platform-editor/comments.css";
+```
+
+Consumers doing a bare `tsc` (no bundler types) may need `declare module "*.css";` for the import to type-check; anything using `vite/client` types already has it.
+
+Icons are [Bootstrap Icons](https://icons.getbootstrap.com/) (MIT); the license travels with the package at `assets/images/icons/LICENSE.md`.
+
+### Overriding or forking the stylesheets
+
+To restyle beyond CSS overrides, copy the sources out of this repo instead:
 
 - Scripture Nodes [/packages/platform/src/usj-nodes.css](/packages/platform/src/usj-nodes.css)
 - Editor [/packages/platform/src/editor/editor.css](/packages/platform/src/editor/editor.css)
-- Marker Menu [/libs/shared/styles/nodes-menu.css](/libs/shared/styles/nodes-menu.css)
+- Marker Menu [/libs/shared/src/styles/nodes-menu.css](/libs/shared/src/styles/nodes-menu.css)
 
-For **icon assets** for the editor referenced in `editor.css` (the license file is included):
+`editor.css` references its icons from [/packages/platform/assets](/packages/platform/assets) by absolute URL, so a hand-copied stylesheet also needs those assets served from your web root. Swap the vendored imports for `styles.css` rather than stacking both, or the rules double up.
 
-- [/packages/platform/assets](/packages/platform/assets)
-
-If using the **commenting features** in the `<Marginal />` component:
+Comment styles, if using `<Marginal />`:
 
 - [/packages/platform/src/marginal/comments/ui/Button.css](/packages/platform/src/marginal/comments/ui/Button.css)
 - [/packages/platform/src/marginal/comments/ui/ContentEditable.css](/packages/platform/src/marginal/comments/ui/ContentEditable.css)

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -21,13 +21,19 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
-    }
+    },
+    "./styles.css": "./dist/styles.css",
+    "./comments.css": "./dist/index.css"
   },
   "files": [
     "dist",
     "src",
     "!src/**/*.test.ts",
-    "!src/**/*.test.tsx"
+    "!src/**/*.test.tsx",
+    "!src/styles.css",
+    "!src/styles.ts",
+    "styles.css",
+    "assets/images/icons/LICENSE.md"
   ],
   "scripts": {
     "generate:test-data": "cross-env GENERATE_TEST_DATA=1 pnpm vitest run generate-2sa-lexical-states",

--- a/packages/platform/src/styles.css
+++ b/packages/platform/src/styles.css
@@ -1,0 +1,13 @@
+/*
+ * Bundled stylesheet for @eten-tech-foundation/platform-editor.
+ *
+ * Built to dist/styles.css and exposed to consumers as
+ * `@eten-tech-foundation/platform-editor/styles.css`. Icon SVGs referenced by
+ * editor.css are inlined as data URIs at build time, so no assets need copying.
+ *
+ * Import order is the documented cascade: Scripture nodes, then the editor
+ * chrome, then the marker menu.
+ */
+@import "./usj-nodes.css";
+@import "./editor/editor.css";
+@import "../../../libs/shared/src/styles/nodes-menu.css";

--- a/packages/platform/src/styles.ts
+++ b/packages/platform/src/styles.ts
@@ -1,0 +1,4 @@
+// CSS-only build entry: emits dist/styles.css. The companion dist/styles.js is
+// empty by design and is not part of the public API — consumers import the
+// stylesheet, never this module.
+import "./styles.css";

--- a/packages/platform/styles.css
+++ b/packages/platform/styles.css
@@ -1,0 +1,6 @@
+/*
+ * Stable path for resolvers that don't honour the "exports" map (webpack 4,
+ * older Metro/Jest). Bundlers that do honour it get dist/styles.css directly
+ * through the "./styles.css" subpath.
+ */
+@import "./dist/styles.css";

--- a/packages/platform/vite.config.mts
+++ b/packages/platform/vite.config.mts
@@ -34,19 +34,40 @@ export default defineConfig({
     emptyOutDir: true,
     sourcemap: true,
     reportCompressedSize: true,
+    // Emit one stylesheet per entry. Vite defaults this to false whenever
+    // build.lib is set, which would concatenate every entry's CSS into a single
+    // asset; keeping it per-entry is what leaves dist/index.css (the comment
+    // styles reachable through ".") byte-for-byte unchanged while the bundled
+    // editor stylesheet lands in dist/styles.css. Safe here because this package
+    // has no dynamic imports, so each entry is a single chunk, and formats:["es"]
+    // means Vite never emits style-injection code into the JS.
+    cssCodeSplit: true,
     commonjsOptions: {
       transformMixedEsModules: true,
     },
     lib: {
-      // Could also be a dictionary or array of multiple entry points.
+      // Entry resolution comes from rollupOptions.input below; this stays a
+      // STRING only to keep vite-plugin-dts in single-entry mode (it derives its
+      // entry list from lib.entry, and an object here makes api-extractor fail on
+      // the export-less CSS entry: "Unable to determine module for styles.d.ts").
+      // Don't "clean up" the apparent duplication.
       entry: "src/index.ts",
       name: "@eten-tech-foundation/platform-editor",
-      fileName: "index",
+      // Two inputs, so the name must be derived per entry — a fixed "index"
+      // makes Rollup dedup into index.js + index2.js.
+      fileName: (_format: string, entryName: string) => `${entryName}.js`,
       // Change this to the formats you want to support.
       // Don't forget to update your package.json as well.
       formats: ["es" as const],
     },
     rollupOptions: {
+      // Absolute paths are required: Vite passes rollupOptions.input to Rollup
+      // verbatim (only the lib.entry fallback is resolved against `root`), so
+      // relative ids would resolve against the current working directory.
+      input: {
+        index: path.resolve(__dirname, "src/index.ts"),
+        styles: path.resolve(__dirname, "src/styles.ts"),
+      },
       external: [
         "react/jsx-runtime",
         // Also externalize the dev JSX runtime so a dev-mode build can never bundle a


### PR DESCRIPTION
Closes part of #516 — the CSS half. Bundle-size trimming (the `@xmldom`/`@lexical/table`/yjs cuts) is not in here.

## Demo

A short screencast (2 min, with narration) is attached in the comments. It uses a **fresh consumer app** — a new Vite project that installs the package from this branch and does exactly what the updated README says: one import for the component, one for the stylesheet, nothing copied out of the repo. It renders a real Gujarati chapter, then toggles only the packaged stylesheet off and on, so you can see precisely what the stylesheet contributes: superscript verse numbers, the chapter heading, spacing, and the toolbar icons (which travel inlined inside it).

https://github.com/user-attachments/assets/00b14767-c689-47f9-81d2-04a79ba96a41

## The problem

The package ships no importable CSS. `src/usj-nodes.css`, `src/editor/editor.css` and `libs/shared/src/styles/nodes-menu.css` are inside the tarball only because `files` includes `src`, but the `exports` map exposes only `.` and `./package.json`, so consumers can't reach them. `dist/index.css` (11.9 kB) contains just the comments-modal styles — they land there because `marginal/comments/*.tsx` do `import "./X.css"`. The 33 icon SVGs aren't published at all, and `editor.css` references them by absolute URL. That's why the README asks consumers to copy the CSS and assets out of the repo by hand — which is what we ended up doing in Fluent: 3,269 vendored lines that will silently drift.

## The change

A second, CSS-only Rollup input pulls the three stylesheets through the same Vite build and emits `dist/styles.css` (51.3 kB, 9.0 kB gzip), with the 15 toolbar icons inlined as data URIs. Consumers then write one line:

```ts
import "@eten-tech-foundation/platform-editor/styles.css";
```

`./comments.css` additionally exposes the existing `dist/index.css` for the deprecated `<Marginal />`.

## Nothing reachable through `"."` moves

This is the part that matters for Platform.Bible, and it's measured rather than argued. Against a pre-change build:

```
index.css   IDENTICAL   (11,869 B)
index.js    IDENTICAL
index.js.map IDENTICAL
index.d.ts  IDENTICAL
```

No CSS is auto-injected (`grep -cE 'index\.css|styles\.css' dist/index.js` → 0; `formats: ["es"]` structurally prevents it), and the source stylesheets are not edited by a single byte, so any vendored copies stay in sync. The new stylesheet is a file you choose to import — importing the component never pulls it in.

## Three things worth knowing before reviewing the config

- **`cssCodeSplit` must be on.** Vite defaults it to `false` whenever `build.lib` is set, which concatenates every entry's CSS into one asset — that alone would change `dist/index.css`. Safe here because the package has no dynamic imports, so each entry is a single chunk.
- **`lib.entry` stays a string** even though `rollupOptions.input` now drives entry resolution. `vite-plugin-dts` derives its entry list from `lib.entry`; making it an object flips it to multi-entry mode and api-extractor then fails with `Unable to determine module for: dist/styles.d.ts` on the export-less CSS entry. There's a comment saying so, because the duplication looks removable.
- **`rollupOptions.input` uses absolute paths.** Vite passes that through to Rollup verbatim (only the `lib.entry` fallback is resolved against `root`), so relative ids resolve against the cwd — it would work under `nx build` today and break under a plain `vite build --config`.

## Icons

Inlined, not shipped as files. Vite's lib mode inlines assets unconditionally, which is already why the four `CommentPlugin.css` icons are data URIs in today's `dist/index.css` — this just extends the same behaviour. Cost is ~2.3 kB gzip, paid also by `hasExternalUI: true` consumers who never render a toolbar; that seemed a fair trade against making everyone copy 144 kB of assets to their web root. The source `url()` paths are deliberately left absolute so the existing copy-to-web-root workflow keeps working. Bootstrap Icons' MIT license now travels with the package.

One consequence for the README: a host CSP whose `img-src` omits `data:` loses the icons silently, so that's called out.

## Verification

```bash
pnpm nx build @eten-tech-foundation/platform-editor
cmp <baseline>/index.css dist/index.css          # identical
grep -o 'data:image/svg' dist/styles.css | wc -l # 15
grep -c '/assets/'        dist/styles.css        # 0, nothing unresolved
grep -c 'annot_spellingerror'        dist/styles.css  # usj-nodes.css present
grep -c 'toolbar-item'               dist/styles.css  # editor.css present
grep -c 'autocomplete-menu-container' dist/styles.css # nodes-menu.css present
pnpm nx extract-api platform-editor              # API report unchanged, no styles.d.ts
npm pack --dry-run                               # ships dist/styles.css + icon LICENSE
```

A root-level `styles.css` shim (`@import "./dist/styles.css"`) is included so resolvers that ignore `exports` (webpack 4, older Metro/Jest) get a working path too.

Happy to adjust if this collides with the editor changes your team has planned — it's deliberately additive and confined to packaging.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/528)
<!-- Reviewable:end -->

