### PR TITLE
Add character marker removal to the editor ref

### DIFF
--- a/libs/shared-react/src/plugins/usj/TextSpacingPlugin.tsx
+++ b/libs/shared-react/src/plugins/usj/TextSpacingPlugin.tsx
@@ -13,7 +13,7 @@ import {
   $isCharNode,
   $isNoteNode,
   $isParaLikeNode,
-  $isParaMarkerPrefix,
+  $isSynthesizedMarkerNode,
   $isTypedMarkNode,
   $isUnknownNode,
   CharNode,
@@ -127,7 +127,7 @@ function $verseNodeTransform(node: SomeVerseNode): void {
     // space belongs after them — and an inserted plain " " would be exporter-visible USJ
     // content that shifts every content index in the paragraph (see PT-3835). Their visual
     // separation comes from the prefix nodes' own text.
-    !$isParaMarkerPrefix(previousSibling) &&
+    !$isSynthesizedMarkerNode(previousSibling) &&
     // Bare text before a verse gets its structural space from $textNodeTrailingSpaceTransform;
     // text inside an annotation wrapper can't (that transform skips TypedMarkNode parents), so
     // the space is inserted here instead and coalesces onto the same USJ text run.

--- a/libs/shared/src/nodes/usj/node.utils.ts
+++ b/libs/shared/src/nodes/usj/node.utils.ts
@@ -563,15 +563,16 @@ export function $isVisibleMarkerNode(
 }
 
 /**
- * True for either flavor of paragraph-marker node: a `MarkerNode` (markerMode "editable") or an
+ * True for either flavor of synthesized marker node: a `MarkerNode` (markerMode "editable") or an
  * `ImmutableTypedTextNode` with `textType: "marker"` (markerMode "visible" or gutter views).
- * These are the two node shapes used to render a paragraph's USFM marker (e.g. `\p`, `\s2`,
- * `\q1`) as the visible first child of its paragraph.
+ * These are the two node shapes used to render a USFM marker as visible content — a paragraph's
+ * marker (e.g. `\p`, `\s2`, `\q1`) as the first child of its `ParaNode`, or a character marker's
+ * opening and closing markers inside its `CharNode`.
  *
  * @param node - The node to check.
  * @returns `true` if the node is a `MarkerNode` or a visible marker node.
  */
-export function $isParaMarkerPrefix(node: LexicalNode | null | undefined): boolean {
+export function $isSynthesizedMarkerNode(node: LexicalNode | null | undefined): boolean {
   return $isMarkerNode(node) || $isVisibleMarkerNode(node);
 }
 

--- a/packages/platform/README.md
+++ b/packages/platform/README.md
@@ -191,15 +191,15 @@ Programmatic control over the editor. Self-evident methods (`focus`, `undo`, `re
 `paste`, `pastePlainText`, `getUsj`, `setUsj`, `formatPara`, `getElementByKey`, `selectNote`,
 `getNoteOps`) are omitted — see the full reference below.
 
-| Method                               | Note                                                                                        |
-| ------------------------------------ | ------------------------------------------------------------------------------------------- |
-| `getSelection` / `setSelection`      | Uses json-path; assumes no comment Milestone nodes in the USJ                               |
-| `setAnnotation` / `removeAnnotation` | Ephemeral — not persisted; same json-path caveat                                            |
-| `applyUpdate` / `replaceEmbedUpdate` | EXPERIMENTAL: real-time collaborative editing                                               |
-| `insertMarker`                       | Replicates marker menu; throws if readonly, `scrRef` not provided, or marker is unsupported |
-| `removeCharacterMarker`              | Removes a character marker, keeping its text; throws if readonly or marker is unsupported   |
-| `insertNote`                         | Deprecated — use `insertMarker`                                                             |
-| `toolbarEndRef`                      | Internal use only: for dynamically adding toolbar controls                                  |
+| Method                               | Note                                                                                                                                                                                                                             |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getSelection` / `setSelection`      | Uses json-path; assumes no comment Milestone nodes in the USJ                                                                                                                                                                    |
+| `setAnnotation` / `removeAnnotation` | Ephemeral — not persisted; same json-path caveat                                                                                                                                                                                 |
+| `applyUpdate` / `replaceEmbedUpdate` | EXPERIMENTAL: real-time collaborative editing                                                                                                                                                                                    |
+| `insertMarker`                       | Replicates marker menu; throws if readonly, `scrRef` not provided, or marker is unsupported                                                                                                                                      |
+| `removeCharacterMarker`              | Removes a character marker, keeping its text. Returns `false` and changes nothing when no marker matches, the selection is in a note, or removal can't be confined to the selection; throws if readonly or marker is unsupported |
+| `insertNote`                         | Deprecated — use `insertMarker`                                                                                                                                                                                                  |
+| `toolbarEndRef`                      | Internal use only: for dynamically adding toolbar controls                                                                                                                                                                       |
 
 > Full API reference: [platform-editor.api.md](etc/platform-editor.api.md)
 

--- a/packages/platform/README.md
+++ b/packages/platform/README.md
@@ -197,6 +197,7 @@ Programmatic control over the editor. Self-evident methods (`focus`, `undo`, `re
 | `setAnnotation` / `removeAnnotation` | Ephemeral — not persisted; same json-path caveat                                            |
 | `applyUpdate` / `replaceEmbedUpdate` | EXPERIMENTAL: real-time collaborative editing                                               |
 | `insertMarker`                       | Replicates marker menu; throws if readonly, `scrRef` not provided, or marker is unsupported |
+| `removeCharacterMarker`              | Removes a character marker, keeping its text; throws if readonly or marker is unsupported   |
 | `insertNote`                         | Deprecated — use `insertMarker`                                                             |
 | `toolbarEndRef`                      | Internal use only: for dynamically adding toolbar controls                                  |
 

--- a/packages/platform/etc/platform-editor.api.md
+++ b/packages/platform/etc/platform-editor.api.md
@@ -110,6 +110,7 @@ export interface EditorRef {
     pastePlainText(): void;
     redo(): void;
     removeAnnotation(type: string, id: string): void;
+    removeCharMarker(marker?: string): void;
     replaceEmbedUpdate(embedNodeKey: string, insertEmbedOps: DeltaOp[]): void;
     selectNote(noteKeyOrIndex: string | number): void;
     setAnnotation(selection: AnnotationRange, type: string, id: string, callbacks?: {

--- a/packages/platform/etc/platform-editor.api.md
+++ b/packages/platform/etc/platform-editor.api.md
@@ -110,7 +110,7 @@ export interface EditorRef {
     pastePlainText(): void;
     redo(): void;
     removeAnnotation(type: string, id: string): void;
-    removeCharacterMarker(marker?: string): void;
+    removeCharacterMarker(marker?: string): boolean;
     replaceEmbedUpdate(embedNodeKey: string, insertEmbedOps: DeltaOp[]): void;
     selectNote(noteKeyOrIndex: string | number): void;
     setAnnotation(selection: AnnotationRange, type: string, id: string, callbacks?: {

--- a/packages/platform/etc/platform-editor.api.md
+++ b/packages/platform/etc/platform-editor.api.md
@@ -110,7 +110,7 @@ export interface EditorRef {
     pastePlainText(): void;
     redo(): void;
     removeAnnotation(type: string, id: string): void;
-    removeCharMarker(marker?: string): void;
+    removeCharacterMarker(marker?: string): void;
     replaceEmbedUpdate(embedNodeKey: string, insertEmbedOps: DeltaOp[]): void;
     selectNote(noteKeyOrIndex: string | number): void;
     setAnnotation(selection: AnnotationRange, type: string, id: string, callbacks?: {

--- a/packages/platform/src/editor/Editor.test.tsx
+++ b/packages/platform/src/editor/Editor.test.tsx
@@ -220,12 +220,30 @@ describe("removeCharacterMarker guards", () => {
     expect(() => editor.removeCharacterMarker("zzz")).toThrow("Unsupported character marker 'zzz'");
   });
 
-  it("does not throw when the marker is omitted and there is no selection", async () => {
+  it.each(["ft", "xt"])(
+    "throws for the note-only character marker '%s', which removal always skips",
+    async (marker) => {
+      const ref = await createEditorRefForTesting();
+      const editor = ref.current;
+      if (!editor) throw new Error("Editor not mounted");
+
+      // CharNode.isValidMarker accepts these — VALID_CHAR_MARKERS spreads in the footnote and
+      // cross-reference markers — but they only ever occur inside a NoteNode, which
+      // $getCharNodeToRemove skips. Throwing beats accepting the call and silently doing nothing.
+      expect(() => editor.removeCharacterMarker(marker)).toThrow(
+        `Unsupported character marker '${marker}'`,
+      );
+    },
+  );
+
+  it("returns false without throwing when the marker is omitted and there is no selection", async () => {
     const ref = await createEditorRefForTesting();
     const editor = ref.current;
     if (!editor) throw new Error("Editor not mounted");
 
-    expect(() => editor.removeCharacterMarker()).not.toThrow();
+    // The return value is what makes this more than a smoke test: a fresh editor has no selection,
+    // so the call must report that it removed nothing rather than merely not crashing.
+    expect(editor.removeCharacterMarker()).toBe(false);
   });
 });
 

--- a/packages/platform/src/editor/Editor.test.tsx
+++ b/packages/platform/src/editor/Editor.test.tsx
@@ -182,6 +182,52 @@ describe("setAnnotation overload", () => {
   });
 });
 
+describe("removeCharMarker guards", () => {
+  async function createReadonlyEditorRefForTesting(): Promise<RefObject<EditorRef | null>> {
+    const ref = createRef<EditorRef>();
+    await act(async () => {
+      render(<Editor ref={ref} defaultUsj={sampleUsj} options={{ isReadonly: true }} />);
+    });
+    if (!ref.current) throw new Error("EditorRef did not mount");
+    return ref;
+  }
+
+  it("throws in readonly mode", async () => {
+    const ref = await createReadonlyEditorRefForTesting();
+    const editor = ref.current;
+    if (!editor) throw new Error("Editor not mounted");
+
+    expect(() => editor.removeCharMarker("nd")).toThrow(
+      "Cannot remove char marker in readonly mode",
+    );
+  });
+
+  it("throws for a para marker, which removal can never act on", async () => {
+    const ref = await createEditorRefForTesting();
+    const editor = ref.current;
+    if (!editor) throw new Error("Editor not mounted");
+
+    // Note this is stricter than insertMarker's isUsjMarkerSupported, which accepts "p".
+    expect(() => editor.removeCharMarker("p")).toThrow("Unsupported char marker 'p'");
+  });
+
+  it("throws for an unknown marker", async () => {
+    const ref = await createEditorRefForTesting();
+    const editor = ref.current;
+    if (!editor) throw new Error("Editor not mounted");
+
+    expect(() => editor.removeCharMarker("zzz")).toThrow("Unsupported char marker 'zzz'");
+  });
+
+  it("does not throw when the marker is omitted and there is no selection", async () => {
+    const ref = await createEditorRefForTesting();
+    const editor = ref.current;
+    if (!editor) throw new Error("Editor not mounted");
+
+    expect(() => editor.removeCharMarker()).not.toThrow();
+  });
+});
+
 /** Grabs the underlying Lexical editor so tests can dispatch commands the public ref doesn't expose. */
 function GrabEditor({ onEditor }: { onEditor: (editor: LexicalEditor) => void }): null {
   const [editor] = useLexicalComposerContext();

--- a/packages/platform/src/editor/Editor.test.tsx
+++ b/packages/platform/src/editor/Editor.test.tsx
@@ -8,8 +8,9 @@ import { flushQueuedEvents } from "./editor-test.utils";
 import { ContentJsonPath, Usj } from "@eten-tech-foundation/scripture-utilities";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { act, render } from "@testing-library/react";
-import { KEY_DOWN_COMMAND, LexicalEditor } from "lexical";
+import { $getRoot, $isTextNode, KEY_DOWN_COMMAND, LexicalEditor, TextNode } from "lexical";
 import { createRef, RefObject, useEffect } from "react";
+import { $isCharNode, $isSomeParaNode, $isSynthesizedMarkerNode, NBSP } from "shared";
 import { vi } from "vitest";
 
 /** USJ with book PSA for Editor sync effect test (clone of usjGen1v1 with book code changed) */
@@ -182,7 +183,7 @@ describe("setAnnotation overload", () => {
   });
 });
 
-describe("removeCharMarker guards", () => {
+describe("removeCharacterMarker guards", () => {
   async function createReadonlyEditorRefForTesting(): Promise<RefObject<EditorRef | null>> {
     const ref = createRef<EditorRef>();
     await act(async () => {
@@ -197,8 +198,8 @@ describe("removeCharMarker guards", () => {
     const editor = ref.current;
     if (!editor) throw new Error("Editor not mounted");
 
-    expect(() => editor.removeCharMarker("nd")).toThrow(
-      "Cannot remove char marker in readonly mode",
+    expect(() => editor.removeCharacterMarker("nd")).toThrow(
+      "Cannot remove character marker in readonly mode",
     );
   });
 
@@ -208,7 +209,7 @@ describe("removeCharMarker guards", () => {
     if (!editor) throw new Error("Editor not mounted");
 
     // Note this is stricter than insertMarker's isUsjMarkerSupported, which accepts "p".
-    expect(() => editor.removeCharMarker("p")).toThrow("Unsupported char marker 'p'");
+    expect(() => editor.removeCharacterMarker("p")).toThrow("Unsupported character marker 'p'");
   });
 
   it("throws for an unknown marker", async () => {
@@ -216,7 +217,7 @@ describe("removeCharMarker guards", () => {
     const editor = ref.current;
     if (!editor) throw new Error("Editor not mounted");
 
-    expect(() => editor.removeCharMarker("zzz")).toThrow("Unsupported char marker 'zzz'");
+    expect(() => editor.removeCharacterMarker("zzz")).toThrow("Unsupported character marker 'zzz'");
   });
 
   it("does not throw when the marker is omitted and there is no selection", async () => {
@@ -224,7 +225,7 @@ describe("removeCharMarker guards", () => {
     const editor = ref.current;
     if (!editor) throw new Error("Editor not mounted");
 
-    expect(() => editor.removeCharMarker()).not.toThrow();
+    expect(() => editor.removeCharacterMarker()).not.toThrow();
   });
 });
 
@@ -314,5 +315,89 @@ describe("undo after a verse-spanning delete (PT-4102 regression)", () => {
     expect(afterUndo).toContain("Alpha ");
     expect(afterUndo).toContain("Bravo");
     expect(afterUndo).toContain('"number":"2"');
+  });
+});
+
+const usjWithCharMarker: Usj = {
+  type: "USJ",
+  version: "3.1",
+  content: [
+    { type: "book", marker: "id", code: "GEN", content: ["Test Book"] },
+    { type: "chapter", marker: "c", number: "1" },
+    {
+      type: "para",
+      marker: "p",
+      content: ["the ", { type: "char", marker: "nd", content: ["Lord"] }, " said"],
+    },
+  ],
+};
+
+/** Selects the whole content of the first `CharNode` in the document. */
+async function selectCharNodeContent(editor: LexicalEditor): Promise<void> {
+  await act(async () => {
+    editor.update(
+      () => {
+        const para = $getRoot().getChildren().find($isSomeParaNode);
+        const charNode = para?.getChildren().find($isCharNode);
+        // Not just `$isTextNode`: `MarkerNode` extends `TextNode`, so under
+        // `markerMode: "editable"` the first match would be the opening `\nd` marker.
+        const textNode = charNode
+          ?.getChildren()
+          .find(
+            (child): child is TextNode => $isTextNode(child) && !$isSynthesizedMarkerNode(child),
+          );
+        if (!textNode) throw new Error("Expected a text node inside a CharNode");
+        textNode.select(0, textNode.getTextContentSize());
+      },
+      { discrete: true },
+    );
+  });
+}
+
+describe("removeCharacterMarker through the editor ref", () => {
+  // The guards above only prove the method throws when it should. This drives it end to end so
+  // `Editor.tsx`'s wiring is covered too - in particular that it forwards its `viewOptions` as the
+  // third argument. `viewOptions` is what enables the NBSP trim, and every adaptor-level test
+  // passes its own view options directly, so a wiring that dropped that argument would leave all
+  // of them green while leaving an NBSP in the text of the real editor.
+  it("removes the marker and its NBSP under markerMode 'editable'", async () => {
+    const ref = createRef<EditorRef>();
+    let editor: LexicalEditor | undefined;
+    await act(async () => {
+      render(
+        <Editor
+          ref={ref}
+          defaultUsj={usjWithCharMarker}
+          options={{
+            view: {
+              markerMode: "editable",
+              noteMode: "expanded",
+              hasSpacing: false,
+              isFormattedFont: false,
+            },
+          }}
+        >
+          <GrabEditor onEditor={(e) => (editor = e)} />
+        </Editor>,
+      );
+    });
+    await flushQueuedEvents();
+    if (!ref.current || !editor) throw new Error("EditorRef did not mount");
+    const editorRef = ref.current;
+
+    // Precondition: the adaptor really did prepend the NBSP, so the trim below has something to do.
+    expect(editor.getEditorState().read(() => $getRoot().getTextContent())).toContain(NBSP);
+
+    await selectCharNodeContent(editor);
+    await act(async () => {
+      editorRef.removeCharacterMarker("nd");
+    });
+    await flushQueuedEvents();
+
+    const para = editorRef.getUsj()?.content[2];
+    if (typeof para !== "object" || !("content" in para))
+      throw new Error("para is not a USJ para node");
+    expect(JSON.stringify(para.content)).not.toContain('"char"');
+    expect(para.content?.join("")).toBe("the Lord said");
   });
 });

--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -321,11 +321,19 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
       )
         throw new Error(`Unsupported character marker '${marker}'`);
 
-      editorRef.current?.update(() => {
-        const selection = $getSelection();
-        if ($isRangeSelection(selection))
-          $removeCharacterMarkerAtSelection(selection, marker, viewOptions);
-      });
+      // `discrete` so the update runs now rather than being deferred behind an in-progress one,
+      // which would leave `didRemove` reporting `false` for a removal that did happen. Same reason
+      // `applyUpdate` above uses it.
+      let didRemove = false;
+      editorRef.current?.update(
+        () => {
+          const selection = $getSelection();
+          if ($isRangeSelection(selection))
+            didRemove = $removeCharacterMarkerAtSelection(selection, marker, viewOptions);
+        },
+        { discrete: true },
+      );
+      return didRemove;
     },
     insertMarker(marker) {
       if (isReadonly) throw new Error("Cannot insert marker in readonly mode");

--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -1,8 +1,9 @@
 import editorUsjAdaptor from "./adaptors/editor-usj.adaptor";
 import usjEditorAdaptor from "./adaptors/usj-editor.adaptor";
 import {
-  $removeCharMarkerAtSelection,
+  $removeCharacterMarkerAtSelection,
   getUsjMarkerAction,
+  isCharacterMarkerSupported,
   isUsjMarkerSupported,
 } from "./adaptors/usj-marker-action.utils";
 import { EditorOptions, EditorProps, EditorRef } from "./editor.model";
@@ -47,7 +48,6 @@ import {
 import {
   $createParaNode,
   blackListedChangeTags,
-  CharNode,
   DELTA_CHANGE_TAG,
   externalTypedMarkType,
   LoggerBasic,
@@ -313,15 +313,18 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
         () => editorRef.current?.getElementByKey(nodeKey) ?? undefined,
       );
     },
-    removeCharMarker(marker) {
-      if (isReadonly) throw new Error("Cannot remove char marker in readonly mode");
-      if (marker !== undefined && !CharNode.isValidMarker(marker, nodeOptions?.extraValidMarkers))
-        throw new Error(`Unsupported char marker '${marker}'`);
+    removeCharacterMarker(marker) {
+      if (isReadonly) throw new Error("Cannot remove character marker in readonly mode");
+      if (
+        marker !== undefined &&
+        !isCharacterMarkerSupported(marker, nodeOptions.extraValidMarkers)
+      )
+        throw new Error(`Unsupported character marker '${marker}'`);
 
       editorRef.current?.update(() => {
         const selection = $getSelection();
         if ($isRangeSelection(selection))
-          $removeCharMarkerAtSelection(selection, marker, viewOptions);
+          $removeCharacterMarkerAtSelection(selection, marker, viewOptions);
       });
     },
     insertMarker(marker) {

--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -1,6 +1,10 @@
 import editorUsjAdaptor from "./adaptors/editor-usj.adaptor";
 import usjEditorAdaptor from "./adaptors/usj-editor.adaptor";
-import { getUsjMarkerAction, isUsjMarkerSupported } from "./adaptors/usj-marker-action.utils";
+import {
+  $removeCharMarkerAtSelection,
+  getUsjMarkerAction,
+  isUsjMarkerSupported,
+} from "./adaptors/usj-marker-action.utils";
 import { EditorOptions, EditorProps, EditorRef } from "./editor.model";
 import editorTheme from "./editor.theme";
 import { ActiveTextPlugin } from "./ActiveTextPlugin";
@@ -43,6 +47,7 @@ import {
 import {
   $createParaNode,
   blackListedChangeTags,
+  CharNode,
   DELTA_CHANGE_TAG,
   externalTypedMarkType,
   LoggerBasic,
@@ -307,6 +312,17 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
       return editorRef.current?.read(
         () => editorRef.current?.getElementByKey(nodeKey) ?? undefined,
       );
+    },
+    removeCharMarker(marker) {
+      if (isReadonly) throw new Error("Cannot remove char marker in readonly mode");
+      if (marker !== undefined && !CharNode.isValidMarker(marker, nodeOptions?.extraValidMarkers))
+        throw new Error(`Unsupported char marker '${marker}'`);
+
+      editorRef.current?.update(() => {
+        const selection = $getSelection();
+        if ($isRangeSelection(selection))
+          $removeCharMarkerAtSelection(selection, marker, viewOptions);
+      });
     },
     insertMarker(marker) {
       if (isReadonly) throw new Error("Cannot insert marker in readonly mode");

--- a/packages/platform/src/editor/ParaMarkerPrefixGuardPlugin.tsx
+++ b/packages/platform/src/editor/ParaMarkerPrefixGuardPlugin.tsx
@@ -1,6 +1,6 @@
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { useEffect } from "react";
-import { $isParaMarkerPrefix, LoggerBasic, ParaNode, PARA_MARKER_DEFAULT } from "shared";
+import { $isSynthesizedMarkerNode, LoggerBasic, ParaNode, PARA_MARKER_DEFAULT } from "shared";
 import { ViewOptions } from "shared-react";
 
 /**
@@ -58,7 +58,7 @@ export function ParaMarkerPrefixGuardPlugin({
 export function $resetMarkerIfPrefixDeleted(para: ParaNode, logger?: LoggerBasic): void {
   if (para.getMarker() === PARA_MARKER_DEFAULT) return;
   if (para.isEmpty()) return;
-  if ($isParaMarkerPrefix(para.getFirstChild())) return;
+  if ($isSynthesizedMarkerNode(para.getFirstChild())) return;
   logger?.debug(
     `[ParaMarkerPrefixGuard] Resetting paragraph "${para.getMarker()}" → "${PARA_MARKER_DEFAULT}" (key ${para.getKey()})`,
   );

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -51,6 +51,7 @@ const reference = { book: "GEN", chapterNum: 1, verseNum: 1 };
 let secondVerseTextNode: TextNode;
 let charTextNode: TextNode;
 let placeholderTextNode: TextNode;
+let targetTextNode: TextNode;
 let noteTextNode: TextNode;
 let tailTextNode: TextNode;
 let firstCharTextNode: TextNode;
@@ -853,6 +854,97 @@ describe("USJ Marker Action Utils", () => {
         const selection = $getSelection();
         if (!$isRangeSelection(selection)) throw new Error("selection is not a range selection");
         expect(selection.getTextContent()).toBe("Lord");
+      });
+    });
+
+    it("restores the selection after the NBSP trim shifts content length in markerMode 'editable'", () => {
+      let charTextNodeSize = 0;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        charTextNode = $createTextNode(NBSP + "Lord");
+        charTextNodeSize = charTextNode.getTextContentSize();
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createTextNode("the "),
+            $createCharNode("nd").append(
+              $createMarkerNode("nd"),
+              charTextNode,
+              $createMarkerNode("nd", "closing"),
+            ),
+            $createTextNode(" said"),
+          ),
+        );
+      });
+      // Select the whole CharNode's content (NBSP + "Lord"), so handleTextNode never calls
+      // TextNode.splitText on it — splitText's own point-transfer logic never runs, unlike the
+      // sibling test above whose split shape isn't exercised here.
+      updateSelection(editor, charTextNode, 0, charTextNode, charTextNodeSize);
+
+      sutRemoveCharMarker(editor, "nd", {
+        markerMode: "editable",
+        hasSpacing: true,
+        isFormattedFont: true,
+      });
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        const mergedTextNode = para.getFirstChild();
+        if (!$isTextNode(mergedTextNode)) throw new Error("merged node is not a TextNode");
+        expect(mergedTextNode.getTextContent()).toBe("the Lord said");
+        // $removeCharNodeKeepingContent's NBSP trim calls TextNode.setTextContent, which only
+        // mutates __text and never touches selection points. Without the restore, the pre-trim
+        // focus offset (5, the end of NBSP+"Lord") survives the trim and then the merge shifts it
+        // by the leading sibling's length alone, landing one character past "Lord"'s real end.
+        $expectSelectionToBe(mergedTextNode, 4, mergedTextNode, 8);
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) throw new Error("selection is not a range selection");
+        expect(selection.getTextContent()).toBe("Lord");
+      });
+    });
+
+    it("known limitation: leaves an unpaired marker when the selection is strictly interior under markerMode 'visible'", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        targetTextNode = $createTextNode("Lord");
+        // "the " / " said" are marked "token" so Lexical's own plain-text normalization doesn't
+        // merge them into targetTextNode on commit — this fixture needs all three to stay
+        // separate nodes, unlike normal prose where such adjacent plain text would coalesce.
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createCharNode("nd").append(
+              $createImmutableTypedTextNode("marker", openingMarkerText("nd")),
+              $createTextNode("the ").setMode("token"),
+              targetTextNode,
+              $createTextNode(" said").setMode("token"),
+              $createImmutableTypedTextNode("marker", closingMarkerText("nd")),
+            ),
+          ),
+        );
+      });
+      // Select only the interior "Lord", leaving real unselected text between it and each
+      // boundary marker — the shape $splitCharNodeAroundTargets' docstring documents as unhandled.
+      updateSelection(editor, targetTextNode, 0, targetTextNode, 4);
+
+      sutRemoveCharMarker(editor, "nd", {
+        markerMode: "visible",
+        hasSpacing: true,
+        isFormattedFont: true,
+      });
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        // Known limitation (see $splitCharNodeAroundTargets docstring, "interior partial coverage
+        // under marker mode"): the boundary-marker fold only reaches a marker immediately adjacent
+        // to the covered range. Here real unselected text ("the " / " said") sits between each
+        // marker and the covered "Lord", so neither marker folds, and each ends up alone in a
+        // leading/trailing clone that $removeCharNodeKeepingContent never sees — the marker is
+        // never stripped. Asserting today's actual (broken) output so a future fix to this
+        // limitation is noticed here rather than silently reintroduced.
+        expect(para.getTextContent()).toContain(openingMarkerText("nd"));
+        expect(para.getTextContent()).toContain(closingMarkerText("nd"));
+        expect(para.getTextContent()).toBe(
+          `${openingMarkerText("nd")}the Lord said${closingMarkerText("nd")}`,
+        );
       });
     });
   });

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -6,8 +6,9 @@ import {
   updateSelection,
 } from "../../../../../libs/shared/src/nodes/usj/test.utils";
 import {
-  $removeCharMarkerAtSelection,
+  $removeCharacterMarkerAtSelection,
   getUsjMarkerAction,
+  isCharacterMarkerSupported,
   isUsjMarkerSupported,
 } from "./usj-marker-action.utils";
 import {
@@ -50,12 +51,7 @@ const reference = { book: "GEN", chapterNum: 1, verseNum: 1 };
 
 let secondVerseTextNode: TextNode;
 let charTextNode: TextNode;
-let placeholderTextNode: TextNode;
-let targetTextNode: TextNode;
-let noteTextNode: TextNode;
 let tailTextNode: TextNode;
-let firstCharTextNode: TextNode;
-let secondCharTextNode: TextNode;
 let innerTextNode: TextNode;
 
 function $defaultInitialEditorState() {
@@ -68,12 +64,16 @@ function $defaultInitialEditorState() {
 }
 
 /** Invokes the system under test inside a discrete update, the way `Editor.tsx` will. */
-function sutRemoveCharMarker(editor: LexicalEditor, marker?: string, viewOptions?: ViewOptions) {
+function sutRemoveCharacterMarker(
+  editor: LexicalEditor,
+  marker?: string,
+  viewOptions?: ViewOptions,
+) {
   editor.update(
     () => {
       const selection = $getSelection();
       if ($isRangeSelection(selection))
-        $removeCharMarkerAtSelection(selection, marker, viewOptions);
+        $removeCharacterMarkerAtSelection(selection, marker, viewOptions);
     },
     { discrete: true },
   );
@@ -336,7 +336,7 @@ describe("USJ Marker Action Utils", () => {
     });
   });
 
-  describe("should remove a char marker", () => {
+  describe("should remove a character marker", () => {
     it("when the cursor is collapsed inside a CharNode", () => {
       const { editor } = createBasicTestEnvironment(nodes, () => {
         charTextNode = $createTextNode("Lord");
@@ -350,7 +350,7 @@ describe("USJ Marker Action Utils", () => {
       });
       updateSelection(editor, charTextNode, 2);
 
-      sutRemoveCharMarker(editor);
+      sutRemoveCharacterMarker(editor);
 
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
@@ -375,7 +375,7 @@ describe("USJ Marker Action Utils", () => {
       });
       updateSelection(editor, charTextNode, 0, charTextNode, 4);
 
-      sutRemoveCharMarker(editor, "wj");
+      sutRemoveCharacterMarker(editor, "wj");
 
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
@@ -387,7 +387,46 @@ describe("USJ Marker Action Utils", () => {
       });
     });
 
+    it("dirties no node when the requested marker is not present", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        charTextNode = $createTextNode("Lord");
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createTextNode("the "),
+            $createCharNode("nd").append(charTextNode),
+            $createTextNode(" said"),
+          ),
+        );
+      });
+      // A *partial* selection, unlike the whole-node selection in the test above: an unguarded
+      // `handleTextNode` would `splitText(1, 3)` here, splitting "Lord" into three pieces.
+      updateSelection(editor, charTextNode, 1, charTextNode, 3);
+
+      // Asserting on dirty nodes rather than on the resulting tree: Lexical's reconciliation
+      // re-merges adjacent simple text nodes, so the split is not observable afterwards — but it
+      // still marks nodes dirty, and that is what puts an entry on the undo stack and produces a
+      // collab delta. A documented no-op must not do either.
+      let dirtyLeafCount = 0;
+      const unregisterUpdateListener = editor.registerUpdateListener(({ dirtyLeaves }) => {
+        dirtyLeafCount += dirtyLeaves.size;
+      });
+
+      sutRemoveCharacterMarker(editor, "wj");
+      unregisterUpdateListener();
+
+      expect(dirtyLeafCount).toBe(0);
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        expect(para.getTextContent()).toBe("the Lord said");
+        const charNode = para.getChildAtIndex(1);
+        if (!$isCharNode(charNode)) throw new Error("charNode is not a CharNode");
+        expect(charNode.getMarker()).toBe("nd");
+      });
+    });
+
     it("skips a selection inside a NoteNode", () => {
+      let noteTextNode!: TextNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         noteTextNode = $createTextNode("Lord");
         $getRoot().append(
@@ -399,7 +438,7 @@ describe("USJ Marker Action Utils", () => {
       });
       updateSelection(editor, noteTextNode, 0, noteTextNode, 4);
 
-      sutRemoveCharMarker(editor, "nd");
+      sutRemoveCharacterMarker(editor, "nd");
 
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
@@ -424,7 +463,7 @@ describe("USJ Marker Action Utils", () => {
       // "Lo|rem ips|um"
       updateSelection(editor, charTextNode, 2, charTextNode, 9);
 
-      sutRemoveCharMarker(editor, "nd");
+      sutRemoveCharacterMarker(editor, "nd");
 
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
@@ -459,7 +498,7 @@ describe("USJ Marker Action Utils", () => {
       // "[Lo]rem ipsum"
       updateSelection(editor, charTextNode, 0, charTextNode, 2);
 
-      sutRemoveCharMarker(editor, "nd");
+      sutRemoveCharacterMarker(editor, "nd");
 
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
@@ -484,7 +523,7 @@ describe("USJ Marker Action Utils", () => {
       // "Lorem ips[um]"
       updateSelection(editor, charTextNode, 9, charTextNode, 11);
 
-      sutRemoveCharMarker(editor, "nd");
+      sutRemoveCharacterMarker(editor, "nd");
 
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
@@ -516,7 +555,7 @@ describe("USJ Marker Action Utils", () => {
       // "the [Lord sa]id"
       updateSelection(editor, charTextNode, 0, tailTextNode, 3);
 
-      sutRemoveCharMarker(editor, "nd");
+      sutRemoveCharacterMarker(editor, "nd");
 
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
@@ -529,6 +568,8 @@ describe("USJ Marker Action Utils", () => {
     });
 
     it("when the selection spans two sibling CharNodes", () => {
+      let firstCharTextNode!: TextNode;
+      let secondCharTextNode!: TextNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         firstCharTextNode = $createTextNode("Lord");
         secondCharTextNode = $createTextNode("God");
@@ -542,7 +583,7 @@ describe("USJ Marker Action Utils", () => {
       });
       updateSelection(editor, firstCharTextNode, 0, secondCharTextNode, 3);
 
-      sutRemoveCharMarker(editor, "nd");
+      sutRemoveCharacterMarker(editor, "nd");
 
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
@@ -563,7 +604,7 @@ describe("USJ Marker Action Utils", () => {
       });
       updateSelection(editor, innerTextNode, 0, innerTextNode, 4);
 
-      sutRemoveCharMarker(editor, "nd");
+      sutRemoveCharacterMarker(editor, "nd");
 
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
@@ -588,7 +629,7 @@ describe("USJ Marker Action Utils", () => {
       });
       updateSelection(editor, innerTextNode, 0, innerTextNode, 4);
 
-      sutRemoveCharMarker(editor, "wj");
+      sutRemoveCharacterMarker(editor, "wj");
 
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
@@ -612,7 +653,7 @@ describe("USJ Marker Action Utils", () => {
       });
       updateSelection(editor, innerTextNode, 0, innerTextNode, 4);
 
-      sutRemoveCharMarker(editor);
+      sutRemoveCharacterMarker(editor);
 
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
@@ -642,7 +683,7 @@ describe("USJ Marker Action Utils", () => {
       // Select only "Lord", inside the nested `nd`, and remove the outer `wj`.
       updateSelection(editor, innerTextNode, 0, innerTextNode, 4);
 
-      sutRemoveCharMarker(editor, "wj");
+      sutRemoveCharacterMarker(editor, "wj");
 
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
@@ -680,7 +721,7 @@ describe("USJ Marker Action Utils", () => {
       // sibling exists (leading), exercising the split's leading-clone branch on its own.
       updateSelection(editor, innerTextNode, 0, innerTextNode, 4);
 
-      sutRemoveCharMarker(editor, "wj");
+      sutRemoveCharacterMarker(editor, "wj");
 
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
@@ -700,7 +741,7 @@ describe("USJ Marker Action Utils", () => {
       });
     });
 
-    it("known limitation: drops the outer marker from a nested marker's whole span when only part of it is selected", () => {
+    it("refuses to remove the outer marker when only part of a nested marker's span is selected", () => {
       const { editor } = createBasicTestEnvironment(nodes, () => {
         innerTextNode = $createTextNode("Lord");
         $getRoot().append(
@@ -716,32 +757,28 @@ describe("USJ Marker Action Utils", () => {
       // Select only "Lo" — part of the nested "Lord" — and remove the outer "wj".
       updateSelection(editor, innerTextNode, 0, innerTextNode, 2);
 
-      sutRemoveCharMarker(editor, "wj");
+      sutRemoveCharacterMarker(editor, "wj");
 
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
         if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
-        // Every character still survives; only marker attribution is affected.
         expect(para.getTextContent()).toBe("the Lord said");
-        // Known limitation (see $splitCharNodeAroundTargets docstring, "partial coverage of a
-        // nested CharNode"): transitive coverage treats the whole inner `nd` CharNode as covered
-        // once selection reaches any of its text, so "wj" is removed from the whole of "Lord" —
-        // not just the selected "Lo" — while "the " and " said" correctly keep "wj". Unlike the
-        // marker-mode limitation, this one changes the document's actual USJ content: a real
-        // marker is dropped from text the user never selected.
+        // See $splitCharNodeAroundTargets docstring, "Refuses — partial coverage of a nested
+        // CharNode": transitive coverage cannot split the inner `nd` CharNode at the selection
+        // boundary, so the only removal available would strip "wj" from the whole of "Lord" —
+        // including the unselected "rd". The removal is refused instead, so "wj" still covers the
+        // entire span and no marker attribution changed anywhere. Asserted so that implementing
+        // recursive nested splitting later trips this test rather than silently changing behavior.
         const children = para.getChildren();
-        expect(children.length).toBe(3);
-        const [leading, middle, trailing] = children;
-        if (!$isCharNode(leading)) throw new Error("leading is not a CharNode");
-        expect(leading.getMarker()).toBe("wj");
-        expect(leading.getTextContent()).toBe("the ");
-        // "nd" survives and covers all of "Lord", including the unselected "rd".
-        if (!$isCharNode(middle)) throw new Error("middle is not a CharNode");
-        expect(middle.getMarker()).toBe("nd");
-        expect(middle.getTextContent()).toBe("Lord");
-        if (!$isCharNode(trailing)) throw new Error("trailing is not a CharNode");
-        expect(trailing.getMarker()).toBe("wj");
-        expect(trailing.getTextContent()).toBe(" said");
+        expect(children.length).toBe(1);
+        const [outer] = children;
+        if (!$isCharNode(outer)) throw new Error("outer is not a CharNode");
+        expect(outer.getMarker()).toBe("wj");
+        expect(outer.getTextContent()).toBe("the Lord said");
+        const inner = outer.getChildren().find($isCharNode);
+        if (!$isCharNode(inner)) throw new Error("inner is not a CharNode");
+        expect(inner.getMarker()).toBe("nd");
+        expect(inner.getTextContent()).toBe("Lord");
       });
     });
 
@@ -766,7 +803,7 @@ describe("USJ Marker Action Utils", () => {
       });
       updateSelection(editor, charTextNode, 0, charTextNode, charTextNodeSize);
 
-      sutRemoveCharMarker(editor, "nd", {
+      sutRemoveCharacterMarker(editor, "nd", {
         markerMode: "editable",
         hasSpacing: true,
         isFormattedFont: true,
@@ -803,7 +840,7 @@ describe("USJ Marker Action Utils", () => {
       });
       updateSelection(editor, charTextNode, 0, charTextNode, 4);
 
-      sutRemoveCharMarker(editor, "nd", {
+      sutRemoveCharacterMarker(editor, "nd", {
         markerMode: "visible",
         hasSpacing: true,
         isFormattedFont: true,
@@ -820,6 +857,7 @@ describe("USJ Marker Action Utils", () => {
     });
 
     it("removes an empty CharNode outright instead of leaking the placeholder", () => {
+      let placeholderTextNode!: TextNode;
       let placeholderTextNodeSize = 0;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         placeholderTextNode = $createTextNode(EMPTY_CHAR_PLACEHOLDER_TEXT);
@@ -834,7 +872,7 @@ describe("USJ Marker Action Utils", () => {
       });
       updateSelection(editor, placeholderTextNode, 0, placeholderTextNode, placeholderTextNodeSize);
 
-      sutRemoveCharMarker(editor, "nd");
+      sutRemoveCharacterMarker(editor, "nd");
 
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
@@ -859,7 +897,7 @@ describe("USJ Marker Action Utils", () => {
       // Select exactly "Lord".
       updateSelection(editor, charTextNode, 0, charTextNode, 4);
 
-      sutRemoveCharMarker(editor, "nd");
+      sutRemoveCharacterMarker(editor, "nd");
 
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
@@ -894,7 +932,7 @@ describe("USJ Marker Action Utils", () => {
       // Select "Lord" backward: anchor at the end, focus at the start.
       updateSelection(editor, charTextNode, 4, charTextNode, 0);
 
-      sutRemoveCharMarker(editor, "nd");
+      sutRemoveCharacterMarker(editor, "nd");
 
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
@@ -934,7 +972,7 @@ describe("USJ Marker Action Utils", () => {
       // sibling test above whose split shape isn't exercised here.
       updateSelection(editor, charTextNode, 0, charTextNode, charTextNodeSize);
 
-      sutRemoveCharMarker(editor, "nd", {
+      sutRemoveCharacterMarker(editor, "nd", {
         markerMode: "editable",
         hasSpacing: true,
         isFormattedFont: true,
@@ -975,7 +1013,7 @@ describe("USJ Marker Action Utils", () => {
       // Collapse the caret at the end of "Lord" (offset 5 = NBSP + "Lord".length).
       updateSelection(editor, charTextNode, 5);
 
-      sutRemoveCharMarker(editor, "nd", {
+      sutRemoveCharacterMarker(editor, "nd", {
         markerMode: "editable",
         hasSpacing: true,
         isFormattedFont: true,
@@ -995,6 +1033,7 @@ describe("USJ Marker Action Utils", () => {
     });
 
     it("known limitation: leaves an unpaired marker when the selection is strictly interior under markerMode 'visible'", () => {
+      let targetTextNode!: TextNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
         // A single ordinary text child. `handleTextNode`'s own `splitText(4, 8)` below carves it
         // into "the " / "Lord" / " said" siblings inside the `CharNode`, so the 5-child shape this
@@ -1015,7 +1054,7 @@ describe("USJ Marker Action Utils", () => {
       // unhandled.
       updateSelection(editor, targetTextNode, 4, targetTextNode, 8);
 
-      sutRemoveCharMarker(editor, "nd", {
+      sutRemoveCharacterMarker(editor, "nd", {
         markerMode: "visible",
         hasSpacing: true,
         isFormattedFont: true,
@@ -1211,6 +1250,25 @@ describe("USJ Marker Action Utils", () => {
 
     it.each(["p", "wj", "f", "v", "c"])("isUsjMarkerSupported returns true for '%s'", (marker) => {
       expect(isUsjMarkerSupported(marker)).toBe(true);
+    });
+
+    it.each(["wj", "nd", "bd"])(
+      "isCharacterMarkerSupported returns true for character marker '%s'",
+      (marker) => {
+        expect(isCharacterMarkerSupported(marker)).toBe(true);
+      },
+    );
+
+    it.each(["p", "f", "v", "c", "zzz"])(
+      "isCharacterMarkerSupported returns false for non-character marker '%s'",
+      (marker) => {
+        expect(isCharacterMarkerSupported(marker)).toBe(false);
+      },
+    );
+
+    it("isCharacterMarkerSupported honors extraValidMarkers, unlike isUsjMarkerSupported", () => {
+      expect(isCharacterMarkerSupported("zzz", ["zzz"])).toBe(true);
+      expect(isUsjMarkerSupported("zzz")).toBe(false);
     });
   });
 });

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -30,6 +30,8 @@ import {
 import {
   $createCharNode,
   $createImmutableChapterNode,
+  $createImmutableTypedTextNode,
+  $createMarkerNode,
   $createNoteNode,
   $createParaNode,
   $isCharNode,
@@ -37,7 +39,10 @@ import {
   $isNoteNode,
   $isParaNode,
   charIdState,
+  closingMarkerText,
   EMPTY_CHAR_PLACEHOLDER_TEXT,
+  NBSP,
+  openingMarkerText,
 } from "shared";
 
 const nodes = usjReactNodes;
@@ -45,6 +50,7 @@ const reference = { book: "GEN", chapterNum: 1, verseNum: 1 };
 
 let secondVerseTextNode: TextNode;
 let charTextNode: TextNode;
+let placeholderTextNode: TextNode;
 let noteTextNode: TextNode;
 let tailTextNode: TextNode;
 let firstCharTextNode: TextNode;
@@ -715,6 +721,106 @@ describe("USJ Marker Action Utils", () => {
         if (!$isCharNode(trailing)) throw new Error("trailing is not a CharNode");
         expect(trailing.getMarker()).toBe("nd");
         expect(trailing.getTextContent()).toBe("Lord");
+      });
+    });
+
+    it("strips synthesized MarkerNode children and the NBSP in markerMode 'editable'", () => {
+      let charTextNodeSize = 0;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        // Mirrors usj-editor.adaptor.ts createChar under markerMode "editable": a MarkerNode
+        // opening, each text child prefixed with NBSP, then a closing MarkerNode.
+        charTextNode = $createTextNode(NBSP + "Lord");
+        charTextNodeSize = charTextNode.getTextContentSize();
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createTextNode("the "),
+            $createCharNode("nd").append(
+              $createMarkerNode("nd"),
+              charTextNode,
+              $createMarkerNode("nd", "closing"),
+            ),
+            $createTextNode(" said"),
+          ),
+        );
+      });
+      updateSelection(editor, charTextNode, 0, charTextNode, charTextNodeSize);
+
+      sutRemoveCharMarker(editor, "nd", {
+        markerMode: "editable",
+        hasSpacing: true,
+        isFormattedFont: true,
+      });
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        expect(para.getChildren().some($isCharNode)).toBe(false);
+        // No literal \nd or \nd* left behind, and no stray NBSP.
+        expect(para.getTextContent()).not.toContain(openingMarkerText("nd"));
+        expect(para.getTextContent()).not.toContain(closingMarkerText("nd"));
+        expect(para.getTextContent()).not.toContain(NBSP);
+        expect(para.getTextContent()).toBe("the Lord said");
+      });
+    });
+
+    it("strips synthesized ImmutableTypedTextNode children in markerMode 'visible'", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        // Mirrors usj-editor.adaptor.ts createChar under markerMode "visible": immutable
+        // typed-text markers on both sides and no NBSP prefix on the content.
+        charTextNode = $createTextNode("Lord");
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createTextNode("the "),
+            $createCharNode("nd").append(
+              $createImmutableTypedTextNode("marker", openingMarkerText("nd")),
+              charTextNode,
+              $createImmutableTypedTextNode("marker", closingMarkerText("nd")),
+            ),
+            $createTextNode(" said"),
+          ),
+        );
+      });
+      updateSelection(editor, charTextNode, 0, charTextNode, 4);
+
+      sutRemoveCharMarker(editor, "nd", {
+        markerMode: "visible",
+        hasSpacing: true,
+        isFormattedFont: true,
+      });
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        expect(para.getChildren().some($isCharNode)).toBe(false);
+        expect(para.getTextContent()).not.toContain(openingMarkerText("nd"));
+        expect(para.getTextContent()).not.toContain(closingMarkerText("nd"));
+        expect(para.getTextContent()).toBe("the Lord said");
+      });
+    });
+
+    it("removes an empty CharNode outright instead of leaking the placeholder", () => {
+      let placeholderTextNodeSize = 0;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        placeholderTextNode = $createTextNode(EMPTY_CHAR_PLACEHOLDER_TEXT);
+        placeholderTextNodeSize = placeholderTextNode.getTextContentSize();
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createTextNode("the "),
+            $createCharNode("nd").append(placeholderTextNode),
+            $createTextNode("said"),
+          ),
+        );
+      });
+      updateSelection(editor, placeholderTextNode, 0, placeholderTextNode, placeholderTextNodeSize);
+
+      sutRemoveCharMarker(editor, "nd");
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        expect(para.getChildren().some($isCharNode)).toBe(false);
+        // The placeholder is synthesized, not content — it must not survive as real text.
+        expect(para.getTextContent()).toBe("the said");
       });
     });
   });

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -337,31 +337,6 @@ describe("USJ Marker Action Utils", () => {
   });
 
   describe("should remove a char marker", () => {
-    it("when the selection is exactly one CharNode", () => {
-      const { editor } = createBasicTestEnvironment(nodes, () => {
-        charTextNode = $createTextNode("Lord");
-        $getRoot().append(
-          $createParaNode("p").append(
-            $createTextNode("the "),
-            $createCharNode("nd").append(charTextNode),
-            $createTextNode(" said"),
-          ),
-        );
-      });
-      updateSelection(editor, charTextNode, 0, charTextNode, 4);
-
-      sutRemoveCharMarker(editor, "nd");
-
-      editor.getEditorState().read(() => {
-        const para = $getRoot().getFirstChild();
-        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
-        // CharNode gone, siblings normalized into a single TextNode.
-        expect(para.getChildren().some($isCharNode)).toBe(false);
-        expect(para.getChildrenSize()).toBe(1);
-        expect(para.getTextContent()).toBe("the Lord said");
-      });
-    });
-
     it("when the cursor is collapsed inside a CharNode", () => {
       const { editor } = createBasicTestEnvironment(nodes, () => {
         charTextNode = $createTextNode("Lord");
@@ -725,6 +700,51 @@ describe("USJ Marker Action Utils", () => {
       });
     });
 
+    it("known limitation: drops the outer marker from a nested marker's whole span when only part of it is selected", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        innerTextNode = $createTextNode("Lord");
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createCharNode("wj").append(
+              $createTextNode("the "),
+              $createCharNode("nd").append(innerTextNode),
+              $createTextNode(" said"),
+            ),
+          ),
+        );
+      });
+      // Select only "Lo" — part of the nested "Lord" — and remove the outer "wj".
+      updateSelection(editor, innerTextNode, 0, innerTextNode, 2);
+
+      sutRemoveCharMarker(editor, "wj");
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        // N2 still holds: every character survives.
+        expect(para.getTextContent()).toBe("the Lord said");
+        // Known limitation (see $splitCharNodeAroundTargets docstring, "partial coverage of a
+        // nested CharNode"): transitive coverage treats the whole inner `nd` CharNode as covered
+        // once selection reaches any of its text, so "wj" is removed from the whole of "Lord" —
+        // not just the selected "Lo" — while "the " and " said" correctly keep "wj". Unlike the
+        // marker-mode limitation pinned above, this one changes the document's actual USJ content
+        // (a real marker is dropped from unselected text), so it is pinned here too.
+        const children = para.getChildren();
+        expect(children.length).toBe(3);
+        const [leading, middle, trailing] = children;
+        if (!$isCharNode(leading)) throw new Error("leading is not a CharNode");
+        expect(leading.getMarker()).toBe("wj");
+        expect(leading.getTextContent()).toBe("the ");
+        // "nd" survives and covers all of "Lord", including the unselected "rd".
+        if (!$isCharNode(middle)) throw new Error("middle is not a CharNode");
+        expect(middle.getMarker()).toBe("nd");
+        expect(middle.getTextContent()).toBe("Lord");
+        if (!$isCharNode(trailing)) throw new Error("trailing is not a CharNode");
+        expect(trailing.getMarker()).toBe("wj");
+        expect(trailing.getTextContent()).toBe(" said");
+      });
+    });
+
     it("strips synthesized MarkerNode children and the NBSP in markerMode 'editable'", () => {
       let charTextNodeSize = 0;
       const { editor } = createBasicTestEnvironment(nodes, () => {
@@ -844,6 +864,9 @@ describe("USJ Marker Action Utils", () => {
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
         if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        // CharNode gone, siblings normalized into a single TextNode.
+        expect(para.getChildren().some($isCharNode)).toBe(false);
+        expect(para.getChildrenSize()).toBe(1);
         expect(para.getTextContent()).toBe("the Lord said");
         // The three text nodes normalized into one, so assert on the survivor.
         const mergedTextNode = para.getFirstChild();
@@ -854,6 +877,38 @@ describe("USJ Marker Action Utils", () => {
         const selection = $getSelection();
         if (!$isRangeSelection(selection)) throw new Error("selection is not a range selection");
         expect(selection.getTextContent()).toBe("Lord");
+      });
+    });
+
+    it("keeps the selection backward when the original selection was backward", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        charTextNode = $createTextNode("Lord");
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createTextNode("the "),
+            $createCharNode("nd").append(charTextNode),
+            $createTextNode(" said"),
+          ),
+        );
+      });
+      // Select "Lord" backward: anchor at the end, focus at the start.
+      updateSelection(editor, charTextNode, 4, charTextNode, 0);
+
+      sutRemoveCharMarker(editor, "nd");
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        const mergedTextNode = para.getFirstChild();
+        if (!$isTextNode(mergedTextNode)) throw new Error("merged node is not a TextNode");
+        expect(mergedTextNode.getTextContent()).toBe("the Lord said");
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) throw new Error("selection is not a range selection");
+        // Direction preserved: anchor stays at the end (offset 8), focus at the start (offset 4) —
+        // not normalized to forward.
+        expect(selection.isBackward()).toBe(true);
+        expect(selection.anchor.offset).toBe(8);
+        expect(selection.focus.offset).toBe(4);
       });
     });
 
@@ -902,27 +957,64 @@ describe("USJ Marker Action Utils", () => {
       });
     });
 
+    it("keeps the collapsed caret positioned after the NBSP trim in markerMode 'editable'", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        charTextNode = $createTextNode(NBSP + "Lord");
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createTextNode("the "),
+            $createCharNode("nd").append(
+              $createMarkerNode("nd"),
+              charTextNode,
+              $createMarkerNode("nd", "closing"),
+            ),
+            $createTextNode(" said"),
+          ),
+        );
+      });
+      // Collapse the caret at the end of "Lord" (offset 5 = NBSP + "Lord".length).
+      updateSelection(editor, charTextNode, 5);
+
+      sutRemoveCharMarker(editor, "nd", {
+        markerMode: "editable",
+        hasSpacing: true,
+        isFormattedFont: true,
+      });
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        const mergedTextNode = para.getFirstChild();
+        if (!$isTextNode(mergedTextNode)) throw new Error("merged node is not a TextNode");
+        expect(mergedTextNode.getTextContent()).toBe("the Lord said");
+        // The caret was at the end of "Lord" (offset 5 within NBSP + "Lord"). Once the NBSP is
+        // trimmed and the siblings merge, it must land at "the Lord"'s end (offset 8), not one
+        // character past it — the collapsed-branch counterpart to the range-branch restore above.
+        $expectSelectionToBe(mergedTextNode, 8);
+      });
+    });
+
     it("known limitation: leaves an unpaired marker when the selection is strictly interior under markerMode 'visible'", () => {
       const { editor } = createBasicTestEnvironment(nodes, () => {
-        targetTextNode = $createTextNode("Lord");
-        // "the " / " said" are marked "token" so Lexical's own plain-text normalization doesn't
-        // merge them into targetTextNode on commit — this fixture needs all three to stay
-        // separate nodes, unlike normal prose where such adjacent plain text would coalesce.
+        // A single ordinary text child — no artificial pre-split needed. `handleTextNode`'s own
+        // `splitText(4, 8)` below carves it into "the " / "Lord" / " said" siblings inside the
+        // `CharNode`, producing the same 5-child shape an everyday selection-and-remove reaches,
+        // not just a hand-built fixture.
+        targetTextNode = $createTextNode("the Lord said");
         $getRoot().append(
           $createParaNode("p").append(
             $createCharNode("nd").append(
               $createImmutableTypedTextNode("marker", openingMarkerText("nd")),
-              $createTextNode("the ").setMode("token"),
               targetTextNode,
-              $createTextNode(" said").setMode("token"),
               $createImmutableTypedTextNode("marker", closingMarkerText("nd")),
             ),
           ),
         );
       });
-      // Select only the interior "Lord", leaving real unselected text between it and each
-      // boundary marker — the shape $splitCharNodeAroundTargets' docstring documents as unhandled.
-      updateSelection(editor, targetTextNode, 0, targetTextNode, 4);
+      // Select only the interior "Lord" (offsets 4-8), leaving real unselected text between it and
+      // each boundary marker — the shape $splitCharNodeAroundTargets' docstring documents as
+      // unhandled.
+      updateSelection(editor, targetTextNode, 4, targetTextNode, 8);
 
       sutRemoveCharMarker(editor, "nd", {
         markerMode: "visible",

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -343,6 +343,7 @@ describe("USJ Marker Action Utils", () => {
         if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
         // CharNode gone, siblings normalized into a single TextNode.
         expect(para.getChildren().some($isCharNode)).toBe(false);
+        expect(para.getChildrenSize()).toBe(1);
         expect(para.getTextContent()).toBe("the Lord said");
       });
     });
@@ -367,6 +368,7 @@ describe("USJ Marker Action Utils", () => {
         if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
         // Collapsed cursor removes the marker from the whole CharNode — no split.
         expect(para.getChildren().some($isCharNode)).toBe(false);
+        expect(para.getChildrenSize()).toBe(1);
         expect(para.getTextContent()).toBe("the Lord said");
       });
     });
@@ -415,7 +417,9 @@ describe("USJ Marker Action Utils", () => {
         if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
         const noteNode = para.getChildAtIndex(1);
         if (!$isNoteNode(noteNode)) throw new Error("noteNode is not a NoteNode");
-        // $getTargetNode already skips note interiors, so the CharNode survives.
+        // $getTargetNode's note check only sees an immediate parent, which doesn't cover a
+        // CharNode nested inside a NoteNode. It's $getCharNodeToRemove's own NoteNode guard that
+        // skips this case, so the CharNode survives.
         expect(noteNode.getChildren().some($isCharNode)).toBe(true);
         expect(noteNode.getTextContent()).toBe("Lord");
       });

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -635,10 +635,89 @@ describe("USJ Marker Action Utils", () => {
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
         if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        expect(para.getTextContent()).toBe("Lord");
         const outerCharNode = para.getFirstChild();
         if (!$isCharNode(outerCharNode)) throw new Error("outer is not a CharNode");
         expect(outerCharNode.getMarker()).toBe("wj");
+        expect(outerCharNode.getChildren().some($isCharNode)).toBe(false);
         expect(outerCharNode.getTextContent()).toBe("Lord");
+      });
+    });
+
+    it("does not strip the outer marker from unselected text flanking a nested marker", () => {
+      let leadTextNode: TextNode;
+      let trailTextNode: TextNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        leadTextNode = $createTextNode("the ");
+        innerTextNode = $createTextNode("Lord");
+        trailTextNode = $createTextNode(" said");
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createCharNode("wj").append(
+              leadTextNode,
+              $createCharNode("nd").append(innerTextNode),
+              trailTextNode,
+            ),
+          ),
+        );
+      });
+      // Select only "Lord", inside the nested `nd`, and remove the outer `wj`.
+      updateSelection(editor, innerTextNode, 0, innerTextNode, 4);
+
+      sutRemoveCharMarker(editor, "wj");
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        expect(para.getTextContent()).toBe("the Lord said");
+        const children = para.getChildren();
+        expect(children.length).toBe(3);
+        const [leading, middle, trailing] = children;
+        // Unselected flanking text must keep its `wj` marker — only the selected span loses it.
+        if (!$isCharNode(leading)) throw new Error("leading is not a CharNode");
+        expect(leading.getMarker()).toBe("wj");
+        expect(leading.getTextContent()).toBe("the ");
+        if (!$isCharNode(middle)) throw new Error("middle is not a CharNode");
+        expect(middle.getMarker()).toBe("nd");
+        expect(middle.getTextContent()).toBe("Lord");
+        if (!$isCharNode(trailing)) throw new Error("trailing is not a CharNode");
+        expect(trailing.getMarker()).toBe("wj");
+        expect(trailing.getTextContent()).toBe(" said");
+      });
+    });
+
+    it("does not strip the outer marker from a leading sibling of a fully covered nested marker", () => {
+      let leadTextNode: TextNode;
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        leadTextNode = $createTextNode("the ");
+        innerTextNode = $createTextNode("Lord");
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createCharNode("wj").append(leadTextNode, $createCharNode("nd").append(innerTextNode)),
+          ),
+        );
+      });
+      // Select all of "Lord", inside the nested `nd`, and remove the outer `wj`. Only one flanking
+      // sibling exists (leading), exercising the split's leading-clone branch on its own.
+      updateSelection(editor, innerTextNode, 0, innerTextNode, 4);
+
+      sutRemoveCharMarker(editor, "wj");
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        expect(para.getTextContent()).toBe("the Lord");
+        const children = para.getChildren();
+        expect(children.length).toBe(2);
+        const [leading, trailing] = children;
+        // The unselected leading text must keep its `wj` marker; only the selected nested span
+        // loses it.
+        if (!$isCharNode(leading)) throw new Error("leading is not a CharNode");
+        expect(leading.getMarker()).toBe("wj");
+        expect(leading.getTextContent()).toBe("the ");
+        if (!$isCharNode(trailing)) throw new Error("trailing is not a CharNode");
+        expect(trailing.getMarker()).toBe("nd");
+        expect(trailing.getTextContent()).toBe("Lord");
       });
     });
   });

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -5,11 +5,30 @@ import {
   createBasicTestEnvironment,
   updateSelection,
 } from "../../../../../libs/shared/src/nodes/usj/test.utils";
-import { getUsjMarkerAction, isUsjMarkerSupported } from "./usj-marker-action.utils";
-import { $createTextNode, $getRoot, $isTextNode, TextNode } from "lexical";
-import { $createImmutableVerseNode, $isImmutableVerseNode, usjReactNodes } from "shared-react";
 import {
+  $removeCharMarkerAtSelection,
+  getUsjMarkerAction,
+  isUsjMarkerSupported,
+} from "./usj-marker-action.utils";
+import {
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $isTextNode,
+  LexicalEditor,
+  TextNode,
+} from "lexical";
+import {
+  $createImmutableVerseNode,
+  $isImmutableVerseNode,
+  usjReactNodes,
+  ViewOptions,
+} from "shared-react";
+import {
+  $createCharNode,
   $createImmutableChapterNode,
+  $createNoteNode,
   $createParaNode,
   $isCharNode,
   $isImmutableChapterNode,
@@ -22,6 +41,8 @@ const nodes = usjReactNodes;
 const reference = { book: "GEN", chapterNum: 1, verseNum: 1 };
 
 let secondVerseTextNode: TextNode;
+let charTextNode: TextNode;
+let noteTextNode: TextNode;
 
 function $defaultInitialEditorState() {
   secondVerseTextNode = $createTextNode("second verse text ");
@@ -29,6 +50,18 @@ function $defaultInitialEditorState() {
     $createImmutableChapterNode("1"),
     $createParaNode().append($createImmutableVerseNode("1"), $createTextNode("first verse text ")),
     $createParaNode().append($createImmutableVerseNode("2"), secondVerseTextNode),
+  );
+}
+
+/** Invokes the system under test inside a discrete update, the way `Editor.tsx` will. */
+function sutRemoveCharMarker(editor: LexicalEditor, marker?: string, viewOptions?: ViewOptions) {
+  editor.update(
+    () => {
+      const selection = $getSelection();
+      if ($isRangeSelection(selection))
+        $removeCharMarkerAtSelection(selection, marker, viewOptions);
+    },
+    { discrete: true },
   );
 }
 
@@ -285,6 +318,106 @@ describe("USJ Marker Action Utils", () => {
         if (!$isTextNode(charTextNode))
           throw new Error("Inserted char node does not have a text node");
         $expectSelectionToBe(charTextNode);
+      });
+    });
+  });
+
+  describe("should remove a char marker", () => {
+    it("when the selection is exactly one CharNode", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        charTextNode = $createTextNode("Lord");
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createTextNode("the "),
+            $createCharNode("nd").append(charTextNode),
+            $createTextNode(" said"),
+          ),
+        );
+      });
+      updateSelection(editor, charTextNode, 0, charTextNode, 4);
+
+      sutRemoveCharMarker(editor, "nd");
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        // CharNode gone, siblings normalized into a single TextNode.
+        expect(para.getChildren().some($isCharNode)).toBe(false);
+        expect(para.getTextContent()).toBe("the Lord said");
+      });
+    });
+
+    it("when the cursor is collapsed inside a CharNode", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        charTextNode = $createTextNode("Lord");
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createTextNode("the "),
+            $createCharNode("nd").append(charTextNode),
+            $createTextNode(" said"),
+          ),
+        );
+      });
+      updateSelection(editor, charTextNode, 2);
+
+      sutRemoveCharMarker(editor);
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        // Collapsed cursor removes the marker from the whole CharNode — no split.
+        expect(para.getChildren().some($isCharNode)).toBe(false);
+        expect(para.getTextContent()).toBe("the Lord said");
+      });
+    });
+
+    it("is a no-op when the requested marker is not present", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        charTextNode = $createTextNode("Lord");
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createTextNode("the "),
+            $createCharNode("nd").append(charTextNode),
+            $createTextNode(" said"),
+          ),
+        );
+      });
+      updateSelection(editor, charTextNode, 0, charTextNode, 4);
+
+      sutRemoveCharMarker(editor, "wj");
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        const charNode = para.getChildAtIndex(1);
+        if (!$isCharNode(charNode)) throw new Error("charNode is not a CharNode");
+        expect(charNode.getMarker()).toBe("nd");
+        expect(para.getTextContent()).toBe("the Lord said");
+      });
+    });
+
+    it("skips a selection inside a NoteNode", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        noteTextNode = $createTextNode("Lord");
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createTextNode("the "),
+            $createNoteNode("f", "+").append($createCharNode("nd").append(noteTextNode)),
+          ),
+        );
+      });
+      updateSelection(editor, noteTextNode, 0, noteTextNode, 4);
+
+      sutRemoveCharMarker(editor, "nd");
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        const noteNode = para.getChildAtIndex(1);
+        if (!$isNoteNode(noteNode)) throw new Error("noteNode is not a NoteNode");
+        // $getTargetNode already skips note interiors, so the CharNode survives.
+        expect(noteNode.getChildren().some($isCharNode)).toBe(true);
+        expect(noteNode.getTextContent()).toBe("Lord");
       });
     });
   });

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -63,20 +63,26 @@ function $defaultInitialEditorState() {
   );
 }
 
-/** Invokes the system under test inside a discrete update, the way `Editor.tsx` will. */
+/**
+ * Invokes the system under test inside a discrete update, the way `Editor.tsx` will.
+ *
+ * @returns whether a marker was removed, mirroring what `EditorRef.removeCharacterMarker` reports.
+ */
 function sutRemoveCharacterMarker(
   editor: LexicalEditor,
   marker?: string,
   viewOptions?: ViewOptions,
-) {
+): boolean {
+  let didRemove = false;
   editor.update(
     () => {
       const selection = $getSelection();
       if ($isRangeSelection(selection))
-        $removeCharacterMarkerAtSelection(selection, marker, viewOptions);
+        didRemove = $removeCharacterMarkerAtSelection(selection, marker, viewOptions);
     },
     { discrete: true },
   );
+  return didRemove;
 }
 
 describe("USJ Marker Action Utils", () => {
@@ -350,7 +356,7 @@ describe("USJ Marker Action Utils", () => {
       });
       updateSelection(editor, charTextNode, 2);
 
-      sutRemoveCharacterMarker(editor);
+      expect(sutRemoveCharacterMarker(editor)).toBe(true);
 
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
@@ -375,7 +381,7 @@ describe("USJ Marker Action Utils", () => {
       });
       updateSelection(editor, charTextNode, 0, charTextNode, 4);
 
-      sutRemoveCharacterMarker(editor, "wj");
+      expect(sutRemoveCharacterMarker(editor, "wj")).toBe(false);
 
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
@@ -406,15 +412,22 @@ describe("USJ Marker Action Utils", () => {
       // re-merges adjacent simple text nodes, so the split is not observable afterwards — but it
       // still marks nodes dirty, and that is what puts an entry on the undo stack and produces a
       // collab delta. A documented no-op must not do either.
+      // `dirtyElements` as well as `dirtyLeaves`: unwrapping or splitting a CharNode dirties an
+      // *element*, which a leaf-only count would miss entirely.
       let dirtyLeafCount = 0;
-      const unregisterUpdateListener = editor.registerUpdateListener(({ dirtyLeaves }) => {
-        dirtyLeafCount += dirtyLeaves.size;
-      });
+      let dirtyElementCount = 0;
+      const unregisterUpdateListener = editor.registerUpdateListener(
+        ({ dirtyLeaves, dirtyElements }) => {
+          dirtyLeafCount += dirtyLeaves.size;
+          dirtyElementCount += dirtyElements.size;
+        },
+      );
 
       sutRemoveCharacterMarker(editor, "wj");
       unregisterUpdateListener();
 
       expect(dirtyLeafCount).toBe(0);
+      expect(dirtyElementCount).toBe(0);
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
         if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
@@ -779,6 +792,53 @@ describe("USJ Marker Action Utils", () => {
         if (!$isCharNode(inner)) throw new Error("inner is not a CharNode");
         expect(inner.getMarker()).toBe("nd");
         expect(inner.getTextContent()).toBe("Lord");
+      });
+    });
+
+    it("dirties no node and leaves the selection alone when the removal is refused", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        innerTextNode = $createTextNode("Lord");
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createCharNode("wj").append(
+              $createTextNode("the "),
+              $createCharNode("nd").append(innerTextNode),
+              $createTextNode(" said"),
+            ),
+          ),
+        );
+      });
+      // Same partial-coverage-of-a-nested-marker shape as the test above, which asserts only the
+      // final tree. Lexical re-merges the split halves, so that tree looks identical whether or not
+      // the refuse path mutated on its way to refusing — this test covers that blind spot.
+      updateSelection(editor, innerTextNode, 0, innerTextNode, 2);
+
+      let dirtyLeafCount = 0;
+      let dirtyElementCount = 0;
+      const unregisterUpdateListener = editor.registerUpdateListener(
+        ({ dirtyLeaves, dirtyElements }) => {
+          dirtyLeafCount += dirtyLeaves.size;
+          dirtyElementCount += dirtyElements.size;
+        },
+      );
+
+      expect(sutRemoveCharacterMarker(editor, "wj")).toBe(false);
+      unregisterUpdateListener();
+
+      // A refused request is documented as a no-op, so it must not put an entry on the undo stack
+      // or produce a collab delta. `$hasRemovableCharNode` decides the refusal read-only, before
+      // the splitting pass, which is what keeps both counts at zero.
+      expect(dirtyLeafCount).toBe(0);
+      expect(dirtyElementCount).toBe(0);
+      editor.getEditorState().read(() => {
+        // The selection restore block must not run either — a no-op has no business moving the
+        // caller's selection off the range they chose.
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) throw new Error("selection is not a range selection");
+        expect(selection.anchor.getNode().getKey()).toBe(innerTextNode.getKey());
+        expect(selection.anchor.offset).toBe(0);
+        expect(selection.focus.getNode().getKey()).toBe(innerTextNode.getKey());
+        expect(selection.focus.offset).toBe(2);
       });
     });
 

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -43,6 +43,9 @@ const reference = { book: "GEN", chapterNum: 1, verseNum: 1 };
 let secondVerseTextNode: TextNode;
 let charTextNode: TextNode;
 let noteTextNode: TextNode;
+let tailTextNode: TextNode;
+let firstCharTextNode: TextNode;
+let secondCharTextNode: TextNode;
 
 function $defaultInitialEditorState() {
   secondVerseTextNode = $createTextNode("second verse text ");
@@ -422,6 +425,84 @@ describe("USJ Marker Action Utils", () => {
         // skips this case, so the CharNode survives.
         expect(noteNode.getChildren().some($isCharNode)).toBe(true);
         expect(noteNode.getTextContent()).toBe("Lord");
+      });
+    });
+
+    it("splits the CharNode when the selection is strictly inside it", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        charTextNode = $createTextNode("Lorem ipsum");
+        $getRoot().append($createParaNode("p").append($createCharNode("nd").append(charTextNode)));
+      });
+      // "Lo|rem ips|um"
+      updateSelection(editor, charTextNode, 2, charTextNode, 9);
+
+      sutRemoveCharMarker(editor, "nd");
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        // N2: every character survives.
+        expect(para.getTextContent()).toBe("Lorem ipsum");
+        const children = para.getChildren();
+        expect(children.length).toBe(3);
+        const [leading, middle, trailing] = children;
+        if (!$isCharNode(leading)) throw new Error("leading is not a CharNode");
+        if (!$isTextNode(middle)) throw new Error("middle is not a TextNode");
+        if (!$isCharNode(trailing)) throw new Error("trailing is not a CharNode");
+        expect(leading.getMarker()).toBe("nd");
+        expect(leading.getTextContent()).toBe("Lo");
+        expect(middle.getTextContent()).toBe("rem ips");
+        expect(trailing.getMarker()).toBe("nd");
+        expect(trailing.getTextContent()).toBe("um");
+      });
+    });
+
+    it("when the selection spans a CharNode and plain text", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        charTextNode = $createTextNode("Lord");
+        tailTextNode = $createTextNode(" said");
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createTextNode("the "),
+            $createCharNode("nd").append(charTextNode),
+            tailTextNode,
+          ),
+        );
+      });
+      // "the [Lord sa]id"
+      updateSelection(editor, charTextNode, 0, tailTextNode, 3);
+
+      sutRemoveCharMarker(editor, "nd");
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        expect(para.getChildren().some($isCharNode)).toBe(false);
+        expect(para.getTextContent()).toBe("the Lord said");
+      });
+    });
+
+    it("when the selection spans two sibling CharNodes", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        firstCharTextNode = $createTextNode("Lord");
+        secondCharTextNode = $createTextNode("God");
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createCharNode("nd").append(firstCharTextNode),
+            $createTextNode(" the "),
+            $createCharNode("nd").append(secondCharTextNode),
+          ),
+        );
+      });
+      updateSelection(editor, firstCharTextNode, 0, secondCharTextNode, 3);
+
+      sutRemoveCharMarker(editor, "nd");
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        expect(para.getChildren().some($isCharNode)).toBe(false);
+        expect(para.getTextContent()).toBe("Lord the God");
       });
     });
   });

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -49,6 +49,7 @@ let noteTextNode: TextNode;
 let tailTextNode: TextNode;
 let firstCharTextNode: TextNode;
 let secondCharTextNode: TextNode;
+let innerTextNode: TextNode;
 
 function $defaultInitialEditorState() {
   secondVerseTextNode = $createTextNode("second verse text ");
@@ -566,6 +567,78 @@ describe("USJ Marker Action Utils", () => {
         if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
         expect(para.getChildren().some($isCharNode)).toBe(false);
         expect(para.getTextContent()).toBe("Lord the God");
+      });
+    });
+
+    it("removes the inner marker of a nested pair, leaving the outer intact", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        innerTextNode = $createTextNode("Lord");
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createCharNode("wj").append($createCharNode("nd").append(innerTextNode)),
+          ),
+        );
+      });
+      updateSelection(editor, innerTextNode, 0, innerTextNode, 4);
+
+      sutRemoveCharMarker(editor, "nd");
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        expect(para.getTextContent()).toBe("Lord");
+        const outerCharNode = para.getFirstChild();
+        if (!$isCharNode(outerCharNode)) throw new Error("outer is not a CharNode");
+        expect(outerCharNode.getMarker()).toBe("wj");
+        expect(outerCharNode.getChildren().some($isCharNode)).toBe(false);
+        expect(outerCharNode.getTextContent()).toBe("Lord");
+      });
+    });
+
+    it("removes the outer marker of a nested pair, leaving the inner intact", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        innerTextNode = $createTextNode("Lord");
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createCharNode("wj").append($createCharNode("nd").append(innerTextNode)),
+          ),
+        );
+      });
+      updateSelection(editor, innerTextNode, 0, innerTextNode, 4);
+
+      sutRemoveCharMarker(editor, "wj");
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        expect(para.getTextContent()).toBe("Lord");
+        const innerCharNode = para.getFirstChild();
+        if (!$isCharNode(innerCharNode)) throw new Error("inner is not a CharNode");
+        expect(innerCharNode.getMarker()).toBe("nd");
+        expect(innerCharNode.getTextContent()).toBe("Lord");
+      });
+    });
+
+    it("removes the innermost marker when none is given", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        innerTextNode = $createTextNode("Lord");
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createCharNode("wj").append($createCharNode("nd").append(innerTextNode)),
+          ),
+        );
+      });
+      updateSelection(editor, innerTextNode, 0, innerTextNode, 4);
+
+      sutRemoveCharMarker(editor);
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        const outerCharNode = para.getFirstChild();
+        if (!$isCharNode(outerCharNode)) throw new Error("outer is not a CharNode");
+        expect(outerCharNode.getMarker()).toBe("wj");
+        expect(outerCharNode.getTextContent()).toBe("Lord");
       });
     });
   });

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -429,7 +429,7 @@ describe("USJ Marker Action Utils", () => {
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
         if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
-        // N2: every character survives.
+        // Every character of the marker's content survives the split.
         expect(para.getTextContent()).toBe("Lorem ipsum");
         const children = para.getChildren();
         expect(children.length).toBe(3);
@@ -721,14 +721,14 @@ describe("USJ Marker Action Utils", () => {
       editor.getEditorState().read(() => {
         const para = $getRoot().getFirstChild();
         if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
-        // N2 still holds: every character survives.
+        // Every character still survives; only marker attribution is affected.
         expect(para.getTextContent()).toBe("the Lord said");
         // Known limitation (see $splitCharNodeAroundTargets docstring, "partial coverage of a
         // nested CharNode"): transitive coverage treats the whole inner `nd` CharNode as covered
         // once selection reaches any of its text, so "wj" is removed from the whole of "Lord" —
         // not just the selected "Lo" — while "the " and " said" correctly keep "wj". Unlike the
-        // marker-mode limitation pinned above, this one changes the document's actual USJ content
-        // (a real marker is dropped from unselected text), so it is pinned here too.
+        // marker-mode limitation, this one changes the document's actual USJ content: a real
+        // marker is dropped from text the user never selected.
         const children = para.getChildren();
         expect(children.length).toBe(3);
         const [leading, middle, trailing] = children;
@@ -996,10 +996,9 @@ describe("USJ Marker Action Utils", () => {
 
     it("known limitation: leaves an unpaired marker when the selection is strictly interior under markerMode 'visible'", () => {
       const { editor } = createBasicTestEnvironment(nodes, () => {
-        // A single ordinary text child — no artificial pre-split needed. `handleTextNode`'s own
-        // `splitText(4, 8)` below carves it into "the " / "Lord" / " said" siblings inside the
-        // `CharNode`, producing the same 5-child shape an everyday selection-and-remove reaches,
-        // not just a hand-built fixture.
+        // A single ordinary text child. `handleTextNode`'s own `splitText(4, 8)` below carves it
+        // into "the " / "Lord" / " said" siblings inside the `CharNode`, so the 5-child shape this
+        // test pins is one an everyday selection-and-remove reaches, not a hand-built fixture.
         targetTextNode = $createTextNode("the Lord said");
         $getRoot().append(
           $createParaNode("p").append(

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -823,6 +823,38 @@ describe("USJ Marker Action Utils", () => {
         expect(para.getTextContent()).toBe("the said");
       });
     });
+
+    it("keeps the selection over the same characters after removal", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        charTextNode = $createTextNode("Lord");
+        $getRoot().append(
+          $createParaNode("p").append(
+            $createTextNode("the "),
+            $createCharNode("nd").append(charTextNode),
+            $createTextNode(" said"),
+          ),
+        );
+      });
+      // Select exactly "Lord".
+      updateSelection(editor, charTextNode, 0, charTextNode, 4);
+
+      sutRemoveCharMarker(editor, "nd");
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        expect(para.getTextContent()).toBe("the Lord said");
+        // The three text nodes normalized into one, so assert on the survivor.
+        const mergedTextNode = para.getFirstChild();
+        if (!$isTextNode(mergedTextNode)) throw new Error("merged node is not a TextNode");
+        expect(mergedTextNode.getTextContent()).toBe("the Lord said");
+        // "the " is 4 chars, "Lord" is 4 more.
+        $expectSelectionToBe(mergedTextNode, 4, mergedTextNode, 8);
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) throw new Error("selection is not a range selection");
+        expect(selection.getTextContent()).toBe("Lord");
+      });
+    });
   });
 
   describe("should insert a note", () => {

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -14,8 +14,10 @@ import {
   $createTextNode,
   $getRoot,
   $getSelection,
+  $getState,
   $isRangeSelection,
   $isTextNode,
+  $setState,
   LexicalEditor,
   TextNode,
 } from "lexical";
@@ -34,6 +36,7 @@ import {
   $isImmutableChapterNode,
   $isNoteNode,
   $isParaNode,
+  charIdState,
   EMPTY_CHAR_PLACEHOLDER_TEXT,
 } from "shared";
 
@@ -431,7 +434,9 @@ describe("USJ Marker Action Utils", () => {
     it("splits the CharNode when the selection is strictly inside it", () => {
       const { editor } = createBasicTestEnvironment(nodes, () => {
         charTextNode = $createTextNode("Lorem ipsum");
-        $getRoot().append($createParaNode("p").append($createCharNode("nd").append(charTextNode)));
+        const charNode = $createCharNode("nd", { customAttr: "value" }).append(charTextNode);
+        $setState(charNode, charIdState, "char-id");
+        $getRoot().append($createParaNode("p").append(charNode));
       });
       // "Lo|rem ips|um"
       updateSelection(editor, charTextNode, 2, charTextNode, 9);
@@ -453,6 +458,62 @@ describe("USJ Marker Action Utils", () => {
         expect(leading.getTextContent()).toBe("Lo");
         expect(middle.getTextContent()).toBe("rem ips");
         expect(trailing.getMarker()).toBe("nd");
+        expect(trailing.getTextContent()).toBe("um");
+        // $createCharNodeLike must carry the original's identity onto both clones, not just the
+        // marker: the cid is what lets $charNodeTransform re-merge the halves later.
+        expect($getState(leading, charIdState)).toBe("char-id");
+        expect(leading.getUnknownAttributes()).toEqual({ customAttr: "value" });
+        expect($getState(trailing, charIdState)).toBe("char-id");
+        expect(trailing.getUnknownAttributes()).toEqual({ customAttr: "value" });
+      });
+    });
+
+    it("splits off only a trailing clone when the selection covers the leading text", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        charTextNode = $createTextNode("Lorem ipsum");
+        $getRoot().append($createParaNode("p").append($createCharNode("nd").append(charTextNode)));
+      });
+      // "[Lo]rem ipsum"
+      updateSelection(editor, charTextNode, 0, charTextNode, 2);
+
+      sutRemoveCharMarker(editor, "nd");
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        expect(para.getTextContent()).toBe("Lorem ipsum");
+        const children = para.getChildren();
+        expect(children.length).toBe(2);
+        const [leading, trailing] = children;
+        if (!$isTextNode(leading)) throw new Error("leading is not a TextNode");
+        if (!$isCharNode(trailing)) throw new Error("trailing is not a CharNode");
+        expect(leading.getTextContent()).toBe("Lo");
+        expect(trailing.getMarker()).toBe("nd");
+        expect(trailing.getTextContent()).toBe("rem ipsum");
+      });
+    });
+
+    it("splits off only a leading clone when the selection covers the trailing text", () => {
+      const { editor } = createBasicTestEnvironment(nodes, () => {
+        charTextNode = $createTextNode("Lorem ipsum");
+        $getRoot().append($createParaNode("p").append($createCharNode("nd").append(charTextNode)));
+      });
+      // "Lorem ips[um]"
+      updateSelection(editor, charTextNode, 9, charTextNode, 11);
+
+      sutRemoveCharMarker(editor, "nd");
+
+      editor.getEditorState().read(() => {
+        const para = $getRoot().getFirstChild();
+        if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
+        expect(para.getTextContent()).toBe("Lorem ipsum");
+        const children = para.getChildren();
+        expect(children.length).toBe(2);
+        const [leading, trailing] = children;
+        if (!$isCharNode(leading)) throw new Error("leading is not a CharNode");
+        if (!$isTextNode(trailing)) throw new Error("trailing is not a TextNode");
+        expect(leading.getMarker()).toBe("nd");
+        expect(leading.getTextContent()).toBe("Lorem ips");
         expect(trailing.getTextContent()).toBe("um");
       });
     });
@@ -478,6 +539,8 @@ describe("USJ Marker Action Utils", () => {
         const para = $getRoot().getFirstChild();
         if (!$isParaNode(para)) throw new Error("para is not a ParaNode");
         expect(para.getChildren().some($isCharNode)).toBe(false);
+        // CharNode gone, siblings normalized into a single TextNode.
+        expect(para.getChildrenSize()).toBe(1);
         expect(para.getTextContent()).toBe("the Lord said");
       });
     });

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -645,18 +645,14 @@ describe("USJ Marker Action Utils", () => {
     });
 
     it("does not strip the outer marker from unselected text flanking a nested marker", () => {
-      let leadTextNode: TextNode;
-      let trailTextNode: TextNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
-        leadTextNode = $createTextNode("the ");
         innerTextNode = $createTextNode("Lord");
-        trailTextNode = $createTextNode(" said");
         $getRoot().append(
           $createParaNode("p").append(
             $createCharNode("wj").append(
-              leadTextNode,
+              $createTextNode("the "),
               $createCharNode("nd").append(innerTextNode),
-              trailTextNode,
+              $createTextNode(" said"),
             ),
           ),
         );
@@ -687,13 +683,14 @@ describe("USJ Marker Action Utils", () => {
     });
 
     it("does not strip the outer marker from a leading sibling of a fully covered nested marker", () => {
-      let leadTextNode: TextNode;
       const { editor } = createBasicTestEnvironment(nodes, () => {
-        leadTextNode = $createTextNode("the ");
         innerTextNode = $createTextNode("Lord");
         $getRoot().append(
           $createParaNode("p").append(
-            $createCharNode("wj").append(leadTextNode, $createCharNode("nd").append(innerTextNode)),
+            $createCharNode("wj").append(
+              $createTextNode("the "),
+              $createCharNode("nd").append(innerTextNode),
+            ),
           ),
         );
       });

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -2,29 +2,28 @@ import { MarkerContent } from "@eten-tech-foundation/scripture-utilities";
 import { SerializedVerseRef } from "@sillsdev/scripture";
 import { $unwrapNode } from "@lexical/utils";
 import {
+  $copyNode,
   $createTextNode,
   $getSelection,
-  $getState,
   $isElementNode,
   $isRangeSelection,
   $isTextNode,
-  $setState,
   EditorUpdateOptions,
+  ElementNode,
   LexicalEditor,
   LexicalNode,
   RangeSelection,
   TextNode,
 } from "lexical";
 import {
-  $createCharNode,
   $createNodeFromSerializedNode,
   $isCharNode,
   $isMarkerNode,
   $isNoteNode,
   $isSomeParaNode,
+  $isSynthesizedMarkerNode,
   $isTypedMarkNode,
   $isVisibleMarkerNode,
-  charIdState,
   CharNode,
   createLexicalUsjNode,
   EMPTY_CHAR_PLACEHOLDER_TEXT,
@@ -93,6 +92,27 @@ export function isUsjMarkerSupported(marker: string): boolean {
     ParaNode.isValidMarker(marker) ||
     CharNode.isValidMarker(marker)
   );
+}
+
+/**
+ * Returns whether the given USFM marker is a character marker, and so can be removed by
+ * {@link $removeCharacterMarkerAtSelection}.
+ *
+ * Deliberately stricter than {@link isUsjMarkerSupported}: that one also accepts para, note,
+ * chapter, and verse markers, but removal only ever targets a `CharNode`, so `"p"` must be
+ * rejected. It also honors `extraValidMarkers`, which `isUsjMarkerSupported` does not — a character
+ * marker this project configures as valid, and which the adaptor therefore accepts on load, should
+ * be removable too.
+ *
+ * @param marker - The USFM marker to check.
+ * @param extraValidMarkers - Extra character markers this project treats as valid.
+ * @returns `true` if the marker is a character marker.
+ */
+export function isCharacterMarkerSupported(
+  marker: string,
+  extraValidMarkers?: readonly string[],
+): boolean {
+  return CharNode.isValidMarker(marker, extraValidMarkers);
 }
 
 /** A function that returns a marker action for a given USJ marker */
@@ -275,6 +295,16 @@ function getSelectionOffsets(selection: RangeSelection): [number, number] {
   return selection.isBackward() ? [focusOffset, anchorOffset] : [anchorOffset, focusOffset];
 }
 
+/**
+ * Whether a marker action never acts on `node`: mark nodes and note contents are always skipped.
+ *
+ * @param node - The node to check.
+ * @returns `true` if the node should be skipped.
+ */
+function $isSkippedByMarkerAction(node: LexicalNode): boolean {
+  return $isTypedMarkNode(node) || $isNoteNode(node) || $isNoteNode(node.getParent());
+}
+
 function $getTargetNode(
   node: LexicalNode,
   isFirst: boolean,
@@ -283,7 +313,7 @@ function $getTargetNode(
   endOffset: number,
 ): LexicalNode | undefined {
   // Skip mark nodes and note nodes
-  if ($isTypedMarkNode(node) || $isNoteNode(node) || $isNoteNode(node.getParent())) {
+  if ($isSkippedByMarkerAction(node)) {
     return undefined;
   }
 
@@ -344,21 +374,24 @@ function $moveLeadingSpaceToPreviousNode(node: LexicalNode, wrapper: LexicalNode
   return text;
 }
 
+// #endregion
+
 /**
  * Remove a character marker from the given selection, keeping all of its text content.
  *
  * A collapsed selection removes the marker from the entire enclosing `CharNode`. Selections
  * inside a `NoteNode` are skipped (see `$getCharNodeToRemove`). A range selection that only
  * partially covers a `CharNode` — or spans a `CharNode` and its neighbors — is narrowed first by
- * `$splitCharNodeAroundTargets`, so uncovered text *at that CharNode's own level* keeps its
- * marker. This is not an unconditional guarantee: see `$splitCharNodeAroundTargets`'s docstring
- * for the nested-CharNode case where uncovered text one level deeper still loses the marker.
+ * `$splitCharNodeAroundTargets`, so uncovered text keeps its marker. Where that narrowing is
+ * impossible — a selection covering only part of a *nested* `CharNode`, which cannot be split at
+ * the selection boundary here — the marker is left in place rather than removed from the whole
+ * nested span; see `$splitCharNodeAroundTargets`'s docstring.
  *
  * @param selection - The current range selection.
  * @param marker - The character marker to remove, or `undefined` for the innermost one.
  * @param viewOptions - View options, used to strip synthesized marker content.
  */
-export function $removeCharMarkerAtSelection(
+export function $removeCharacterMarkerAtSelection(
   selection: RangeSelection,
   marker: string | undefined,
   viewOptions: ViewOptions | undefined,
@@ -392,14 +425,13 @@ export function $removeCharMarkerAtSelection(
   }
 
   const nodes = selection.getNodes();
+  // Check there is something to remove before the loop below starts splitting text nodes, so a
+  // no-match request mutates nothing at all. See `$hasCharNodeToRemove`.
+  if (!$hasCharNodeToRemove(nodes, marker)) return;
+
   const isBackward = selection.isBackward();
   const [startOffset, endOffset] = getSelectionOffsets(selection);
   const targetNodes: TextNode[] = [];
-  // Known, harmless: this splits every selected text node via `handleTextNode`'s `splitText`
-  // whether or not any of them turn out to sit inside a matching `CharNode` below. A no-match
-  // request still leaves the document split at the selection boundaries — content-preserving, but
-  // an avoidable no-op mutation (a spurious undo entry, and possibly an empty collab delta).
-  // Resolving the matching `CharNode` set before this loop would avoid it.
   nodes.forEach((node, index) => {
     const targetNode = $getTargetNode(
       node,
@@ -412,50 +444,34 @@ export function $removeCharMarkerAtSelection(
   });
   if (targetNodes.length === 0) return;
 
-  // No reachable path currently resolves two targetNodes to the same CharNode key.
-  // $splitCharNodeAroundTargets consults the full targetNodes array,
-  // so the first targetNode belonging to a given CharNode already causes every other targetNode
-  // sharing it to be carved into (or left in) that same node before this loop reaches them. When
-  // $removeCharNodeKeepingContent unwraps that CharNode, later targetNodes resolve to undefined
-  // (their former parent is gone). When it removes the CharNode outright instead — which only
-  // happens when the CharNode is empty or holds nothing but the single-character
-  // EMPTY_CHAR_PLACEHOLDER_TEXT — a later targetNode walking up from a still-attached child WOULD
-  // resolve to the same key (`.remove()` leaves `__parent` pointers and the node in the nodeMap for
-  // the rest of the update), but that branch can't contain two distinct target text nodes to begin
-  // with, so it never has a "later targetNode" to reach. Kept as a guard in case a future change
-  // reintroduces a path where two targetNodes still resolve to the same charNode.getKey().
+  // Belt-and-braces: no current path resolves two targetNodes to the same CharNode key, since
+  // `$splitCharNodeAroundTargets` reads the whole `targetNodes` array and unwrapping detaches the
+  // rest. Kept in case a future change reintroduces one.
   const handledCharNodeKeys = new Set<string>();
   targetNodes.forEach((targetNode) => {
     const charNode = $getCharNodeToRemove(targetNode, marker);
     if (!charNode || handledCharNodeKeys.has(charNode.getKey())) return;
     handledCharNodeKeys.add(charNode.getKey());
+    // `undefined` means removal would have to affect unselected text — see
+    // `$splitCharNodeAroundTargets`. Leave this CharNode alone rather than over-remove.
     const coveredCharNode = $splitCharNodeAroundTargets(charNode, targetNodes);
-    $removeCharNodeKeepingContent(coveredCharNode, viewOptions);
+    if (coveredCharNode) $removeCharNodeKeepingContent(coveredCharNode, viewOptions);
   });
 
   // Restore the range over the same characters so a toolbar caller can re-toggle without
-  // re-selecting. `handleTextNode` split each target to cover exactly the selected portion, so the
-  // range is the whole of the first target through the whole of the last. This is not always a
-  // no-op: `TextNode.splitText` (used by `handleTextNode` above, via `$getTargetNode`) transfers
-  // anchor/focus onto the right split piece on its own, but `TextNode.setTextContent` — used by
-  // `$removeCharNodeKeepingContent`'s NBSP trim under `markerMode: "editable"` — only mutates
-  // `__text` and does not touch selection points at all. When the trim runs on a node the focus
-  // still points at (e.g. selecting a whole `CharNode`'s content, so no split happens), the
-  // pre-trim offset ends up one character past the new end without this restore. Skipped when a
-  // target node itself didn't survive — this happens when its enclosing CharNode held nothing but
-  // the empty-char placeholder and was removed outright rather than unwrapped (see
-  // $removeCharNodeKeepingContent) — in which case Lexical's own selection repair applies instead.
-  // Preserves the original direction: `isBackward` was captured above, before the removal loop,
-  // since a backward range's anchor is the *last* target and its focus is the *first* — swapping
-  // which end gets which role keeps a backward selection backward instead of always normalizing
-  // to forward.
+  // re-selecting: each target covers exactly the selected portion, so the range runs from the
+  // whole first target to the whole last. Three traps make this more than a no-op:
   //
-  // Re-fetch the selection instead of reusing the `selection` parameter: `$unwrapNode` (used by
-  // `$removeCharNodeKeepingContent`) unwraps via `CharNode.replace()`, and `TextNode.replace()`
-  // unconditionally clones the active selection and calls `$setSelection` on the clone partway
-  // through — even when neither point needs adjusting. That silently swaps the *active* selection
-  // for a new object, leaving the `selection` parameter pointing at a now-stale, detached one.
-  // Mutating the stale object here would have no effect on what the later merge actually reads.
+  // - `TextNode.setTextContent` (the NBSP trim under `markerMode: "editable"`) mutates `__text`
+  //   without touching selection points, so a focus on a trimmed node ends up one past the new end.
+  // - `isBackward` is captured before the loop: a backward range's anchor is the *last* target, so
+  //   swapping the roles keeps it backward instead of normalizing to forward.
+  // - `$getSelection()` is re-fetched rather than reusing `selection`: `TextNode.replace()` (via
+  //   `$unwrapNode`) clones the active selection and `$setSelection`s the clone, so the parameter
+  //   is left pointing at a detached object and mutating it would have no effect.
+  //
+  // Skipped when a target didn't survive — its CharNode held only the empty-char placeholder and
+  // was removed outright — in which case Lexical's own selection repair applies instead.
   const currentSelection = $getSelection();
   const firstTargetNode = targetNodes[0];
   const lastTargetNode = targetNodes[targetNodes.length - 1];
@@ -470,6 +486,8 @@ export function $removeCharMarkerAtSelection(
     else currentSelection.setTextNodeRange(firstTargetNode, 0, lastTargetNode, lastOffset);
   }
 }
+
+// #region Helper functions for $removeCharacterMarkerAtSelection
 
 /**
  * Find the `CharNode` a removal should act on, walking up from a target node.
@@ -504,16 +522,45 @@ function $getCharNodeToRemove(node: LexicalNode, marker: string | undefined): Ch
 }
 
 /**
- * True for either flavor of synthesized marker child a `CharNode` can hold under
- * `markerMode: "editable"` (`MarkerNode`) or `"visible"` (an `ImmutableTypedTextNode` with
- * `textType: "marker"`). Not `$isParaMarkerPrefix` from `shared` — same predicate, but that name
- * describes a paragraph's leading marker, which would mislead here.
+ * Whether any of the selection's nodes sits inside a `CharNode` matching `marker`.
  *
- * @param node - The node to check.
- * @returns `true` if the node is a synthesized marker child.
+ * Read-only, and answered *before* the splitting pass, so that a request with nothing to remove
+ * leaves the document completely untouched: `handleTextNode`'s `splitText` mutates the tree, and
+ * running it first would give a documented no-op a spurious undo entry (and possibly an empty
+ * collab delta). Splitting never changes a node's ancestry — the pieces keep the same parent — so
+ * this answers the same question the post-split loop would.
+ *
+ * Deliberately no narrower than `$getTargetNode`: it shares the skip rule via
+ * `$isSkippedByMarkerAction` and does not replicate `handleTextNode`'s zero-width filter. So it can
+ * only ever be more permissive, never wrongly refuse a removal that would have happened.
+ *
+ * @param nodes - The nodes in the selection.
+ * @param marker - The character marker to remove, or `undefined` for the innermost one.
+ * @returns `true` if there is a matching `CharNode` to remove.
  */
-function $isSynthesizedMarkerNode(node: LexicalNode | null | undefined): boolean {
-  return $isMarkerNode(node) || $isVisibleMarkerNode(node);
+function $hasCharNodeToRemove(nodes: LexicalNode[], marker: string | undefined): boolean {
+  return nodes.some(
+    (node) =>
+      !$isSkippedByMarkerAction(node) &&
+      ($isTextNode(node) || ($isElementNode(node) && node.isInline())) &&
+      $getCharNodeToRemove(node, marker) !== undefined,
+  );
+}
+
+/**
+ * Whether every character inside `element` is covered by the selection.
+ *
+ * Synthesized marker children don't count against coverage: they carry no user content and
+ * `$removeCharNodeKeepingContent` strips them unconditionally.
+ *
+ * @param element - The element to check, typically a nested `CharNode`.
+ * @param targetKeys - Keys of the text nodes the selection covers.
+ * @returns `true` if the selection covers all of the element's content.
+ */
+function $isFullyCoveredByTargets(element: ElementNode, targetKeys: Set<string>): boolean {
+  return element
+    .getAllTextNodes()
+    .every((textNode) => targetKeys.has(textNode.getKey()) || $isSynthesizedMarkerNode(textNode));
 }
 
 /**
@@ -550,31 +597,42 @@ function $isSynthesizedMarkerNode(node: LexicalNode | null | undefined): boolean
  * opening *and* closing marker children — adaptor-level work beyond this function's scope — so it
  * is left as a documented limitation rather than attempted here.
  *
- * Known limitation — partial coverage of a nested CharNode: transitive coverage (above) only
- * decides whether a nested element child counts as covered at *this* level; it cannot split that
- * child at the selection boundary. So when the selection covers only part of a nested CharNode's
- * text, the whole nested child is treated as covered and left untouched, and the outer marker is
- * still removed from all of it — including the unselected remainder inside it. For example,
+ * Refuses — partial coverage of a nested CharNode: transitive coverage (above) only decides whether
+ * a nested element child counts as covered at *this* level; it cannot split that child at the
+ * selection boundary. So when the selection covers only part of a nested `CharNode`'s text, there
+ * is no shape this function can produce that removes the marker from the selection alone. Rather
+ * than remove it from the whole nested span — silently changing the USJ of text the user never
+ * selected — this returns `undefined` so the caller leaves the document untouched. For example,
  * selecting only part of a divine-name word (`\nd`) inside red-letter text (`\wj`) and removing
- * `\wj` will correctly preserve `\wj` on any plain-text siblings of the `\nd` span, but will still
- * silently drop `\wj` from the rest of that divine-name word, not just the selected part. Fixing
- * this needs recursive splitting of the nested CharNode itself, which this function does not do.
+ * `\wj` does nothing, rather than dropping `\wj` from the rest of that divine-name word too.
+ *
+ * This is deliberately narrow: it is the *partially* covered nested case only. Removing either the
+ * inner or the outer marker of a fully covered nested pair works, and is the case the feature's UI
+ * actually reaches. Doing it properly needs recursive splitting of the nested `CharNode` itself,
+ * which is out of scope here — refusing keeps that a strictly additive change later, whereas
+ * shipping the whole-span removal would make the eventual fix a behavior change.
  *
  * @param charNode - The `CharNode` the selection touches.
  * @param targetNodes - The text nodes the selection covers.
- * @returns the `CharNode` that now covers only the selection. Unchanged when coverage is total.
+ * @returns the `CharNode` that now covers only the selection — unchanged when coverage is total —
+ *   or `undefined` when the marker cannot be removed without also affecting unselected text.
  */
-function $splitCharNodeAroundTargets(charNode: CharNode, targetNodes: TextNode[]): CharNode {
+function $splitCharNodeAroundTargets(
+  charNode: CharNode,
+  targetNodes: TextNode[],
+): CharNode | undefined {
   const targetKeys = new Set(targetNodes.map((targetNode) => targetNode.getKey()));
   const children = charNode.getChildren();
-  const coveredIndexes = children
-    .map((child, index) =>
-      targetKeys.has(child.getKey()) ||
-      ($isElementNode(child) && targetNodes.some((targetNode) => child.isParentOf(targetNode)))
-        ? index
-        : -1,
-    )
-    .filter((index) => index >= 0);
+  const coveredIndexes: number[] = [];
+  for (const [index, child] of children.entries()) {
+    if (targetKeys.has(child.getKey())) {
+      coveredIndexes.push(index);
+    } else if ($isElementNode(child) && targetNodes.some((target) => child.isParentOf(target))) {
+      // Nothing has been mutated yet, so refusing here leaves the document exactly as it was.
+      if (!$isFullyCoveredByTargets(child, targetKeys)) return undefined;
+      coveredIndexes.push(index);
+    }
+  }
   if (coveredIndexes.length === 0) return charNode;
 
   let firstCoveredIndex = coveredIndexes[0];
@@ -604,27 +662,27 @@ function $splitCharNodeAroundTargets(charNode: CharNode, targetNodes: TextNode[]
 /**
  * Create an empty `CharNode` carrying the same identity as `charNode`.
  *
- * Copies marker, unknown attributes, direction, format, and style — modeled on
- * `CharNode.insertNewAfter`'s copy, but pairing `setStyle` with `getStyle` rather than
- * `getTextStyle` (see the note below) so the style copy actually takes effect. Additionally
- * copies `charIdState` — without the cid, `$charNodeTransform`'s `$hasSameCharAttributes` check
- * would refuse to re-merge the halves later.
+ * `$copyNode` gives a childless copy with a fresh key: `CharNode.clone` carries the marker and
+ * unknown attributes, `ElementNode.afterCloneFrom` carries indent, format, style, direction and
+ * both text-style members, and `LexicalNode.afterCloneFrom` carries node state — including
+ * `charIdState`, which `resetOnCopyNode` leaves alone because that config doesn't opt into being
+ * reset. The cid matters: without it `$charNodeTransform`'s `$hasSameCharAttributes` check would
+ * refuse to re-merge the halves later.
+ *
+ * The children copy in `afterCloneFrom` is gated on the keys matching, and `$copyNode` assigns a
+ * fresh key before calling it, so the copy is genuinely empty. `$copyNode` also skips
+ * `$applyNodeReplacement`, which is irrelevant here — no `CharNode` replacement is registered.
+ *
+ * Don't hand-roll this: `CharNode.insertNewAfter` (CharNode.ts:254) and `ParaNode.insertNewAfter`
+ * (ParaNode.ts:286) model a manual copy, but both pair `setStyle` with `getTextStyle()` — a
+ * different member (`__textStyle`, the default inline style for children) than `setStyle` writes
+ * (`__style`) — so their style copies are silently inert.
  *
  * @param charNode - The `CharNode` to copy identity from.
  * @returns a new empty `CharNode` with the same identity.
  */
 function $createCharNodeLike(charNode: CharNode): CharNode {
-  const newCharNode = $createCharNode(charNode.getMarker(), charNode.getUnknownAttributes());
-  newCharNode.setDirection(charNode.getDirection());
-  newCharNode.setFormat(charNode.getFormatType());
-  // Note: `getStyle()`/`setStyle()` are the matching pair for an ElementNode's own CSS style
-  // string (`__style`); `getTextStyle()` reads a different member (`__textStyle`, the default
-  // inline style for children) entirely. Note `CharNode.insertNewAfter` (CharNode.ts:254) and
-  // `ParaNode.insertNewAfter` (ParaNode.ts:286) both pair `setStyle` with `getTextStyle`, so their
-  // style copies are inert; don't copy that pairing from them.
-  newCharNode.setStyle(charNode.getStyle());
-  $setState(newCharNode, charIdState, () => $getState(charNode, charIdState));
-  return newCharNode;
+  return $copyNode(charNode);
 }
 
 /**

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -4,9 +4,11 @@ import { $unwrapNode } from "@lexical/utils";
 import {
   $createTextNode,
   $getSelection,
+  $getState,
   $isElementNode,
   $isRangeSelection,
   $isTextNode,
+  $setState,
   EditorUpdateOptions,
   LexicalEditor,
   LexicalNode,
@@ -14,6 +16,7 @@ import {
   TextNode,
 } from "lexical";
 import {
+  $createCharNode,
   $createNodeFromSerializedNode,
   $isCharNode,
   $isMarkerNode,
@@ -21,6 +24,7 @@ import {
   $isSomeParaNode,
   $isTypedMarkNode,
   $isVisibleMarkerNode,
+  charIdState,
   CharNode,
   createLexicalUsjNode,
   EMPTY_CHAR_PLACEHOLDER_TEXT,
@@ -344,14 +348,9 @@ function $moveLeadingSpaceToPreviousNode(node: LexicalNode, wrapper: LexicalNode
  * Remove a character marker from the given selection, keeping all of its text content.
  *
  * A collapsed selection removes the marker from the entire enclosing `CharNode`. Selections
- * inside a `NoteNode` are skipped (see `$getCharNodeToRemove`).
- *
- * Known limitation: a range selection that only partially covers a `CharNode` is not split here.
- * `handleTextNode` does split the underlying `TextNode`, but all of the resulting pieces stay
- * children of the same `CharNode`, and `$removeCharNodeKeepingContent`'s `$unwrapNode` call lifts
- * all of them out together — so a partial-coverage removal currently strips the marker from the
- * whole run, not just the selected part. Splitting the `CharNode` so the uncovered text keeps its
- * marker is Task 3's job.
+ * inside a `NoteNode` are skipped (see `$getCharNodeToRemove`). A range selection that only
+ * partially covers a `CharNode` — or spans a `CharNode` and its neighbors — is narrowed first by
+ * `$splitCharNodeAroundTargets`, so uncovered text keeps its marker.
  *
  * @param selection - The current range selection.
  * @param marker - The character marker to remove, or `undefined` for the innermost one.
@@ -383,17 +382,21 @@ export function $removeCharMarkerAtSelection(
   });
   if (targetNodes.length === 0) return;
 
-  // Not currently reachable: once a CharNode is unwrapped its former children are reparented onto
-  // the para, so a later targetNode that shared it would resolve to undefined; an outright
-  // removal likewise detaches the node from any node a later targetNode could still reach. Kept
-  // as a guard for Task 3, where splitting a CharNode across multiple targetNodes may reintroduce
-  // a case where two targetNodes still resolve to the same charNode.getKey().
+  // Still not reachable after $splitCharNodeAroundTargets: it consults the full targetNodes array,
+  // so the first targetNode belonging to a given CharNode already causes every other targetNode
+  // sharing it to be carved into (or left in) that same node before this loop reaches them. By the
+  // time a later targetNode is processed, $removeCharNodeKeepingContent has already detached that
+  // CharNode (unwrapped or removed outright), so its former children are reparented onto — or
+  // orphaned from — the para, and $getCharNodeToRemove resolves to undefined rather than the same
+  // key. Kept as a guard in case a future change reintroduces a path where two targetNodes still
+  // resolve to the same charNode.getKey().
   const handledCharNodeKeys = new Set<string>();
   targetNodes.forEach((targetNode) => {
     const charNode = $getCharNodeToRemove(targetNode, marker);
     if (!charNode || handledCharNodeKeys.has(charNode.getKey())) return;
     handledCharNodeKeys.add(charNode.getKey());
-    $removeCharNodeKeepingContent(charNode, viewOptions);
+    const coveredCharNode = $splitCharNodeAroundTargets(charNode, targetNodes);
+    $removeCharNodeKeepingContent(coveredCharNode, viewOptions);
   });
 }
 
@@ -427,6 +430,58 @@ function $getCharNodeToRemove(node: LexicalNode, marker: string | undefined): Ch
     currentNode = currentNode.getParent();
   }
   return matchedCharNode;
+}
+
+/**
+ * Narrow a `CharNode` to just the children the selection covers, moving the uncovered leading and
+ * trailing children into sibling `CharNode`s that keep the marker.
+ *
+ * Needed because `handleTextNode` splits the *text* node, leaving all the pieces inside the same
+ * `CharNode` — so unwrapping it would strip the marker from the uncovered text too.
+ *
+ * @param charNode - The `CharNode` the selection touches.
+ * @param targetNodes - The text nodes the selection covers.
+ * @returns the `CharNode` that now covers only the selection. Unchanged when coverage is total.
+ */
+function $splitCharNodeAroundTargets(charNode: CharNode, targetNodes: TextNode[]): CharNode {
+  const children = charNode.getChildren();
+  const coveredIndexes = children
+    .map((child, index) => ($isTextNode(child) && targetNodes.includes(child) ? index : -1))
+    .filter((index) => index >= 0);
+  if (coveredIndexes.length === 0) return charNode;
+
+  const firstCoveredIndex = coveredIndexes[0];
+  const lastCoveredIndex = coveredIndexes[coveredIndexes.length - 1];
+  if (firstCoveredIndex === 0 && lastCoveredIndex === children.length - 1) return charNode;
+
+  // Append moves the children out of `charNode`, so it is left holding only the covered ones.
+  const trailingChildren = children.slice(lastCoveredIndex + 1);
+  if (trailingChildren.length > 0)
+    charNode.insertAfter($createCharNodeLike(charNode).append(...trailingChildren));
+  const leadingChildren = children.slice(0, firstCoveredIndex);
+  if (leadingChildren.length > 0)
+    charNode.insertBefore($createCharNodeLike(charNode).append(...leadingChildren));
+
+  return charNode;
+}
+
+/**
+ * Create an empty `CharNode` carrying the same identity as `charNode`.
+ *
+ * Copies marker, unknown attributes, direction, format, and style like `CharNode.insertNewAfter`
+ * does, and additionally copies `charIdState` — without the cid, `$charNodeTransform`'s
+ * `$hasSameCharAttributes` check would refuse to re-merge the halves later.
+ *
+ * @param charNode - The `CharNode` to copy identity from.
+ * @returns a new empty `CharNode` with the same identity.
+ */
+function $createCharNodeLike(charNode: CharNode): CharNode {
+  const newCharNode = $createCharNode(charNode.getMarker(), charNode.getUnknownAttributes());
+  newCharNode.setDirection(charNode.getDirection());
+  newCharNode.setFormat(charNode.getFormatType());
+  newCharNode.setStyle(charNode.getTextStyle());
+  $setState(newCharNode, charIdState, () => $getState(charNode, charIdState));
+  return newCharNode;
 }
 
 /**

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -350,7 +350,9 @@ function $moveLeadingSpaceToPreviousNode(node: LexicalNode, wrapper: LexicalNode
  * A collapsed selection removes the marker from the entire enclosing `CharNode`. Selections
  * inside a `NoteNode` are skipped (see `$getCharNodeToRemove`). A range selection that only
  * partially covers a `CharNode` — or spans a `CharNode` and its neighbors — is narrowed first by
- * `$splitCharNodeAroundTargets`, so uncovered text keeps its marker.
+ * `$splitCharNodeAroundTargets`, so uncovered text *at that CharNode's own level* keeps its
+ * marker. This is not an unconditional guarantee: see `$splitCharNodeAroundTargets`'s docstring
+ * for the nested-CharNode case where uncovered text one level deeper still loses the marker.
  *
  * @param selection - The current range selection.
  * @param marker - The character marker to remove, or `undefined` for the innermost one.
@@ -452,6 +454,17 @@ function $getCharNodeToRemove(node: LexicalNode, marker: string | undefined): Ch
  * side of a split, it lands in the leading or trailing clone without its counterpart, leaving that
  * clone with half a marker pair. Handling that is Task 5's job, not this function's.
  *
+ * Known limitation — partial coverage of a nested CharNode: transitive coverage (above) only
+ * decides whether a nested element child counts as covered at *this* level; it cannot split that
+ * child at the selection boundary. So when the selection covers only part of a nested CharNode's
+ * text, the whole nested child is treated as covered and left untouched, and the outer marker is
+ * still removed from all of it — including the unselected remainder inside it. For example,
+ * selecting only part of a divine-name word (`\nd`) inside red-letter text (`\wj`) and removing
+ * `\wj` will correctly preserve `\wj` on any plain-text siblings of the `\nd` span, but will still
+ * silently drop `\wj` from the rest of that divine-name word, not just the selected part. Fixing
+ * this needs recursive splitting of the nested CharNode itself, which this function does not do.
+ *
+
  * @param charNode - The `CharNode` the selection touches.
  * @param targetNodes - The text nodes the selection covers.
  * @returns the `CharNode` that now covers only the selection. Unchanged when coverage is total.

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -343,9 +343,15 @@ function $moveLeadingSpaceToPreviousNode(node: LexicalNode, wrapper: LexicalNode
 /**
  * Remove a character marker from the given selection, keeping all of its text content.
  *
- * A collapsed selection removes the marker from the entire enclosing `CharNode`. A range
- * selection that only partially covers a `CharNode` splits it first, so the uncovered text keeps
- * its marker. Selections inside a `NoteNode` are skipped (see `$getCharNodeToRemove`).
+ * A collapsed selection removes the marker from the entire enclosing `CharNode`. Selections
+ * inside a `NoteNode` are skipped (see `$getCharNodeToRemove`).
+ *
+ * Known limitation: a range selection that only partially covers a `CharNode` is not split here.
+ * `handleTextNode` does split the underlying `TextNode`, but all of the resulting pieces stay
+ * children of the same `CharNode`, and `$removeCharNodeKeepingContent`'s `$unwrapNode` call lifts
+ * all of them out together — so a partial-coverage removal currently strips the marker from the
+ * whole run, not just the selected part. Splitting the `CharNode` so the uncovered text keeps its
+ * marker is Task 3's job.
  *
  * @param selection - The current range selection.
  * @param marker - The character marker to remove, or `undefined` for the innermost one.
@@ -377,6 +383,11 @@ export function $removeCharMarkerAtSelection(
   });
   if (targetNodes.length === 0) return;
 
+  // Not currently reachable: once a CharNode is unwrapped its former children are reparented onto
+  // the para, so a later targetNode that shared it would resolve to undefined; an outright
+  // removal likewise detaches the node from any node a later targetNode could still reach. Kept
+  // as a guard for Task 3, where splitting a CharNode across multiple targetNodes may reintroduce
+  // a case where two targetNodes still resolve to the same charNode.getKey().
   const handledCharNodeKeys = new Set<string>();
   targetNodes.forEach((targetNode) => {
     const charNode = $getCharNodeToRemove(targetNode, marker);

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -104,6 +104,11 @@ export function isUsjMarkerSupported(marker: string): boolean {
  * marker this project configures as valid, and which the adaptor therefore accepts on load, should
  * be removable too.
  *
+ * Stricter than `CharNode.isValidMarker` too: that list spreads in the footnote and
+ * cross-reference character markers (`"ft"`, `"xt"`, …), but those only ever occur inside a
+ * `NoteNode`, which `$getCharNodeToRemove` skips. Accepting them here would promise a removal that
+ * can never happen and then silently no-op, so they are rejected up front instead.
+ *
  * @param marker - The USFM marker to check.
  * @param extraValidMarkers - Extra character markers this project treats as valid.
  * @returns `true` if the marker is a character marker.
@@ -112,6 +117,8 @@ export function isCharacterMarkerSupported(
   marker: string,
   extraValidMarkers?: readonly string[],
 ): boolean {
+  if (CharNode.isValidFootnoteMarker(marker) || CharNode.isValidCrossReferenceMarker(marker))
+    return false;
   return CharNode.isValidMarker(marker, extraValidMarkers);
 }
 
@@ -390,17 +397,18 @@ function $moveLeadingSpaceToPreviousNode(node: LexicalNode, wrapper: LexicalNode
  * @param selection - The current range selection.
  * @param marker - The character marker to remove, or `undefined` for the innermost one.
  * @param viewOptions - View options, used to strip synthesized marker content.
+ * @returns `true` if a marker was removed, `false` if the request was a no-op.
  */
 export function $removeCharacterMarkerAtSelection(
   selection: RangeSelection,
   marker: string | undefined,
   viewOptions: ViewOptions | undefined,
-): void {
+): boolean {
   if (selection.isCollapsed()) {
     const anchorNode = selection.anchor.getNode();
     const anchorOffset = selection.anchor.offset;
     const charNode = $getCharNodeToRemove(anchorNode, marker);
-    if (!charNode) return;
+    if (!charNode) return false;
     const originalSize = $isTextNode(anchorNode) ? anchorNode.getTextContentSize() : 0;
     $removeCharNodeKeepingContent(charNode, viewOptions);
 
@@ -421,16 +429,16 @@ export function $removeCharacterMarkerAtSelection(
       if ($isRangeSelection(currentSelection))
         currentSelection.setTextNodeRange(anchorNode, newOffset, anchorNode, newOffset);
     }
-    return;
+    return true;
   }
 
   const nodes = selection.getNodes();
-  // Check there is something to remove before the loop below starts splitting text nodes, so a
-  // no-match request mutates nothing at all. See `$hasCharNodeToRemove`.
-  if (!$hasCharNodeToRemove(nodes, marker)) return;
-
   const isBackward = selection.isBackward();
   const [startOffset, endOffset] = getSelectionOffsets(selection);
+  // Check there is something removable before the loop below starts splitting text nodes, so a
+  // request that ends up a no-op mutates nothing at all. See `$hasRemovableCharNode`.
+  if (!$hasRemovableCharNode(nodes, marker, startOffset, endOffset)) return false;
+
   const targetNodes: TextNode[] = [];
   nodes.forEach((node, index) => {
     const targetNode = $getTargetNode(
@@ -442,20 +450,26 @@ export function $removeCharacterMarkerAtSelection(
     );
     if ($isTextNode(targetNode)) targetNodes.push(targetNode);
   });
-  if (targetNodes.length === 0) return;
+  if (targetNodes.length === 0) return false;
 
   // Belt-and-braces: no current path resolves two targetNodes to the same CharNode key, since
   // `$splitCharNodeAroundTargets` reads the whole `targetNodes` array and unwrapping detaches the
   // rest. Kept in case a future change reintroduces one.
   const handledCharNodeKeys = new Set<string>();
+  let didRemove = false;
   targetNodes.forEach((targetNode) => {
     const charNode = $getCharNodeToRemove(targetNode, marker);
     if (!charNode || handledCharNodeKeys.has(charNode.getKey())) return;
     handledCharNodeKeys.add(charNode.getKey());
     // `undefined` means removal would have to affect unselected text — see
     // `$splitCharNodeAroundTargets`. Leave this CharNode alone rather than over-remove.
+    // `$hasRemovableCharNode` above has already established that at least one CharNode in the
+    // selection is *not* refused, so this cannot be the only outcome for the whole call.
     const coveredCharNode = $splitCharNodeAroundTargets(charNode, targetNodes);
-    if (coveredCharNode) $removeCharNodeKeepingContent(coveredCharNode, viewOptions);
+    if (coveredCharNode) {
+      $removeCharNodeKeepingContent(coveredCharNode, viewOptions);
+      didRemove = true;
+    }
   });
 
   // Restore the range over the same characters so a toolbar caller can re-toggle without
@@ -466,9 +480,12 @@ export function $removeCharacterMarkerAtSelection(
   //   without touching selection points, so a focus on a trimmed node ends up one past the new end.
   // - `isBackward` is captured before the loop: a backward range's anchor is the *last* target, so
   //   swapping the roles keeps it backward instead of normalizing to forward.
-  // - `$getSelection()` is re-fetched rather than reusing `selection`: `TextNode.replace()` (via
-  //   `$unwrapNode`) clones the active selection and `$setSelection`s the clone, so the parameter
-  //   is left pointing at a detached object and mutating it would have no effect.
+  // - `$getSelection()` is re-fetched rather than reusing `selection`: `$unwrapNode` splices the
+  //   CharNode out with `NodeCaret.splice`, which calls `replace()` on it (Lexical 0.43.0,
+  //   `NodeCaret.splice` → `target.replace(node)`), and `LexicalNode.replace` clones the active
+  //   selection and `$setSelection`s the clone. So the parameter is left pointing at a detached
+  //   object and mutating it would have no effect. Note this is the CharNode's own
+  //   `ElementNode.replace()`, not `TextNode.replace()`.
   //
   // Skipped when a target didn't survive — its CharNode held only the empty-char placeholder and
   // was removed outright — in which case Lexical's own selection repair applies instead.
@@ -485,6 +502,8 @@ export function $removeCharacterMarkerAtSelection(
       currentSelection.setTextNodeRange(lastTargetNode, lastOffset, firstTargetNode, 0);
     else currentSelection.setTextNodeRange(firstTargetNode, 0, lastTargetNode, lastOffset);
   }
+
+  return didRemove;
 }
 
 // #region Helper functions for $removeCharacterMarkerAtSelection
@@ -522,29 +541,124 @@ function $getCharNodeToRemove(node: LexicalNode, marker: string | undefined): Ch
 }
 
 /**
- * Whether any of the selection's nodes sits inside a `CharNode` matching `marker`.
- *
- * Read-only, and answered *before* the splitting pass, so that a request with nothing to remove
- * leaves the document completely untouched: `handleTextNode`'s `splitText` mutates the tree, and
- * running it first would give a documented no-op a spurious undo entry (and possibly an empty
- * collab delta). Splitting never changes a node's ancestry — the pieces keep the same parent — so
- * this answers the same question the post-split loop would.
+ * The selection's nodes that a marker action can actually act on.
  *
  * Deliberately no narrower than `$getTargetNode`: it shares the skip rule via
- * `$isSkippedByMarkerAction` and does not replicate `handleTextNode`'s zero-width filter. So it can
- * only ever be more permissive, never wrongly refuse a removal that would have happened.
+ * `$isSkippedByMarkerAction` and does not replicate `handleTextNode`'s zero-width filter. So the
+ * read-only pre-pass built on it can only ever be more permissive, never wrongly refuse a removal
+ * that would have happened.
+ *
+ * @param nodes - The nodes in the selection.
+ * @returns the subset of `nodes` a marker action can act on.
+ */
+function $getActionableNodes(nodes: LexicalNode[]): LexicalNode[] {
+  return nodes.filter(
+    (node) =>
+      !$isSkippedByMarkerAction(node) &&
+      ($isTextNode(node) || ($isElementNode(node) && node.isInline())),
+  );
+}
+
+/**
+ * Keys of the selection's text nodes that the selection covers *in full*, computed before the
+ * splitting pass.
+ *
+ * A boundary node the selection covers only partially is deliberately excluded. `handleTextNode`
+ * would split such a node, and only the covered piece becomes a target — so the uncovered piece
+ * remains inside whatever element held it, and any nested-coverage question about that element must
+ * answer "not fully covered". Treating the whole pre-split node as uncovered here makes this set
+ * agree with the post-split `targetNodes` set that `$splitCharNodeAroundTargets` sees.
+ *
+ * @param nodes - The nodes in the selection.
+ * @param startOffset - The selection's start offset within the first node.
+ * @param endOffset - The selection's end offset within the last node.
+ * @returns keys of the fully covered text nodes.
+ */
+function $getFullyCoveredTextKeys(
+  nodes: LexicalNode[],
+  startOffset: number,
+  endOffset: number,
+): Set<string> {
+  const keys = new Set<string>();
+  nodes.forEach((node, index) => {
+    if (!$isTextNode(node) || $isSkippedByMarkerAction(node)) return;
+    const size = node.getTextContentSize();
+    const start = index === 0 ? startOffset : 0;
+    const end = index === nodes.length - 1 ? endOffset : size;
+    if (start === 0 && end === size) keys.add(node.getKey());
+  });
+  return keys;
+}
+
+/**
+ * Whether `$splitCharNodeAroundTargets` would refuse this `CharNode`, decided read-only.
+ *
+ * Mirrors that function's nested-partial-coverage refusal (see its docstring) without mutating
+ * anything: a nested element child that holds part of the selection but is not covered in full
+ * cannot be split at the selection boundary, so the marker must be left in place.
+ *
+ * Answerable before the split because splitting never changes a node's ancestry — the pieces keep
+ * the same parent — and `$getFullyCoveredTextKeys` already accounts for the uncovered pieces the
+ * split will create.
+ *
+ * @param charNode - The `CharNode` a removal would act on.
+ * @param actionableNodes - The selection's actionable nodes.
+ * @param fullyCoveredKeys - Keys of the text nodes the selection covers in full.
+ * @returns `true` if this `CharNode` would be refused.
+ */
+function $isRefusedForNestedCoverage(
+  charNode: CharNode,
+  actionableNodes: LexicalNode[],
+  fullyCoveredKeys: Set<string>,
+): boolean {
+  return charNode
+    .getChildren()
+    .some(
+      (child) =>
+        $isElementNode(child) &&
+        actionableNodes.some((node) => child.isParentOf(node)) &&
+        !$isFullyCoveredByTargets(child, fullyCoveredKeys),
+    );
+}
+
+/**
+ * Whether the selection contains a `CharNode` matching `marker` that removal would actually strip.
+ *
+ * Read-only, and answered *before* the splitting pass, so that a request which ends up a no-op
+ * leaves the document completely untouched: `handleTextNode`'s `splitText` mutates the tree, and
+ * running it first would give a documented no-op a spurious undo entry (and possibly an empty
+ * collab delta), and would then let the restore block overwrite the caller's selection.
+ *
+ * Both no-op paths are screened here — no matching `CharNode` at all, and a matching one that
+ * `$splitCharNodeAroundTargets` would refuse for nested partial coverage.
+ *
+ * Residual, deliberately not fixed here: when a selection spans two matching `CharNode`s and only
+ * one of them is refused, this returns `true` (correctly — a removal does happen), so the split
+ * pass still runs and briefly dirties the refused node's text too. Lexical re-merges it, so the
+ * tree is unchanged, but the undo entry covers both. Avoiding that needs the split loop to skip
+ * refused nodes, which its index-based offset math can't express without a wider rework.
  *
  * @param nodes - The nodes in the selection.
  * @param marker - The character marker to remove, or `undefined` for the innermost one.
- * @returns `true` if there is a matching `CharNode` to remove.
+ * @param startOffset - The selection's start offset within the first node.
+ * @param endOffset - The selection's end offset within the last node.
+ * @returns `true` if there is a matching `CharNode` that would be removed.
  */
-function $hasCharNodeToRemove(nodes: LexicalNode[], marker: string | undefined): boolean {
-  return nodes.some(
-    (node) =>
-      !$isSkippedByMarkerAction(node) &&
-      ($isTextNode(node) || ($isElementNode(node) && node.isInline())) &&
-      $getCharNodeToRemove(node, marker) !== undefined,
-  );
+function $hasRemovableCharNode(
+  nodes: LexicalNode[],
+  marker: string | undefined,
+  startOffset: number,
+  endOffset: number,
+): boolean {
+  const actionableNodes = $getActionableNodes(nodes);
+  const fullyCoveredKeys = $getFullyCoveredTextKeys(nodes, startOffset, endOffset);
+  const seenCharNodeKeys = new Set<string>();
+  return actionableNodes.some((node) => {
+    const charNode = $getCharNodeToRemove(node, marker);
+    if (!charNode || seenCharNodeKeys.has(charNode.getKey())) return false;
+    seenCharNodeKeys.add(charNode.getKey());
+    return !$isRefusedForNestedCoverage(charNode, actionableNodes, fullyCoveredKeys);
+  });
 }
 
 /**
@@ -552,6 +666,13 @@ function $hasCharNodeToRemove(nodes: LexicalNode[], marker: string | undefined):
  *
  * Synthesized marker children don't count against coverage: they carry no user content and
  * `$removeCharNodeKeepingContent` strips them unconditionally.
+ *
+ * That exemption is only reached under `markerMode: "editable"`, where markers are `MarkerNode`s —
+ * real `TextNode`s, so `getAllTextNodes()` returns them and they would otherwise fail the coverage
+ * check. Under `markerMode: "visible"` markers are `ImmutableTypedTextNode`s, which extend
+ * `DecoratorNode` rather than `TextNode`, so `getAllTextNodes()` never returns them and they cannot
+ * count against coverage in the first place. Both modes end up with the same answer by different
+ * routes; the `$isSynthesizedMarkerNode` clause is what makes the editable one agree.
  *
  * @param element - The element to check, typically a nested `CharNode`.
  * @param targetKeys - Keys of the text nodes the selection covers.
@@ -602,9 +723,13 @@ function $isFullyCoveredByTargets(element: ElementNode, targetKeys: Set<string>)
  * selection boundary. So when the selection covers only part of a nested `CharNode`'s text, there
  * is no shape this function can produce that removes the marker from the selection alone. Rather
  * than remove it from the whole nested span — silently changing the USJ of text the user never
- * selected — this returns `undefined` so the caller leaves the document untouched. For example,
+ * selected — this returns `undefined` so the caller leaves this `CharNode` alone. For example,
  * selecting only part of a divine-name word (`\nd`) inside red-letter text (`\wj`) and removing
  * `\wj` does nothing, rather than dropping `\wj` from the rest of that divine-name word too.
+ *
+ * `$hasRemovableCharNode` predicts this same refusal read-only, so a request that would be refused
+ * outright never reaches the splitting pass and leaves the document — and the caller's selection —
+ * completely untouched.
  *
  * This is deliberately narrow: it is the *partially* covered nested case only. Removing either the
  * inner or the outer marker of a fully covered nested pair works, and is the case the feature's UI
@@ -628,12 +753,19 @@ function $splitCharNodeAroundTargets(
     if (targetKeys.has(child.getKey())) {
       coveredIndexes.push(index);
     } else if ($isElementNode(child) && targetNodes.some((target) => child.isParentOf(target))) {
-      // Nothing has been mutated yet, so refusing here leaves the document exactly as it was.
+      // Refusing here mutates nothing *in this function*, but the caller has already run
+      // `handleTextNode`'s `splitText` to build `targetNodes`. So this alone is not enough to keep
+      // a refused request off the undo stack — `$hasRemovableCharNode` screens the whole-call case
+      // read-only, before any splitting. See its docstring for the residual mixed-selection case.
       if (!$isFullyCoveredByTargets(child, targetKeys)) return undefined;
       coveredIndexes.push(index);
     }
   }
-  if (coveredIndexes.length === 0) return charNode;
+  // Unreachable today: the caller only gets here via a target inside `charNode`, which yields at
+  // least one covered index. Refusing rather than returning `charNode` keeps this function's
+  // "refuse rather than over-remove" contract the default if a future caller does reach it —
+  // returning `charNode` would strip the marker from content nothing established as covered.
+  if (coveredIndexes.length === 0) return undefined;
 
   let firstCoveredIndex = coveredIndexes[0];
   let lastCoveredIndex = coveredIndexes[coveredIndexes.length - 1];

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -442,6 +442,11 @@ function $getCharNodeToRemove(node: LexicalNode, marker: string | undefined): Ch
  * Needed because `handleTextNode` splits the *text* node, leaving all the pieces inside the same
  * `CharNode` — so unwrapping it would strip the marker from the uncovered text too.
  *
+ * A child counts as covered either directly (it is one of `targetNodes`) or transitively (it is an
+ * element, such as a nested `CharNode`, that contains one of `targetNodes`) — so a partially
+ * covered outer marker around an inner marked span still narrows correctly instead of being
+ * mistaken for having no covered children at all.
+ *
  * Marker-mode caveat: under `markerMode: "visible"` / `"editable"`, a `CharNode`'s opening marker
  * child sits at index 0 and its closing marker child sits last. If either ends up on the uncovered
  * side of a split, it lands in the leading or trailing clone without its counterpart, leaving that
@@ -455,7 +460,12 @@ function $splitCharNodeAroundTargets(charNode: CharNode, targetNodes: TextNode[]
   const targetKeys = new Set(targetNodes.map((targetNode) => targetNode.getKey()));
   const children = charNode.getChildren();
   const coveredIndexes = children
-    .map((child, index) => ($isTextNode(child) && targetKeys.has(child.getKey()) ? index : -1))
+    .map((child, index) =>
+      targetKeys.has(child.getKey()) ||
+      ($isElementNode(child) && targetNodes.some((targetNode) => child.isParentOf(targetNode)))
+        ? index
+        : -1,
+    )
     .filter((index) => index >= 0);
   if (coveredIndexes.length === 0) return charNode;
 

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -449,10 +449,13 @@ function $getCharNodeToRemove(node: LexicalNode, marker: string | undefined): Ch
  * covered outer marker around an inner marked span still narrows correctly instead of being
  * mistaken for having no covered children at all.
  *
- * Marker-mode caveat: under `markerMode: "visible"` / `"editable"`, a `CharNode`'s opening marker
- * child sits at index 0 and its closing marker child sits last. If either ends up on the uncovered
- * side of a split, it lands in the leading or trailing clone without its counterpart, leaving that
- * clone with half a marker pair. Handling that is Task 5's job, not this function's.
+ * Marker-mode handling: under `markerMode: "visible"` / `"editable"`, a `CharNode`'s opening
+ * marker child sits at index 0 and its closing marker child sits last. Left uncovered on its own,
+ * either would land alone in a leading or trailing clone with no counterpart. Since
+ * `$removeCharNodeKeepingContent` strips these markers unconditionally regardless of which clone
+ * they end up in, folding an adjacent boundary marker into the covered range changes nothing about
+ * the marker's fate — it only prevents a stray marker-only sibling `CharNode` from being created
+ * when the actual content is fully covered.
  *
  * Known limitation — partial coverage of a nested CharNode: transitive coverage (above) only
  * decides whether a nested element child counts as covered at *this* level; it cannot split that
@@ -482,8 +485,22 @@ function $splitCharNodeAroundTargets(charNode: CharNode, targetNodes: TextNode[]
     .filter((index) => index >= 0);
   if (coveredIndexes.length === 0) return charNode;
 
-  const firstCoveredIndex = coveredIndexes[0];
-  const lastCoveredIndex = coveredIndexes[coveredIndexes.length - 1];
+  let firstCoveredIndex = coveredIndexes[0];
+  let lastCoveredIndex = coveredIndexes[coveredIndexes.length - 1];
+  // Fold an adjacent boundary marker into the covered range so it isn't left stranded alone in a
+  // clone — see the marker-mode handling note above.
+  if (
+    firstCoveredIndex > 0 &&
+    ($isMarkerNode(children[firstCoveredIndex - 1]) ||
+      $isVisibleMarkerNode(children[firstCoveredIndex - 1]))
+  )
+    firstCoveredIndex -= 1;
+  if (
+    lastCoveredIndex < children.length - 1 &&
+    ($isMarkerNode(children[lastCoveredIndex + 1]) ||
+      $isVisibleMarkerNode(children[lastCoveredIndex + 1]))
+  )
+    lastCoveredIndex += 1;
   if (firstCoveredIndex === 0 && lastCoveredIndex === children.length - 1) return charNode;
 
   // Append moves the children out of `charNode`, so it is left holding only the covered ones.

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -403,6 +403,23 @@ export function $removeCharMarkerAtSelection(
     const coveredCharNode = $splitCharNodeAroundTargets(charNode, targetNodes);
     $removeCharNodeKeepingContent(coveredCharNode, viewOptions);
   });
+
+  // Restore the range over the same characters so a toolbar caller can re-toggle without
+  // re-selecting. `handleTextNode` split each target to cover exactly the selected portion, so
+  // the range is the whole of the first target through the whole of the last. Lexical's text
+  // normalization transfers these points when it merges the freed siblings. Skipped when a target
+  // node itself didn't survive — this happens when its enclosing CharNode held nothing but the
+  // empty-char placeholder and was removed outright rather than unwrapped (see
+  // $removeCharNodeKeepingContent) — in which case Lexical's own selection repair applies instead.
+  const firstTargetNode = targetNodes[0];
+  const lastTargetNode = targetNodes[targetNodes.length - 1];
+  if (firstTargetNode.isAttached() && lastTargetNode.isAttached())
+    selection.setTextNodeRange(
+      firstTargetNode,
+      0,
+      lastTargetNode,
+      lastTargetNode.getTextContentSize(),
+    );
 }
 
 /**
@@ -467,7 +484,6 @@ function $getCharNodeToRemove(node: LexicalNode, marker: string | undefined): Ch
  * silently drop `\wj` from the rest of that divine-name word, not just the selected part. Fixing
  * this needs recursive splitting of the nested CharNode itself, which this function does not do.
  *
-
  * @param charNode - The `CharNode` the selection touches.
  * @param targetNodes - The text nodes the selection covers.
  * @returns the `CharNode` that now covers only the selection. Unchanged when coverage is total.

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -1,5 +1,6 @@
 import { MarkerContent } from "@eten-tech-foundation/scripture-utilities";
 import { SerializedVerseRef } from "@sillsdev/scripture";
+import { $unwrapNode } from "@lexical/utils";
 import {
   $createTextNode,
   $getSelection,
@@ -14,12 +15,15 @@ import {
 } from "lexical";
 import {
   $createNodeFromSerializedNode,
+  $isCharNode,
   $isMarkerNode,
   $isNoteNode,
+  $isSomeParaNode,
   $isTypedMarkNode,
   $isVisibleMarkerNode,
   CharNode,
   createLexicalUsjNode,
+  EMPTY_CHAR_PLACEHOLDER_TEXT,
   getNextVerse,
   LoggerBasic,
   MarkerAction,
@@ -254,7 +258,7 @@ function $wrapTextSelectionInInlineNode(
   if ($isTextNode(currentWrapper) || $isElementNode(currentWrapper)) currentWrapper.selectEnd();
 }
 
-// #region Helper functions for $wrapTextSelectionInInlineNode
+// #region Helper functions for wrapping and unwrapping inline nodes
 
 /**
  * Get the start and end offsets of a selection.
@@ -334,6 +338,121 @@ function $moveLeadingSpaceToPreviousNode(node: LexicalNode, wrapper: LexicalNode
     if (!$isTextNode(previousNode)) wrapper.insertBefore($createTextNode(" "));
   }
   return text;
+}
+
+/**
+ * Remove a character marker from the given selection, keeping all of its text content.
+ *
+ * A collapsed selection removes the marker from the entire enclosing `CharNode`. A range
+ * selection that only partially covers a `CharNode` splits it first, so the uncovered text keeps
+ * its marker. Selections inside a `NoteNode` are skipped (see `$getCharNodeToRemove`).
+ *
+ * @param selection - The current range selection.
+ * @param marker - The character marker to remove, or `undefined` for the innermost one.
+ * @param viewOptions - View options, used to strip synthesized marker content.
+ */
+export function $removeCharMarkerAtSelection(
+  selection: RangeSelection,
+  marker: string | undefined,
+  viewOptions: ViewOptions | undefined,
+): void {
+  if (selection.isCollapsed()) {
+    const charNode = $getCharNodeToRemove(selection.anchor.getNode(), marker);
+    if (charNode) $removeCharNodeKeepingContent(charNode, viewOptions);
+    return;
+  }
+
+  const nodes = selection.getNodes();
+  const [startOffset, endOffset] = getSelectionOffsets(selection);
+  const targetNodes: TextNode[] = [];
+  nodes.forEach((node, index) => {
+    const targetNode = $getTargetNode(
+      node,
+      index === 0,
+      index === nodes.length - 1,
+      startOffset,
+      endOffset,
+    );
+    if ($isTextNode(targetNode)) targetNodes.push(targetNode);
+  });
+  if (targetNodes.length === 0) return;
+
+  const handledCharNodeKeys = new Set<string>();
+  targetNodes.forEach((targetNode) => {
+    const charNode = $getCharNodeToRemove(targetNode, marker);
+    if (!charNode || handledCharNodeKeys.has(charNode.getKey())) return;
+    handledCharNodeKeys.add(charNode.getKey());
+    $removeCharNodeKeepingContent(charNode, viewOptions);
+  });
+}
+
+/**
+ * Find the `CharNode` a removal should act on, walking up from a target node.
+ *
+ * Returns `undefined` when nothing matches, which the caller treats as a no-op for that target
+ * node. The walk is per-target, so a selection spanning a matching and a non-matching node still
+ * acts on the matching one. A `CharNode` nested inside a `NoteNode` is skipped: `$getTargetNode`
+ * only recognizes note interiors one level deep (a leaf whose *immediate* parent is the
+ * `NoteNode`), so a marker `CharNode` nested deeper inside a note — the common case — would
+ * otherwise still be found and removed by this walk.
+ *
+ * @param node - The node to walk up from.
+ * @param marker - The marker to match, or `undefined` to take the innermost `CharNode`.
+ * @returns the `CharNode` to remove, or `undefined` if there isn't one.
+ */
+function $getCharNodeToRemove(node: LexicalNode, marker: string | undefined): CharNode | undefined {
+  let currentNode: LexicalNode | null = node;
+  let matchedCharNode: CharNode | undefined;
+  while (currentNode && !$isSomeParaNode(currentNode)) {
+    if ($isNoteNode(currentNode)) return undefined;
+    // Walking upwards, the first CharNode found is the innermost one. Keep walking past it (up
+    // to the enclosing para) so a NoteNode further up still causes a skip.
+    if (
+      !matchedCharNode &&
+      $isCharNode(currentNode) &&
+      (marker === undefined || currentNode.getMarker() === marker)
+    )
+      matchedCharNode = currentNode;
+    currentNode = currentNode.getParent();
+  }
+  return matchedCharNode;
+}
+
+/**
+ * Remove a `CharNode` but keep its text content in the parent.
+ *
+ * Synthesized marker children (`markerMode: "editable"` / `"visible"`) are stripped first so no
+ * literal `\nd` / `\nd*` text is left behind, and in `"editable"` mode the NBSP that
+ * `usj-editor.adaptor.ts` prepends to each text child for rendering is trimmed. A `CharNode`
+ * holding nothing but the empty-char placeholder is removed outright rather than unwrapped.
+ *
+ * @param charNode - The `CharNode` to remove.
+ * @param viewOptions - View options, used to decide what counts as synthesized content.
+ */
+function $removeCharNodeKeepingContent(
+  charNode: CharNode,
+  viewOptions: ViewOptions | undefined,
+): void {
+  charNode.getChildren().forEach((child) => {
+    if ($isMarkerNode(child) || $isVisibleMarkerNode(child)) child.remove();
+  });
+
+  // Checked before the NBSP trim below: the placeholder IS an NBSP, and the adaptor does not
+  // prepend a second one to it.
+  const remainingChildren = charNode.getChildren();
+  if (remainingChildren.length === 0 || charNode.getTextContent() === EMPTY_CHAR_PLACEHOLDER_TEXT) {
+    charNode.remove();
+    return;
+  }
+
+  if (viewOptions?.markerMode === "editable")
+    remainingChildren.forEach((child) => {
+      const text = child.getTextContent();
+      if ($isTextNode(child) && text.startsWith(NBSP))
+        child.setTextContent(text.slice(NBSP.length));
+    });
+
+  $unwrapNode(charNode);
 }
 
 // #endregion

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -384,12 +384,15 @@ export function $removeCharMarkerAtSelection(
 
   // Still not reachable after $splitCharNodeAroundTargets: it consults the full targetNodes array,
   // so the first targetNode belonging to a given CharNode already causes every other targetNode
-  // sharing it to be carved into (or left in) that same node before this loop reaches them. By the
-  // time a later targetNode is processed, $removeCharNodeKeepingContent has already detached that
-  // CharNode (unwrapped or removed outright), so its former children are reparented onto — or
-  // orphaned from — the para, and $getCharNodeToRemove resolves to undefined rather than the same
-  // key. Kept as a guard in case a future change reintroduces a path where two targetNodes still
-  // resolve to the same charNode.getKey().
+  // sharing it to be carved into (or left in) that same node before this loop reaches them. When
+  // $removeCharNodeKeepingContent unwraps that CharNode, later targetNodes resolve to undefined
+  // (their former parent is gone). When it removes the CharNode outright instead — which only
+  // happens when the CharNode is empty or holds nothing but the single-character
+  // EMPTY_CHAR_PLACEHOLDER_TEXT — a later targetNode walking up from a still-attached child WOULD
+  // resolve to the same key (`.remove()` leaves `__parent` pointers and the node in the nodeMap for
+  // the rest of the update), but that branch can't contain two distinct target text nodes to begin
+  // with, so it never has a "later targetNode" to reach. Kept as a guard in case a future change
+  // reintroduces a path where two targetNodes still resolve to the same charNode.getKey().
   const handledCharNodeKeys = new Set<string>();
   targetNodes.forEach((targetNode) => {
     const charNode = $getCharNodeToRemove(targetNode, marker);
@@ -439,14 +442,20 @@ function $getCharNodeToRemove(node: LexicalNode, marker: string | undefined): Ch
  * Needed because `handleTextNode` splits the *text* node, leaving all the pieces inside the same
  * `CharNode` — so unwrapping it would strip the marker from the uncovered text too.
  *
+ * Marker-mode caveat: under `markerMode: "visible"` / `"editable"`, a `CharNode`'s opening marker
+ * child sits at index 0 and its closing marker child sits last. If either ends up on the uncovered
+ * side of a split, it lands in the leading or trailing clone without its counterpart, leaving that
+ * clone with half a marker pair. Handling that is Task 5's job, not this function's.
+ *
  * @param charNode - The `CharNode` the selection touches.
  * @param targetNodes - The text nodes the selection covers.
  * @returns the `CharNode` that now covers only the selection. Unchanged when coverage is total.
  */
 function $splitCharNodeAroundTargets(charNode: CharNode, targetNodes: TextNode[]): CharNode {
+  const targetKeys = new Set(targetNodes.map((targetNode) => targetNode.getKey()));
   const children = charNode.getChildren();
   const coveredIndexes = children
-    .map((child, index) => ($isTextNode(child) && targetNodes.includes(child) ? index : -1))
+    .map((child, index) => ($isTextNode(child) && targetKeys.has(child.getKey()) ? index : -1))
     .filter((index) => index >= 0);
   if (coveredIndexes.length === 0) return charNode;
 

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -405,16 +405,36 @@ export function $removeCharMarkerAtSelection(
   });
 
   // Restore the range over the same characters so a toolbar caller can re-toggle without
-  // re-selecting. `handleTextNode` split each target to cover exactly the selected portion, so
-  // the range is the whole of the first target through the whole of the last. Lexical's text
-  // normalization transfers these points when it merges the freed siblings. Skipped when a target
-  // node itself didn't survive — this happens when its enclosing CharNode held nothing but the
-  // empty-char placeholder and was removed outright rather than unwrapped (see
+  // re-selecting. `handleTextNode` split each target to cover exactly the selected portion, so the
+  // range is the whole of the first target through the whole of the last. This is not always a
+  // no-op: `TextNode.splitText` (used by `handleTextNode` above, via `$getTargetNode`) transfers
+  // anchor/focus onto the right split piece on its own, but `TextNode.setTextContent` — used by
+  // `$removeCharNodeKeepingContent`'s NBSP trim under `markerMode: "editable"` — only mutates
+  // `__text` and does not touch selection points at all. When the trim runs on a node the focus
+  // still points at (e.g. selecting a whole `CharNode`'s content, so no split happens), the
+  // pre-trim offset ends up one character past the new end without this restore. Skipped when a
+  // target node itself didn't survive — this happens when its enclosing CharNode held nothing but
+  // the empty-char placeholder and was removed outright rather than unwrapped (see
   // $removeCharNodeKeepingContent) — in which case Lexical's own selection repair applies instead.
+  // Note: this always writes anchor at the first target's start and focus at the last target's
+  // end, so a backward selection comes back forward — a normalization the spec doesn't require but
+  // is harmless, since `getSelectionOffsets` above is already backward-safe.
+  //
+  // Re-fetch the selection instead of reusing the `selection` parameter: `$unwrapNode` (used by
+  // `$removeCharNodeKeepingContent`) unwraps via `CharNode.replace()`, and `TextNode.replace()`
+  // unconditionally clones the active selection and calls `$setSelection` on the clone partway
+  // through — even when neither point needs adjusting. That silently swaps the *active* selection
+  // for a new object, leaving our `selection` parameter pointing at a now-stale, detached one.
+  // Mutating the stale object here would have no effect on what the later merge actually reads.
+  const currentSelection = $getSelection();
   const firstTargetNode = targetNodes[0];
   const lastTargetNode = targetNodes[targetNodes.length - 1];
-  if (firstTargetNode.isAttached() && lastTargetNode.isAttached())
-    selection.setTextNodeRange(
+  if (
+    $isRangeSelection(currentSelection) &&
+    firstTargetNode.isAttached() &&
+    lastTargetNode.isAttached()
+  )
+    currentSelection.setTextNodeRange(
       firstTargetNode,
       0,
       lastTargetNode,
@@ -466,13 +486,27 @@ function $getCharNodeToRemove(node: LexicalNode, marker: string | undefined): Ch
  * covered outer marker around an inner marked span still narrows correctly instead of being
  * mistaken for having no covered children at all.
  *
- * Marker-mode handling: under `markerMode: "visible"` / `"editable"`, a `CharNode`'s opening
- * marker child sits at index 0 and its closing marker child sits last. Left uncovered on its own,
- * either would land alone in a leading or trailing clone with no counterpart. Since
- * `$removeCharNodeKeepingContent` strips these markers unconditionally regardless of which clone
- * they end up in, folding an adjacent boundary marker into the covered range changes nothing about
- * the marker's fate — it only prevents a stray marker-only sibling `CharNode` from being created
- * when the actual content is fully covered.
+ * Marker-mode handling — boundary case only: under `markerMode: "visible"` / `"editable"`, a
+ * `CharNode`'s opening marker child sits at index 0 and its closing marker child sits last. When
+ * the covered range already touches that boundary (nothing real and unselected sits between the
+ * marker and the covered content on that side), folding the adjacent marker into the covered range
+ * before splitting avoids stranding it alone in a leading or trailing clone. This is safe *for the
+ * folded side*: `$removeCharNodeKeepingContent` strips a marker unconditionally regardless of which
+ * clone it ends up in, so folding it into the covered side changes nothing about its fate — it only
+ * prevents a stray marker-only sibling `CharNode` from surviving when the real content is fully
+ * covered.
+ *
+ * Known limitation — interior partial coverage under marker mode: the fold above only reaches a
+ * marker immediately adjacent to the covered range. When real, unselected text sits between the
+ * marker and the covered range — e.g. children `[openMarker, leadingText, targetText,
+ * trailingText, closeMarker]` with only `targetText` covered — neither boundary marker is adjacent
+ * to `coveredIndexes`, so neither folds. The split then produces a leading clone
+ * `[openMarker, leadingText]` and a trailing clone `[trailingText, closeMarker]`, each carrying an
+ * unpaired marker node that is never stripped, because only the returned (covered) node is passed
+ * to `$removeCharNodeKeepingContent`. A literal `\nd` / `\nd*` survives in the document in that
+ * shape. Fixing this correctly requires each surviving clone to be given its own regenerated
+ * opening *and* closing marker children — adaptor-level work beyond this function's scope — so it
+ * is left as a documented limitation rather than attempted here.
  *
  * Known limitation — partial coverage of a nested CharNode: transitive coverage (above) only
  * decides whether a nested element child counts as covered at *this* level; it cannot split that

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -398,7 +398,8 @@ export function $removeCharMarkerAtSelection(
   // Known, harmless: this splits every selected text node via `handleTextNode`'s `splitText`
   // whether or not any of them turn out to sit inside a matching `CharNode` below. A no-match
   // request still leaves the document split at the selection boundaries — content-preserving, but
-  // an avoidable no-op mutation. Triaged, not fixed here.
+  // an avoidable no-op mutation (a spurious undo entry, and possibly an empty collab delta).
+  // Resolving the matching `CharNode` set before this loop would avoid it.
   nodes.forEach((node, index) => {
     const targetNode = $getTargetNode(
       node,
@@ -411,7 +412,8 @@ export function $removeCharMarkerAtSelection(
   });
   if (targetNodes.length === 0) return;
 
-  // Still not reachable after $splitCharNodeAroundTargets: it consults the full targetNodes array,
+  // No reachable path currently resolves two targetNodes to the same CharNode key.
+  // $splitCharNodeAroundTargets consults the full targetNodes array,
   // so the first targetNode belonging to a given CharNode already causes every other targetNode
   // sharing it to be carved into (or left in) that same node before this loop reaches them. When
   // $removeCharNodeKeepingContent unwraps that CharNode, later targetNodes resolve to undefined
@@ -452,7 +454,7 @@ export function $removeCharMarkerAtSelection(
   // `$removeCharNodeKeepingContent`) unwraps via `CharNode.replace()`, and `TextNode.replace()`
   // unconditionally clones the active selection and calls `$setSelection` on the clone partway
   // through — even when neither point needs adjusting. That silently swaps the *active* selection
-  // for a new object, leaving our `selection` parameter pointing at a now-stale, detached one.
+  // for a new object, leaving the `selection` parameter pointing at a now-stale, detached one.
   // Mutating the stale object here would have no effect on what the later merge actually reads.
   const currentSelection = $getSelection();
   const firstTargetNode = targetNodes[0];
@@ -617,9 +619,9 @@ function $createCharNodeLike(charNode: CharNode): CharNode {
   newCharNode.setFormat(charNode.getFormatType());
   // Note: `getStyle()`/`setStyle()` are the matching pair for an ElementNode's own CSS style
   // string (`__style`); `getTextStyle()` reads a different member (`__textStyle`, the default
-  // inline style for children) entirely. `CharNode.insertNewAfter` (CharNode.ts:254) pairs
-  // `setStyle` with `getTextStyle` too, so that copy is inert there as well — not our bug to fix
-  // under `libs/`, but ours here uses the matching pair so this copy actually does something.
+  // inline style for children) entirely. Note `CharNode.insertNewAfter` (CharNode.ts:254) and
+  // `ParaNode.insertNewAfter` (ParaNode.ts:286) both pair `setStyle` with `getTextStyle`, so their
+  // style copies are inert; don't copy that pairing from them.
   newCharNode.setStyle(charNode.getStyle());
   $setState(newCharNode, charIdState, () => $getState(charNode, charIdState));
   return newCharNode;

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -364,14 +364,41 @@ export function $removeCharMarkerAtSelection(
   viewOptions: ViewOptions | undefined,
 ): void {
   if (selection.isCollapsed()) {
-    const charNode = $getCharNodeToRemove(selection.anchor.getNode(), marker);
-    if (charNode) $removeCharNodeKeepingContent(charNode, viewOptions);
+    const anchorNode = selection.anchor.getNode();
+    const anchorOffset = selection.anchor.offset;
+    const charNode = $getCharNodeToRemove(anchorNode, marker);
+    if (!charNode) return;
+    const originalSize = $isTextNode(anchorNode) ? anchorNode.getTextContentSize() : 0;
+    $removeCharNodeKeepingContent(charNode, viewOptions);
+
+    // Mirror the range branch's restore below: `$removeCharNodeKeepingContent`'s NBSP trim
+    // (`markerMode: "editable"`) calls `TextNode.setTextContent`, which never touches selection
+    // points, and `$unwrapNode`'s underlying `replace()` call clones the active selection without
+    // adjusting them either. Without this, a collapsed caret inside NBSP-prefixed content ends up
+    // one character right of where it belongs — out of range entirely when the caret was at the
+    // text's end. Skipped when the anchor node itself didn't survive: that happens only when its
+    // enclosing CharNode held nothing but the empty-char placeholder and was removed outright
+    // rather than unwrapped (see `$removeCharNodeKeepingContent`), in which case `.remove()`'s own
+    // `restoreSelection` already redirects the point correctly.
+    if ($isTextNode(anchorNode) && anchorNode.isAttached()) {
+      const newSize = anchorNode.getTextContentSize();
+      const trimmedLength = Math.max(originalSize - newSize, 0);
+      const newOffset = Math.max(0, Math.min(anchorOffset - trimmedLength, newSize));
+      const currentSelection = $getSelection();
+      if ($isRangeSelection(currentSelection))
+        currentSelection.setTextNodeRange(anchorNode, newOffset, anchorNode, newOffset);
+    }
     return;
   }
 
   const nodes = selection.getNodes();
+  const isBackward = selection.isBackward();
   const [startOffset, endOffset] = getSelectionOffsets(selection);
   const targetNodes: TextNode[] = [];
+  // Known, harmless: this splits every selected text node via `handleTextNode`'s `splitText`
+  // whether or not any of them turn out to sit inside a matching `CharNode` below. A no-match
+  // request still leaves the document split at the selection boundaries — content-preserving, but
+  // an avoidable no-op mutation. Triaged, not fixed here.
   nodes.forEach((node, index) => {
     const targetNode = $getTargetNode(
       node,
@@ -416,9 +443,10 @@ export function $removeCharMarkerAtSelection(
   // target node itself didn't survive — this happens when its enclosing CharNode held nothing but
   // the empty-char placeholder and was removed outright rather than unwrapped (see
   // $removeCharNodeKeepingContent) — in which case Lexical's own selection repair applies instead.
-  // Note: this always writes anchor at the first target's start and focus at the last target's
-  // end, so a backward selection comes back forward — a normalization the spec doesn't require but
-  // is harmless, since `getSelectionOffsets` above is already backward-safe.
+  // Preserves the original direction: `isBackward` was captured above, before the removal loop,
+  // since a backward range's anchor is the *last* target and its focus is the *first* — swapping
+  // which end gets which role keeps a backward selection backward instead of always normalizing
+  // to forward.
   //
   // Re-fetch the selection instead of reusing the `selection` parameter: `$unwrapNode` (used by
   // `$removeCharNodeKeepingContent`) unwraps via `CharNode.replace()`, and `TextNode.replace()`
@@ -433,13 +461,12 @@ export function $removeCharMarkerAtSelection(
     $isRangeSelection(currentSelection) &&
     firstTargetNode.isAttached() &&
     lastTargetNode.isAttached()
-  )
-    currentSelection.setTextNodeRange(
-      firstTargetNode,
-      0,
-      lastTargetNode,
-      lastTargetNode.getTextContentSize(),
-    );
+  ) {
+    const lastOffset = lastTargetNode.getTextContentSize();
+    if (isBackward)
+      currentSelection.setTextNodeRange(lastTargetNode, lastOffset, firstTargetNode, 0);
+    else currentSelection.setTextNodeRange(firstTargetNode, 0, lastTargetNode, lastOffset);
+  }
 }
 
 /**
@@ -472,6 +499,19 @@ function $getCharNodeToRemove(node: LexicalNode, marker: string | undefined): Ch
     currentNode = currentNode.getParent();
   }
   return matchedCharNode;
+}
+
+/**
+ * True for either flavor of synthesized marker child a `CharNode` can hold under
+ * `markerMode: "editable"` (`MarkerNode`) or `"visible"` (an `ImmutableTypedTextNode` with
+ * `textType: "marker"`). Not `$isParaMarkerPrefix` from `shared` — same predicate, but that name
+ * describes a paragraph's leading marker, which would mislead here.
+ *
+ * @param node - The node to check.
+ * @returns `true` if the node is a synthesized marker child.
+ */
+function $isSynthesizedMarkerNode(node: LexicalNode | null | undefined): boolean {
+  return $isMarkerNode(node) || $isVisibleMarkerNode(node);
 }
 
 /**
@@ -539,16 +579,11 @@ function $splitCharNodeAroundTargets(charNode: CharNode, targetNodes: TextNode[]
   let lastCoveredIndex = coveredIndexes[coveredIndexes.length - 1];
   // Fold an adjacent boundary marker into the covered range so it isn't left stranded alone in a
   // clone — see the marker-mode handling note above.
-  if (
-    firstCoveredIndex > 0 &&
-    ($isMarkerNode(children[firstCoveredIndex - 1]) ||
-      $isVisibleMarkerNode(children[firstCoveredIndex - 1]))
-  )
+  if (firstCoveredIndex > 0 && $isSynthesizedMarkerNode(children[firstCoveredIndex - 1]))
     firstCoveredIndex -= 1;
   if (
     lastCoveredIndex < children.length - 1 &&
-    ($isMarkerNode(children[lastCoveredIndex + 1]) ||
-      $isVisibleMarkerNode(children[lastCoveredIndex + 1]))
+    $isSynthesizedMarkerNode(children[lastCoveredIndex + 1])
   )
     lastCoveredIndex += 1;
   if (firstCoveredIndex === 0 && lastCoveredIndex === children.length - 1) return charNode;
@@ -567,9 +602,11 @@ function $splitCharNodeAroundTargets(charNode: CharNode, targetNodes: TextNode[]
 /**
  * Create an empty `CharNode` carrying the same identity as `charNode`.
  *
- * Copies marker, unknown attributes, direction, format, and style like `CharNode.insertNewAfter`
- * does, and additionally copies `charIdState` — without the cid, `$charNodeTransform`'s
- * `$hasSameCharAttributes` check would refuse to re-merge the halves later.
+ * Copies marker, unknown attributes, direction, format, and style — modeled on
+ * `CharNode.insertNewAfter`'s copy, but pairing `setStyle` with `getStyle` rather than
+ * `getTextStyle` (see the note below) so the style copy actually takes effect. Additionally
+ * copies `charIdState` — without the cid, `$charNodeTransform`'s `$hasSameCharAttributes` check
+ * would refuse to re-merge the halves later.
  *
  * @param charNode - The `CharNode` to copy identity from.
  * @returns a new empty `CharNode` with the same identity.
@@ -578,7 +615,12 @@ function $createCharNodeLike(charNode: CharNode): CharNode {
   const newCharNode = $createCharNode(charNode.getMarker(), charNode.getUnknownAttributes());
   newCharNode.setDirection(charNode.getDirection());
   newCharNode.setFormat(charNode.getFormatType());
-  newCharNode.setStyle(charNode.getTextStyle());
+  // Note: `getStyle()`/`setStyle()` are the matching pair for an ElementNode's own CSS style
+  // string (`__style`); `getTextStyle()` reads a different member (`__textStyle`, the default
+  // inline style for children) entirely. `CharNode.insertNewAfter` (CharNode.ts:254) pairs
+  // `setStyle` with `getTextStyle` too, so that copy is inert there as well — not our bug to fix
+  // under `libs/`, but ours here uses the matching pair so this copy actually does something.
+  newCharNode.setStyle(charNode.getStyle());
   $setState(newCharNode, charIdState, () => $getState(charNode, charIdState));
   return newCharNode;
 }
@@ -599,7 +641,7 @@ function $removeCharNodeKeepingContent(
   viewOptions: ViewOptions | undefined,
 ): void {
   charNode.getChildren().forEach((child) => {
-    if ($isMarkerNode(child) || $isVisibleMarkerNode(child)) child.remove();
+    if ($isSynthesizedMarkerNode(child)) child.remove();
   });
 
   // Checked before the NBSP trim below: the placeholder IS an NBSP, and the adaptor does not

--- a/packages/platform/src/editor/editor.model.ts
+++ b/packages/platform/src/editor/editor.model.ts
@@ -120,13 +120,16 @@ export interface EditorRef {
   /** Get the editor element for the given node key, if any. */
   getElementByKey(nodeKey: string): HTMLElement | undefined;
   /**
-   * Remove a character marker from the current editor selection, keeping its text content. Works
-   * with both collapsed (removes the marker from the whole enclosing marker) and range (splits the
-   * marker, leaving the uncovered text marked) selections.
+   * Remove a character marker from the current editor selection, keeping its text content.
    *
-   * Does nothing, without throwing, when there is no matching character marker enclosing the
-   * selection, when the selection is inside a note, when the removal could not be confined to the
-   * selection (see below), or when there is no active selection at all.
+   * Returns whether a marker was actually removed, so a caller can tell a real removal from a
+   * refused or unmatched one. Works with both collapsed (removes the marker from the whole
+   * enclosing marker) and range (splits the marker, leaving the uncovered text marked) selections.
+   *
+   * Returns `false` and does nothing, without throwing, when there is no matching character marker
+   * enclosing the selection, when the selection is inside a note, when the removal could not be
+   * confined to the selection (see below), or when there is no active selection at all. In every
+   * one of those cases the document and the selection are left untouched — no undo entry is added.
    *
    * @remarks
    * Two narrowed edge cases, both preserving every character of the document's text content:
@@ -147,11 +150,14 @@ export interface EditorRef {
    *   the document is loaded from USJ.
    *
    * @param marker - A USFM character marker string, e.g. `"nd"`, `"wj"`. Omit to remove the
-   *   innermost character marker enclosing the selection.
+   *   innermost character marker enclosing the selection. Footnote and cross-reference character
+   *   markers (e.g. `"ft"`, `"xt"`) are not supported: they only occur inside notes, which removal
+   *   skips, so they throw rather than silently doing nothing.
+   * @returns `true` if a character marker was removed, `false` if the request was a no-op.
    * @throws Will throw an error if the editor is in readonly mode.
    * @throws Will throw an error if `marker` is given and is not a supported character marker.
    */
-  removeCharacterMarker(marker?: string): void;
+  removeCharacterMarker(marker?: string): boolean;
   /**
    * Insert a marker at the current editor selection, replicating the behavior of the
    * built-in marker menu. Works with both collapsed (insertion point) and range selections.

--- a/packages/platform/src/editor/editor.model.ts
+++ b/packages/platform/src/editor/editor.model.ts
@@ -120,6 +120,17 @@ export interface EditorRef {
   /** Get the editor element for the given node key, if any. */
   getElementByKey(nodeKey: string): HTMLElement | undefined;
   /**
+   * Remove a character marker from the current editor selection, keeping its text content. Works
+   * with both collapsed (removes the marker from the whole enclosing marker) and range (splits the
+   * marker, leaving the uncovered text marked) selections.
+   *
+   * @param marker - A USFM character marker string, e.g. `"nd"`, `"wj"`. Omit to remove the
+   *   innermost character marker enclosing the selection.
+   * @throws Will throw an error if the editor is in readonly mode.
+   * @throws Will throw an error if `marker` is given and is not a supported character marker.
+   */
+  removeCharMarker(marker?: string): void;
+  /**
    * Insert a marker at the current editor selection, replicating the behavior of the
    * built-in marker menu. Works with both collapsed (insertion point) and range selections.
    *

--- a/packages/platform/src/editor/editor.model.ts
+++ b/packages/platform/src/editor/editor.model.ts
@@ -125,16 +125,19 @@ export interface EditorRef {
    * marker, leaving the uncovered text marked) selections.
    *
    * Does nothing, without throwing, when there is no matching character marker enclosing the
-   * selection, when the selection is inside a note, or when there is no active selection at all.
+   * selection, when the selection is inside a note, when the removal could not be confined to the
+   * selection (see below), or when there is no active selection at all.
    *
    * @remarks
    * Two narrowed edge cases, both preserving every character of the document's text content:
    *
-   * - Nested markers: text left uncovered by the selection keeps its marker, provided the
-   *   selection does not partially cover a nested character marker's text. When it does, and the
-   *   *outer* marker is the one being removed, the outer marker is removed from that nested
-   *   marker's entire span — not just the selected part of it — because recursive splitting of a
-   *   nested marker's text is not implemented.
+   * - Nested markers: text left uncovered by the selection keeps its marker. Inner and outer
+   *   markers of a nested pair can each be removed independently while the selection covers them
+   *   fully. When a range selection covers only *part* of a nested character marker's text and the
+   *   *outer* marker is the one being removed, the request is refused and the document is left
+   *   unchanged: recursive splitting of a nested marker's text is not implemented, so the marker
+   *   could only be removed from that nested marker's entire span, including text the caller never
+   *   selected. Refusing keeps the guarantee that removal never alters unselected text.
    * - Marker display modes (paragraph structure and unformatted views): the marker's own visible
    *   representation is stripped from the span the marker is removed from, but when a range
    *   selection leaves unselected text between a marker's boundary and the selection, the marked
@@ -148,7 +151,7 @@ export interface EditorRef {
    * @throws Will throw an error if the editor is in readonly mode.
    * @throws Will throw an error if `marker` is given and is not a supported character marker.
    */
-  removeCharMarker(marker?: string): void;
+  removeCharacterMarker(marker?: string): void;
   /**
    * Insert a marker at the current editor selection, replicating the behavior of the
    * built-in marker menu. Works with both collapsed (insertion point) and range selections.

--- a/packages/platform/src/editor/editor.model.ts
+++ b/packages/platform/src/editor/editor.model.ts
@@ -124,6 +124,25 @@ export interface EditorRef {
    * with both collapsed (removes the marker from the whole enclosing marker) and range (splits the
    * marker, leaving the uncovered text marked) selections.
    *
+   * Does nothing, without throwing, when there is no matching character marker enclosing the
+   * selection, when the selection is inside a note, or when there is no active selection at all.
+   *
+   * @remarks
+   * Two narrowed edge cases, both preserving every character of the document's text content:
+   *
+   * - Nested markers: text left uncovered by the selection keeps its marker, provided the
+   *   selection does not partially cover a nested character marker's text. When it does, and the
+   *   *outer* marker is the one being removed, the outer marker is removed from that nested
+   *   marker's entire span — not just the selected part of it — because recursive splitting of a
+   *   nested marker's text is not implemented.
+   * - Marker display modes (paragraph structure and unformatted views): the marker's own visible
+   *   representation is stripped from the span the marker is removed from, but when a range
+   *   selection leaves unselected text between a marker's boundary and the selection, the marked
+   *   sibling that keeps that unselected text is left with an unpaired marker half — a literal
+   *   opening or closing marker (e.g. `\nd` or `\nd*`) stays visible in the editor. This is a
+   *   presentation artifact only: it is excluded from USJ export and self-corrects the next time
+   *   the document is loaded from USJ.
+   *
    * @param marker - A USFM character marker string, e.g. `"nd"`, `"wj"`. Omit to remove the
    *   innermost character marker enclosing the selection.
    * @throws Will throw an error if the editor is in readonly mode.

--- a/packages/platform/src/marginal/Marginal.tsx
+++ b/packages/platform/src/marginal/Marginal.tsx
@@ -183,8 +183,8 @@ const Marginal = forwardRef(function Marginal<TLogger extends LoggerBasic>(
     getElementByKey(nodeKey: string) {
       return editorRef.current?.getElementByKey(nodeKey);
     },
-    removeCharMarker(marker) {
-      editorRef.current?.removeCharMarker(marker);
+    removeCharacterMarker(marker) {
+      editorRef.current?.removeCharacterMarker(marker);
     },
     insertMarker(marker) {
       editorRef.current?.insertMarker(marker);

--- a/packages/platform/src/marginal/Marginal.tsx
+++ b/packages/platform/src/marginal/Marginal.tsx
@@ -183,6 +183,9 @@ const Marginal = forwardRef(function Marginal<TLogger extends LoggerBasic>(
     getElementByKey(nodeKey: string) {
       return editorRef.current?.getElementByKey(nodeKey);
     },
+    removeCharMarker(marker) {
+      editorRef.current?.removeCharMarker(marker);
+    },
     insertMarker(marker) {
       editorRef.current?.insertMarker(marker);
     },

--- a/packages/platform/src/marginal/Marginal.tsx
+++ b/packages/platform/src/marginal/Marginal.tsx
@@ -184,7 +184,7 @@ const Marginal = forwardRef(function Marginal<TLogger extends LoggerBasic>(
       return editorRef.current?.getElementByKey(nodeKey);
     },
     removeCharacterMarker(marker) {
-      editorRef.current?.removeCharacterMarker(marker);
+      return editorRef.current?.removeCharacterMarker(marker) ?? false;
     },
     insertMarker(marker) {
       editorRef.current?.insertMarker(marker);


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: character-marker-remove

**Base**: origin/main

**Date**: 2026-08-06

**Review model**: Claude Opus 5 (1M context)

**Files changed**: 11

## Overview

Adds a new `removeCharacterMarker(marker?)` method to `EditorRef`. It removes a USFM character
marker (e.g. `\nd`, `\wj`) from the current editor selection while preserving every character of the
text inside it — deleting the marker, never the content. This is the editor-side half of giving users
a discoverable way to add, change, and remove character markers; the UI that will call it lives in
paranext-core.

Removal is the only operation added here. Querying which marker is at the cursor needs no new API,
because `StateChangeSnapshot.contextMarker` already reports it and paranext-core already reads it.

The implementation composes helpers that already existed in `usj-marker-action.utils.ts` rather than
adding new algorithms or a new module: it calls `$unwrapNode` from `@lexical/utils` directly, leaves
`$unwrapTypedMarkNode` and every annotation and comment path untouched, and adds no new package-level
exports. It handles a selection that covers only part of a marked run by splitting the `CharNode`
around the selection, strips the marker's own visible representation and its NBSP prefix in the views
that display markers, skips selections inside a footnote, and restores the user's selection
afterwards — including collapsed carets and backward selections.

The review made seven substantive changes. The most significant is a **behavioral change**: when the
selection covers only part of a *nested* marked run, removing the outer marker is now refused instead
of removing that marker from the whole nested run. See Interview Notes for the reasoning — this is
the one item that rests on an unresolved product question.

## API Changes

- `@eten-tech-foundation/platform-editor` (`EditorRef`): added
  `removeCharacterMarker(marker?: string): void`. Purely additive — no existing member's signature,
  documentation, or behavior changed. Implemented at `Editor.tsx:316` and mirrored in the
  `Marginal.tsx:186` pass-through (mandatory, since `MarginalRef extends EditorRef`). `Editorial`
  forwards its ref straight to `Editor`, so it needed no change.
- `packages/platform/etc/platform-editor.api.md`: regenerated with the single new
  `removeCharacterMarker(marker?: string): void` line, alphabetized between `removeAnnotation` and
  `replaceEmbedUpdate`. Confirmed generated rather than hand-edited — `nx extract-api` produces an
  empty diff.
- Internal, not public API: `$removeCharacterMarkerAtSelection` and the new
  `isCharacterMarkerSupported` are exported from `usj-marker-action.utils.ts`, which is not
  re-exported from `packages/platform/src/index.ts`; neither appears in the API report.
- `libs/shared`: `$isParaMarkerPrefix` renamed to `$isSynthesizedMarkerNode` (2 call sites).
  `libs/shared` has no API report, so this is source-only and not a published-surface change.
- No new or changed exported types. `packages/scribe` has its own unrelated `EditorRef` and is
  unaffected.

Downstream cross-check in paranext-core (branch `character-marker-control`):
`use-character-marker-state.hook.ts:33` declares the consumer seam as
`removeCharacterMarker?: (marker: string) => void`. The name here now matches it exactly.

## Findings

### Critical — Must address before merge

- [x] **`$splitCharNodeAroundTargets` silently removed the outer marker from a nested marked run's
      entire span when the selection covered only part of it** — changing the saved USJ for text the
      user never selected. It was documented and pinned by a "known limitation" test, but a caller had
      no way to detect it. _(fixed during review: `$splitCharNodeAroundTargets` now returns
      `CharNode | undefined` and returns `undefined` when a nested element child that the selection
      reaches into is not fully covered. The check runs during the read-only coverage scan, before any
      mutation, so the document is left untouched. Added an `$isFullyCoveredByTargets` helper;
      synthesized marker children are excluded from the coverage requirement. Public TSDoc reframed
      around the guarantee that removal never alters unselected text, and the pinning test flipped
      from asserting the marker was dropped to asserting nothing changed. Removing either marker of a
      fully covered nested pair is unaffected.)_

Author response: Author asked for a reasoned conclusion drawn from the product requirements and the
implementation plan rather than accepting or dismissing the finding, then approved the recommendation
to refuse. Full reasoning is in Interview Notes; the decisive point is that the product decision was
to act on the innermost marker only, which makes this code path unreachable from the shipping UI.

### Important — Should address before merge

- [x] **A call that matched no marker still mutated the document before knowing there was anything
      to remove** — the loop ran `splitText` over every selected text node before any matching
      `CharNode` was resolved, contradicting the documented "Does nothing, without throwing."
      _(fixed during review: added a read-only `$hasCharNodeToRemove` pre-pass with an early return,
      and extracted `$getTargetNode`'s skip rule into a shared `$isSkippedByMarkerAction` so the
      pre-pass cannot drift from the loop it guards. The pre-pass deliberately omits
      `handleTextNode`'s zero-width filter, so it can only ever be more permissive — it can never
      wrongly refuse a removal that would otherwise have happened.)_
- [x] **`$createCharNodeLike` hand-rolled Lexical's `$copyNode`** — five manual property copies plus
      a node-state copy. _(fixed during review: replaced with `$copyNode`. Verified against the
      Lexical 0.43.0 source rather than taken on trust: `$copyNode` assigns a fresh key before
      `afterCloneFrom`, whose children copy is gated on matching keys, so the copy is childless; it
      unconditionally copies indent, format, style, direction and both text-style members; it carries
      node state via `getWritable`; and `resetOnCopyNode()` only clears state configs that opt in,
      which `charIdState` does not — so the char id survives. `CharNode.clone` carries the marker and
      unknown attributes. `$copyNode` skips `$applyNodeReplacement`, which is harmless here: the only
      registered replacement is `ParagraphNode → ImpliedParaNode`. Four imports became unused and
      were dropped. The pre-existing char-id/unknown-attributes identity test still passes, so this is
      confirmed by a falsifiable test and not only by reading source.)_
- [x] **A local predicate was a byte-identical fork of an exported shared one** — the new
      `$isSynthesizedMarkerNode` duplicated `$isParaMarkerPrefix` from `libs/shared` across a package
      boundary. _(fixed during review: renamed the shared function to `$isSynthesizedMarkerNode` —
      its docstring was already generic, only the name said "para" — generalized that docstring to
      cover character markers, deleted the local fork, and updated both call sites.
      `ParaMarkerPrefixGuardPlugin` keeps its name, since that concept genuinely is about
      paragraphs.)_
- [x] **Marker validation lived in the imperative handle and diverged from `insertMarker` on
      `extraValidMarkers`** — removal validated inline with `CharNode.isValidMarker(marker,
      extraValidMarkers)` while `insertMarker` delegates to `isUsjMarkerSupported`, which ignores the
      extras. Net effect: a project-supplied extra marker was removable but not insertable.
      _(fixed during review: added an exported `isCharacterMarkerSupported(marker,
      extraValidMarkers?)` beside `isUsjMarkerSupported`, documenting both deliberate divergences —
      stricter, because removal only ever targets a `CharNode`, and extras-aware. `Editor.tsx` now
      calls it and no longer imports `CharNode` at all. Nine new tests, including one that pins the
      asymmetry explicitly. No public API change.)_
- [ ] ~~The collaborative-editing path at `delta-apply-update.utils.ts:398,406` calls bare
      `$unwrapNode` on a `CharNode` with no marker stripping and no NBSP trim — the exact gap
      `$removeCharNodeKeepingContent` exists to close. Its placement in `packages/platform` means
      `libs/shared-react` cannot share it.~~ _(Pre-existing defect, neither introduced by nor
      reachable from this branch's code. Author agreed to record it for the reviewer rather than widen
      scope. Logged in Suggested Review Focus.)_

Author response: Author requested fixes for all four in-scope items and agreed the
collaborative-editing finding should be recorded as pre-existing rather than pulled into this branch.

### Minor — Consider

- [x] **Naming: the method was `removeCharMarker`**, which contradicted the project's preferred
      terminology ("character marker" over "char marker") and the seam paranext-core had already
      declared as `removeCharacterMarker`. Free to change now; breaking once paranext-core consumes
      it. _(fixed during review: renamed to `removeCharacterMarker` across `editor.model.ts`,
      `Editor.tsx`, `Marginal.tsx`, tests, and the regenerated API report;
      `$removeCharMarkerAtSelection` → `$removeCharacterMarkerAtSelection`; error messages and the
      test helper and describe block renamed to match. Pre-existing "char marker" strings in
      `usj-editor.adaptor.ts` and the scribe adaptors were deliberately left alone, to keep the diff
      to this change.)_
- [x] **Dead optional chain** at `Editor.tsx:318` — `nodeOptions?.extraValidMarkers`, where
      `nodeOptions` is `useMemo(() => nodes ?? defaultNodeOptions, [nodes])` and is never
      `undefined`; every other use in the file passes it without `?.`. _(fixed during review: folded
      into the `isCharacterMarkerSupported` change above.)_
- [x] **The exported entry point sat inside the private-helpers `#region`**, whose header had been
      widened to accommodate it. _(fixed during review, but NOT by hoisting the export as suggested —
      that would have broken the file's actual convention, which is "primary function immediately
      above its own helpers" (`getUsjMarkerAction` → `getMarkerAction`;
      `$wrapTextSelectionInInlineNode` → its helper region). Instead the wrap-helpers region is now
      closed before `$removeCharacterMarkerAtSelection`, and a second region opened for the removal
      helpers, so no exported function sits inside a block labelled "Helper functions". The widened
      first-region label was kept because it is now literally accurate — four of its helpers are
      genuinely shared by both the wrap and the unwrap paths.)_
- [x] **Over-long comment blocks** — a 12-line note justifying a guard the note itself argued was
      currently unreachable, and a ~24-line selection-restore note above a 9-line block. _(fixed
      during review: trimmed to 3 and 14 lines. The selection-restore note was restructured into
      three named traps — the `setTextContent` offset drift, capturing selection direction before
      mutation, and the stale-selection-object trap — each mapping to a line that looks removable but
      isn't. No documented behavior was dropped; all of it remains asserted by tests.)_
- [x] **Eight module-scope mutable test fixtures** reassigned across roughly 18 tests. _(fixed during
      review: the five used by a single test each were converted to locals, taking module scope from
      nine declarations down to four. The genuinely multi-test fixtures were kept. **Caveat flagged
      to the author:** this required introducing `let x!: TextNode;`, a definite-assignment assertion
      that appears nowhere else in this repo's tests — a plain local fails with `TS2454`, because the
      assignment happens inside a callback TypeScript cannot see through. Most of the benefit is
      readability rather than safety: the cross-test leakage hazard was already near-zero for
      single-use variables.)_
- [x] **No end-to-end test of the `Editor.tsx` wiring**, specifically that it forwards its view
      options as the third argument — a wrong or omitted argument would leave every adaptor-level test
      green while breaking marker stripping in the views that display markers. _(fixed during review:
      added `describe("removeCharacterMarker through the editor ref")` in `Editor.test.tsx`, driving
      the public ref end to end with markers displayed and asserting the text reads back with no
      leftover NBSP. Verified falsifiable: stubbing the view options to `undefined` makes it fail on
      the leftover NBSP while all 187 adaptor tests stay green. It also asserts a precondition that
      the NBSP was actually present, so it cannot pass vacuously.)_
- [x] **The README `EditorRef` table had no row for the new method.** _(fixed during review: added
      between `insertMarker` and `insertNote`, matching the interface's own grouping.)_
- [ ] ~~The `Marginal.tsx` pass-through is untested — typecheck proves the member exists, not that it
      delegates.~~ _(Pre-existing gap: no test file exists anywhere under
      `packages/platform/src/marginal/`, and `insertMarker`'s pass-through is equally untested. Author
      agreed that creating the directory's first-ever test file to assert one delegation is
      disproportionate, and that it is better logged for the reviewer.)_

Author response: Author requested fixes for every minor finding except the two recorded as
pre-existing, and asked that the region-placement item follow the file's own conventions rather than
the analysis agent's suggestion — which changed the fix that was made.

### Template Propagation

#### Shared Regions Modified

None. No `#region shared with` markers exist in any changed file.

#### Extension Config Changes

None. This repo has no `extensions/` directory, so extension-config propagation does not apply.

## Positive Observations

- The API change is strictly additive by construction, verifiable straight from the diff:
  `insertMarker`, `formatPara`, `applyUpdate`, `$unwrapTypedMarkNode`, and every annotation and
  comment path are untouched. That was an explicit acceptance criterion, since one editor package
  serves more than one product surface.
- The three binding design decisions made up front were all honored and are confirmable from the
  diff: call `$unwrapNode` directly rather than generalizing `$unwrapTypedMarkNode`; put the code in
  the existing `usj-marker-action.utils.ts` rather than a new `libs/shared-react` module; add zero
  new package-level exports.
- Test coverage substantially exceeds the required list: every required case is present and asserts
  content preservation, plus leading-only and trailing-only clone splits, identity copying,
  backward-selection direction preservation, empty-marker-placeholder handling, and both
  marker-display modes.
- The remaining documented limitation is pinned by a test asserting today's actual output with an
  explanatory comment, so a future fix trips the test rather than silently changing behavior.
- The marker-display test fixtures were built to mirror `usj-editor.adaptor.ts`'s `createChar` rather
  than guessed at, each with a comment tying it back to that function.
- Caret and selection restoration — the main user-visible risk in an operation like this — is handled
  deliberately: the collapsed branch compensates for the NBSP trim and clamps to range, the range
  branch preserves selection direction instead of normalizing to forward, and the selection is
  re-fetched to avoid a `TextNode.replace()` stale-selection trap. Restoring the range over the same
  characters means a toolbar caller can re-toggle without the user having to re-select.
- A real pre-existing bug was spotted and deliberately not copied: `CharNode.insertNewAfter` and
  `ParaNode.insertNewAfter` both pair `setStyle` with `getTextStyle()` — two different members —
  making their style copies silently inert. The comment recording this survives in
  `$createCharNodeLike`.
- Selections inside a footnote are skipped rather than partially handled, avoiding a confusing
  half-applied edit inside note content.
- No localization work needed: `packages/platform/src` has no i18n machinery and the only new strings
  are developer-facing `Error` messages. No new React components, so no Storybook stories apply. No
  build config, dependency, or workflow changes.

## Interview Notes

**Stated purpose**: add the editor-side character-marker removal capability described in the
character-level markers implementation plan, cross-referenced against paranext-core as the consumer.

**The author did not defer to AI on any finding, and did not express uncertainty about their own
code.** On the one genuinely ambiguous item — the nested-marker Critical — they explicitly declined to
either accept or dismiss it, and instead asked for a conclusion derived from the product requirements
and the implementation plan. That is the right instinct for a question the plan itself flags as
needing product sign-off, and is noted here as a positive rather than a gap.

**The nested-marker decision, and why it is the one item a reviewer should scrutinize.** The
recommendation to refuse rather than over-remove rests on four points, three of them independently
verifiable:

1. Nesting was deliberately taken out of scope. The product decision was to act on the **innermost
   marker only**; the richer "show every marker touching the selection" option — the one that would
   make nested markers individually addressable — was closed rather than deferred. Recursive
   splitting is exactly the work that decision excluded, and the appetite for this epic fixes time
   and flexes scope.
2. Shipping the over-removal was not sanctioned either. The plan's test list covers nested removal
   only for *fully covered* markers. It separately records that semantics for nested and
   partially-covered markers are still undecided and need a product decision, and names USFM
   semantics as an explicit stop-and-ask area requiring product sign-off rather than an engineering
   guess.
3. **Decisive, and verified in paranext-core rather than assumed**: the affected path is unreachable
   from the shipping UI. `resolveCurrentMarker` returns `undefined` whenever two or more markers cover
   the selection (`use-character-marker-state.hook.ts:79-80`), and the remove row renders only when a
   current marker is set (`character-marker-menu.utils.ts:125`). Every nested selection yields two or
   more covering markers — proven by that repo's own test "reports nested markers independently"
   (`character-marker-coverage.utils.test.ts:173-183`, which asserts `wj: 'all'` and `nd: 'partial'`).
   So the UI offers no removal at all in nested situations, and this behavioral change costs the
   feature nothing.
4. Refusing keeps the eventual recursive fix strictly additive. Shipping the over-removal would have
   made that later fix a behavior change on documents users had already edited.

**This remains a reading of an open product question, not a resolved one.** It is a one-line question
to the product owner, and refusing is the safe default while waiting. It should be confirmed in the
review meeting.

**Corrections made during the review, recorded because they changed the work:**

- The "a no-match call leaves the document split" framing used by three analysis agents was wrong in
  one respect, discovered while writing the test for it: Lexical's reconciliation re-merges adjacent
  simple text nodes, so the split was never observable in the resulting tree. The real cost was
  dirtying a node, which is what creates the undo entry and the collaborative-editing delta. The test
  asserts `dirtyLeaves.size === 0` accordingly. The first attempt at that test passed both with and
  without the fix — it was worthless — which is how the re-merging behavior surfaced.
- The region-placement suggestion was not followed, because scanning the file showed its convention is
  "primary function, then its own helpers", not "all exports at the top". Following the suggestion
  would have broken the pattern rather than restored it.

**Incidental discovery, out of scope but worth a look:** the first version of the end-to-end test used
the public `setSelection()` with a USJ json path covering a marked run fully, and got back
`["the Lor", {char nd content:["d"]}, " said"]` — three of four characters. With markers displayed,
the USJ-to-editor range mapping appears to shift the start offset past the NBSP but not the end. That
lives in `$getRangeFromUsjSelection`, which this branch does not touch, so it is a **possible
pre-existing off-by-one** rather than a regression. The test was rewritten to select through the
Lexical editor instead. Not investigated further.

## In-Review Quality Check

All checks were run after the in-review changes, across the whole workspace rather than only the
touched projects, because the changes reached `libs/shared`:

- `nx run-many -t typecheck lint test` — **passed for all 10 projects.** 1,633 tests passing
  (`platform-editor` 188, `shared-react` 1,322, `shared` 123), 3 skipped.
- `nx run-many -t build extract-api` — **passed for all 10 projects.** Two pre-existing
  `Unexpected ")"` CSS warnings, unrelated to these files.
- API report drift — **none.** Running `nx extract-api` after all the renames leaves `git diff` empty
  on `packages/*/etc/`, confirming the report is generated rather than hand-edited. This also closes
  the compliance analysis pass's one caveat, which had verified the report by inspection only.
- `prettier --check` on every changed file — **clean.**

Two issues were caught by the checks rather than by review, and fixed:

- `typecheck` flagged `.select()` on an un-narrowed `.find()` result in the new end-to-end test —
  invisible to the test run, since vitest does not typecheck. Fixed with an explicit type guard.
- The new test's node lookup initially matched the opening `\nd` marker node instead of the content,
  because `MarkerNode extends TextNode`. Fixed using the newly generalized
  `$isSynthesizedMarkerNode` — incidental confirmation that promoting that predicate to `libs/shared`
  was the right call.

No unfixable failures.

## Suggested Review Focus

- [ ] **The nested partial-coverage decision (highest priority).** Removing an outer marker across a
      partially covered nested marked run is now refused. This is a reasoned reading of an open
      product question about nested and partially-covered marker semantics, which the plan itself says
      needs product sign-off. Confirm with the product owner. Alternatives considered and rejected:
      over-remove (silently edits unselected text) and recursive splitting (outside the appetite, and
      the scope the innermost-marker-only decision excluded).
- [ ] **Whether "refuse" should be silent or throw.** It is currently a silent no-op, consistent with
      the method's existing behavior when the requested marker is not present, on the grounds that an
      unsupported document shape is not a programmer error. A `@throws` would be louder and
      caller-detectable. Unreachable from today's UI either way.
- [ ] **The same rule will need to bind the follow-on replace and extend work**, which share this file
      and the same splitting path. Settling it now gives those a consistent contract.
- [ ] **Pre-existing collaborative-editing gap** (`delta-apply-update.utils.ts:398,406`): bare
      `$unwrapNode` on a `CharNode`, with no marker stripping or NBSP trim. In the views that display
      markers, a remotely-applied marker removal leaves a literal `\nd`/`\nd*` and a stray NBSP.
      Out of scope here; worth its own ticket, and worth deciding whether
      `$removeCharNodeKeepingContent` should move to `libs/shared` so both paths share one
      implementation.
- [ ] **Possible pre-existing off-by-one in the USJ-to-editor range mapping** when markers are
      displayed (see Interview Notes). A full-coverage USJ range over a marked run resolved to three
      of four characters. Not investigated; may warrant its own ticket.
- [ ] **The remaining documented limitation**: in the views that display markers, a selection strictly
      inside a marked run leaves an unpaired `\nd`/`\nd*` visible, because only the covered clone is
      stripped. Presentation-only — it is excluded from USJ export and self-corrects on the next load
      — but user-visible, and the upcoming UI work will expose it. Decide whether it needs a tracked
      follow-up referenced from the docstring.
- [ ] **The `Marginal.tsx` pass-through and `insertMarker` are both untested** (no test file exists
      under `src/marginal/`). Pre-existing; decide whether that directory should get its first test
      file.
- [ ] **New idiom in tests**: `let x!: TextNode;` was introduced in five places to convert single-use
      module-scope fixtures into locals. It appears nowhere else in this repo's tests. Confirm the
      style is acceptable, or revert that one change.
<!-- review-paratext:summary:end -->

AI-assisted — session: <session URL>

---



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/529)
<!-- Reviewable:end -->

