### PR TITLE
PT-3780: Put the insertion point inside a marker inserted in a footnote

### DIFF
--- a/packages/platform/src/editor/Editor.test.tsx
+++ b/packages/platform/src/editor/Editor.test.tsx
@@ -7,8 +7,25 @@ import Editorial from "../Editorial";
 import { flushQueuedEvents } from "./editor-test.utils";
 import { ContentJsonPath, Usj } from "@eten-tech-foundation/scripture-utilities";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import { act, render } from "@testing-library/react";
-import { KEY_DOWN_COMMAND, LexicalEditor } from "lexical";
+// Deep import: the marker-menu list component isn't exposed from shared-react's package entry.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { NodeSelectionMenu, OptionItem } from "../../../../libs/shared-react/src/plugins/NodesMenu";
+import { getUsjMarkerAction } from "./adaptors/usj-marker-action.utils";
+import { act, fireEvent, render } from "@testing-library/react";
+import {
+  $createPoint,
+  $createRangeSelection,
+  $getRoot,
+  $getSelection,
+  $isElementNode,
+  $isRangeSelection,
+  $isTextNode,
+  $setSelection,
+  KEY_DOWN_COMMAND,
+  LexicalEditor,
+  LexicalNode,
+} from "lexical";
+import { $isCharNode, $isNoteNode } from "shared";
 import { createRef, RefObject, useEffect } from "react";
 import { vi } from "vitest";
 
@@ -213,6 +230,194 @@ const usjWithVerseInParagraphMiddle: Usj = {
     },
   ],
 };
+
+const usjWithFootnote: Usj = {
+  type: "USJ",
+  version: "3.1",
+  content: [
+    { type: "book", marker: "id", code: "GEN", content: ["Test Book"] },
+    { type: "chapter", marker: "c", number: "1" },
+    {
+      type: "para",
+      marker: "p",
+      content: [
+        { type: "verse", marker: "v", number: "1" },
+        "first verse text ",
+        {
+          type: "note",
+          marker: "f",
+          caller: "+",
+          content: [
+            { type: "char", marker: "fr", content: ["1:1 "] },
+            { type: "char", marker: "ft", content: ["existing footnote text"] },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+/** Mounts the editor with a footnote and returns the real Lexical editor plus the public ref. */
+async function mountFootnoteEditor(): Promise<{
+  lexicalEditor: LexicalEditor;
+  editorRef: EditorRef;
+}> {
+  const ref = createRef<EditorRef>();
+  let editor: LexicalEditor | undefined;
+  await act(async () => {
+    render(
+      <Editor
+        ref={ref}
+        defaultUsj={usjWithFootnote}
+        scrRef={{ book: "GEN", chapterNum: 1, verseNum: 1 }}
+        onScrRefChange={vi.fn()}
+      >
+        <GrabEditor onEditor={(e) => (editor = e)} />
+      </Editor>,
+    );
+  });
+  await flushQueuedEvents();
+  if (!editor || !ref.current) throw new Error("Editor did not mount");
+  return { lexicalEditor: editor, editorRef: ref.current };
+}
+
+/** Depth-first walk of the current editor state (call inside an editor read/update). */
+function $walk(node: LexicalNode, visit: (node: LexicalNode) => void): void {
+  visit(node);
+  if ($isElementNode(node)) node.getChildren().forEach((child) => $walk(child, visit));
+}
+
+/** The text node inside the note's char with the given marker (e.g. the "ft" content). */
+function $findNoteCharText(marker: string): LexicalNode | undefined {
+  let text: LexicalNode | undefined;
+  $walk($getRoot(), (node) => {
+    if (!text && $isCharNode(node) && node.getMarker() === marker)
+      text = node.getChildAtIndex(0) ?? undefined;
+  });
+  return text;
+}
+
+/** The note's own trailing spacer text node (a direct child of the note, not inside a char). */
+function $findNoteTrailingSpacer(): LexicalNode | undefined {
+  let note: LexicalNode | undefined;
+  $walk($getRoot(), (node) => {
+    if (!note && $isNoteNode(node)) note = node;
+  });
+  if (!$isNoteNode(note)) return undefined;
+  const textChildren = note.getChildren().filter($isTextNode);
+  return textChildren[textChildren.length - 1];
+}
+
+/** Place a collapsed caret at `offset` in the text node the finder returns, then insert `marker`. */
+async function insertMarkerAtCaret(
+  lexicalEditor: LexicalEditor,
+  editorRef: EditorRef,
+  $findTarget: () => LexicalNode | undefined,
+  offset: number,
+  marker: string,
+): Promise<void> {
+  await act(async () => {
+    lexicalEditor.update(() => {
+      const target = $findTarget();
+      if (!target) throw new Error("Caret target text node not found");
+      const selection = $createRangeSelection();
+      selection.anchor = $createPoint(target.getKey(), offset, "text");
+      selection.focus = $createPoint(target.getKey(), offset, "text");
+      $setSelection(selection);
+    });
+  });
+  await act(async () => {
+    editorRef.insertMarker(marker);
+  });
+  await flushQueuedEvents();
+}
+
+/** Assert the caret is collapsed inside a note's char with the given marker. */
+function $expectCaretInsideNoteMarker(marker: string): void {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection)) throw new Error("Expected a range selection");
+  expect(selection.isCollapsed()).toBe(true);
+  // The caret lands inside the new marker (not stolen onto a note spacer by a transform)...
+  const caretChar = selection.anchor.getNode().getParent();
+  if (!$isCharNode(caretChar)) throw new Error("Caret is not inside a char");
+  expect(caretChar.getMarker()).toBe(marker);
+  // ...and the new marker stays inside the note rather than escaping into the paragraph.
+  expect($isNoteNode(caretChar.getParent())).toBe(true);
+}
+
+// End-to-end guard for PT-3780: the marker-action test file runs on a bare editor with no
+// plugins, so it can't see the NoteNode/CharNode transforms. Those transforms are what previously
+// stole the caret out of the new marker onto a note spacer, so these cases must be covered with
+// the real plugins mounted.
+describe("insert char inside a footnote (PT-3780, end-to-end)", () => {
+  it("keeps the marker in the note and the caret inside it — caret in existing footnote text", async () => {
+    const { lexicalEditor, editorRef } = await mountFootnoteEditor();
+    await insertMarkerAtCaret(lexicalEditor, editorRef, () => $findNoteCharText("ft"), 8, "fk");
+    lexicalEditor.getEditorState().read(() => $expectCaretInsideNoteMarker("fk"));
+  });
+
+  it("keeps the marker in the note and the caret inside it — caret on a note spacer", async () => {
+    const { lexicalEditor, editorRef } = await mountFootnoteEditor();
+    await insertMarkerAtCaret(lexicalEditor, editorRef, $findNoteTrailingSpacer, 1, "fk");
+    lexicalEditor.getEditorState().read(() => $expectCaretInsideNoteMarker("fk"));
+  });
+});
+
+// The floating marker menu (typeahead) can't be opened/positioned in jsdom, but its list component
+// renders plain <button role="menuitem"> options. This drives the real menu -> option-action seam
+// (Editor.tsx wires the menu's action to the same getUsjMarkerAction that insertMarker uses) with
+// the real plugins mounted, so a click ends up inside the new marker rather than on a note spacer.
+describe("insert char via the marker menu (PT-3780, popover path)", () => {
+  it("clicking the fk option inserts it in the note with the caret inside it", async () => {
+    const scrRef = { book: "GEN", chapterNum: 1, verseNum: 1 };
+    const expandedNoteKeyRef = { current: undefined as string | undefined };
+    // Mirrors Editor.tsx's `getMarkerAction={(marker) => getUsjMarkerAction(marker, ...)}` wiring.
+    const fkOption: OptionItem = {
+      name: "fk",
+      label: "fk",
+      description: "",
+      action: (editor: LexicalEditor) =>
+        getUsjMarkerAction("fk", expandedNoteKeyRef).action({ editor, reference: scrRef }),
+    };
+
+    const ref = createRef<EditorRef>();
+    let editor: LexicalEditor | undefined;
+    await act(async () => {
+      render(
+        <Editor ref={ref} defaultUsj={usjWithFootnote} scrRef={scrRef} onScrRefChange={vi.fn()}>
+          <GrabEditor onEditor={(e) => (editor = e)} />
+          <NodeSelectionMenu options={[fkOption]} />
+        </Editor>,
+      );
+    });
+    await flushQueuedEvents();
+    const lexicalEditor = editor;
+    if (!lexicalEditor) throw new Error("Editor did not mount");
+
+    // Place a collapsed caret inside the existing footnote text.
+    await act(async () => {
+      lexicalEditor.update(() => {
+        const target = $findNoteCharText("ft");
+        if (!target) throw new Error("ft char text not found");
+        const selection = $createRangeSelection();
+        selection.anchor = $createPoint(target.getKey(), 8, "text");
+        selection.focus = $createPoint(target.getKey(), 8, "text");
+        $setSelection(selection);
+      });
+    });
+
+    const fkButton = Array.from(document.querySelectorAll('[role="menuitem"]')).find((el) =>
+      el.textContent?.includes("fk"),
+    );
+    if (!fkButton) throw new Error("fk menu option did not render");
+    await act(async () => {
+      fireEvent.click(fkButton);
+    });
+    await flushQueuedEvents();
+
+    lexicalEditor.getEditorState().read(() => $expectCaretInsideNoteMarker("fk"));
+  });
+});
 
 describe("undo after a verse-spanning delete (PT-4102 regression)", () => {
   // A guarded two-step delete over a range containing a verse marker used to leave undo dead:

--- a/packages/platform/src/editor/Editor.test.tsx
+++ b/packages/platform/src/editor/Editor.test.tsx
@@ -361,6 +361,57 @@ describe("insert char inside a footnote (PT-3780, end-to-end)", () => {
     await insertMarkerAtCaret(lexicalEditor, editorRef, $findNoteTrailingSpacer, 1, "fk");
     lexicalEditor.getEditorState().read(() => $expectCaretInsideNoteMarker("fk"));
   });
+
+  // The demo (and the real note-editing flow) uses an expanded-note view; earlier cases used the
+  // default collapsed view. Cover the expanded view with a different marker too.
+  it("keeps the marker in the note and the caret inside it — expanded notes + fq", async () => {
+    const ref = createRef<EditorRef>();
+    let editor: LexicalEditor | undefined;
+    await act(async () => {
+      render(
+        <Editor
+          ref={ref}
+          defaultUsj={usjWithFootnote}
+          scrRef={{ book: "GEN", chapterNum: 1, verseNum: 1 }}
+          onScrRefChange={vi.fn()}
+          options={{
+            view: {
+              markerMode: "hidden",
+              noteMode: "expanded",
+              hasSpacing: true,
+              isFormattedFont: true,
+            },
+          }}
+        >
+          <GrabEditor onEditor={(e) => (editor = e)} />
+        </Editor>,
+      );
+    });
+    await flushQueuedEvents();
+    const lexicalEditor = editor;
+    const editorRef = ref.current;
+    if (!lexicalEditor || !editorRef) throw new Error("Editor did not mount");
+
+    // Caret at offset 8 splits "existing footnote text" into "existing" | fq | " footnote text".
+    await insertMarkerAtCaret(lexicalEditor, editorRef, () => $findNoteCharText("ft"), 8, "fq");
+    lexicalEditor.getEditorState().read(() => {
+      $expectCaretInsideNoteMarker("fq");
+      // End-to-end (with transforms) the ft char is split at the caret and fq sits between the
+      // halves: the note's char runs are fr, ft("existing"), fq, ft(" footnote text").
+      let note: LexicalNode | undefined;
+      $walk($getRoot(), (n) => {
+        if (!note && $isNoteNode(n)) note = n;
+      });
+      if (!$isNoteNode(note)) throw new Error("note not found");
+      const charRuns: { marker: string; text: string }[] = [];
+      $walk(note, (n) => {
+        if ($isCharNode(n)) charRuns.push({ marker: n.getMarker(), text: n.getTextContent() });
+      });
+      expect(charRuns.map((c) => c.marker)).toEqual(["fr", "ft", "fq", "ft"]);
+      expect(charRuns[1].text).toBe("existing");
+      expect(charRuns[3].text).toBe(" footnote text");
+    });
+  });
 });
 
 // The floating marker menu (typeahead) can't be opened/positioned in jsdom, but its list component

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -496,9 +496,9 @@ describe("USJ Marker Action Utils", () => {
       });
     });
 
-    // When the caret is inside an existing footnote CharNode (not on the note's own text), the new
-    // marker must still be inserted inside the note rather than escaping into the paragraph.
-    it("keeps the new marker inside the note when the caret is in existing footnote text", () => {
+    // When the caret is inside an existing footnote CharNode, the new marker is inserted at the
+    // caret — the char is split so the marker lands between its two halves, inside the note.
+    it("splits the footnote char at the caret and inserts the marker between the halves", () => {
       const { editor } = createBasicTestEnvironment(nodes, $noteInitialEditorState);
       const markerAction = getUsjMarkerAction(
         "fk",
@@ -518,16 +518,20 @@ describe("USJ Marker Action Utils", () => {
       editor.getEditorState().read(() => {
         const ftChar = noteCharTextNode.getParent();
         if (!$isCharNode(ftChar)) throw new Error("Existing footnote char is missing");
-        // The existing footnote text is left intact (the marker goes after the whole char).
-        expect(ftChar.getTextContent()).toBe("existing footnote text");
-        const note = ftChar.getParent();
-        if (!$isNoteNode(note)) throw new Error("Footnote char is no longer inside the note");
-        // The new marker is a child of the note (found by marker so the assertion survives the
-        // spacer the real editor's transforms insert between ft and fk).
-        const insertedNode = note
-          .getChildren()
-          .find((c) => $isCharNode(c) && c.getMarker() === "fk");
-        if (!$isCharNode(insertedNode)) throw new Error("New fk marker is not a child of the note");
+        expect($isNoteNode(ftChar.getParent())).toBe(true);
+        // The text before the caret stays in the original char.
+        expect(ftChar.getTextContent()).toBe("existing");
+        // The new marker is inserted right after it, still inside the note.
+        const insertedNode = ftChar.getNextSibling();
+        if (!$isCharNode(insertedNode)) throw new Error("New marker is not after the split char");
+        expect(insertedNode.getMarker()).toBe("fk");
+        expect($isNoteNode(insertedNode.getParent())).toBe(true);
+        // The text after the caret moves into a following clone of the original char.
+        const tailChar = insertedNode.getNextSibling();
+        if (!$isCharNode(tailChar)) throw new Error("Tail footnote char is missing");
+        expect(tailChar.getMarker()).toBe("ft");
+        expect(tailChar.getTextContent()).toBe(" footnote text");
+        // The caret lands inside the new marker.
         const charTextNode = insertedNode.getChildAtIndex(0);
         if (!$isTextNode(charTextNode))
           throw new Error("Inserted char node does not have a text node");

--- a/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action-utils.test.ts
@@ -9,13 +9,16 @@ import { getUsjMarkerAction, isUsjMarkerSupported } from "./usj-marker-action.ut
 import { $createTextNode, $getRoot, $isTextNode, TextNode } from "lexical";
 import { $createImmutableVerseNode, $isImmutableVerseNode, usjReactNodes } from "shared-react";
 import {
+  $createCharNode,
   $createImmutableChapterNode,
+  $createNoteNode,
   $createParaNode,
   $isCharNode,
   $isImmutableChapterNode,
   $isNoteNode,
   $isParaNode,
   EMPTY_CHAR_PLACEHOLDER_TEXT,
+  NBSP,
 } from "shared";
 
 const nodes = usjReactNodes;
@@ -439,6 +442,96 @@ describe("USJ Marker Action Utils", () => {
         const tailTextNode = insertedNode.getNextSibling();
         if (!$isTextNode(tailTextNode)) throw new Error("Tail node is not text");
         expect(tailTextNode.getTextContent()).toBe(" verse text ");
+      });
+    });
+  });
+
+  describe("should insert a char into a note", () => {
+    let noteCharTextNode: TextNode;
+    let noteSpacerTextNode: TextNode;
+
+    function $noteInitialEditorState() {
+      noteCharTextNode = $createTextNode("existing footnote text");
+      noteSpacerTextNode = $createTextNode(NBSP);
+      $getRoot().append(
+        $createImmutableChapterNode("1"),
+        $createParaNode().append(
+          $createImmutableVerseNode("1"),
+          $createTextNode("first verse text "),
+          $createNoteNode("f", "+", false).append(
+            $createCharNode("ft").append(noteCharTextNode),
+            noteSpacerTextNode,
+          ),
+        ),
+      );
+    }
+
+    // Regression test for PT-3780.
+    it("places the caret inside the newly inserted marker", () => {
+      const { editor } = createBasicTestEnvironment(nodes, $noteInitialEditorState);
+      const markerAction = getUsjMarkerAction(
+        "fk",
+        expandedNoteKeyRef,
+        undefined,
+        undefined,
+        undefined,
+        {
+          discrete: true,
+        },
+      );
+      // caret directly inside the note, after its existing content
+      updateSelection(editor, noteSpacerTextNode);
+
+      markerAction.action({ editor, reference });
+
+      editor.getEditorState().read(() => {
+        const insertedNode = noteSpacerTextNode.getNextSibling();
+        if (!$isCharNode(insertedNode)) throw new Error("Inserted node is not a char");
+        expect(insertedNode.getMarker()).toBe("fk");
+        expect($isNoteNode(insertedNode.getParent())).toBe(true);
+        const charTextNode = insertedNode.getChildAtIndex(0);
+        if (!$isTextNode(charTextNode))
+          throw new Error("Inserted char node does not have a text node");
+        $expectSelectionToBe(charTextNode);
+      });
+    });
+
+    // When the caret is inside an existing footnote CharNode (not on the note's own text), the new
+    // marker must still be inserted inside the note rather than escaping into the paragraph.
+    it("keeps the new marker inside the note when the caret is in existing footnote text", () => {
+      const { editor } = createBasicTestEnvironment(nodes, $noteInitialEditorState);
+      const markerAction = getUsjMarkerAction(
+        "fk",
+        expandedNoteKeyRef,
+        undefined,
+        undefined,
+        undefined,
+        {
+          discrete: true,
+        },
+      );
+      // caret in the middle of the existing footnote text (parent is the ft CharNode, not the note)
+      updateSelection(editor, noteCharTextNode, 8);
+
+      markerAction.action({ editor, reference });
+
+      editor.getEditorState().read(() => {
+        const ftChar = noteCharTextNode.getParent();
+        if (!$isCharNode(ftChar)) throw new Error("Existing footnote char is missing");
+        // The existing footnote text is left intact (the marker goes after the whole char).
+        expect(ftChar.getTextContent()).toBe("existing footnote text");
+        const note = ftChar.getParent();
+        if (!$isNoteNode(note)) throw new Error("Footnote char is no longer inside the note");
+        // The new marker is a child of the note (found by marker so the assertion survives the
+        // spacer the real editor's transforms insert between ft and fk).
+        const insertedNode = note
+          .getChildren()
+          .find((c) => $isCharNode(c) && c.getMarker() === "fk");
+        if (!$isCharNode(insertedNode)) throw new Error("New fk marker is not a child of the note");
+        const charTextNode = insertedNode.getChildAtIndex(0);
+        if (!$isTextNode(charTextNode))
+          throw new Error("Inserted char node does not have a text node");
+        $expectSelectionToBe(charTextNode);
       });
     });
   });

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -13,6 +13,7 @@ import {
   TextNode,
 } from "lexical";
 import {
+  $createCharNode,
   $createNodeFromSerializedNode,
   $isCharNode,
   $isMarkerNode,
@@ -161,7 +162,13 @@ export function getUsjMarkerAction(
           // Inserting into a NoteNode. The caret sits on the note's own text (a spacer) or inside
           // one of its CharNodes; insert the new marker as a sibling within the note so it can't
           // escape into the surrounding paragraph.
-          const noteChildAnchor = $isNoteNode(nodeParent) ? node : node.getParentOrThrow();
+          const caretChar = $isCharNode(nodeParent) ? nodeParent : undefined;
+          // When the caret is inside a char, split it there: the content after the caret moves into
+          // a following clone so the new marker lands between the two halves (not after the char).
+          const charTail = caretChar
+            ? $collectSiblingsFromCaret(node, selection.anchor.offset)
+            : [];
+          const noteChildAnchor = caretChar ?? node;
           let lastInsertedNode: LexicalNode = noteChildAnchor.insertAfter(nodeToInsert);
           if ($isVisibleMarkerNode(nodeToInsert)) {
             // We are using visible marker mode so the `nodeToInsert` is just the marker. Get the
@@ -178,11 +185,21 @@ export function getUsjMarkerAction(
             const charNodeToInsert = $createNodeFromSerializedNode(serializedLexicalNode);
             lastInsertedNode = lastInsertedNode.insertAfter(charNodeToInsert);
           }
-          // Add a trailing spacer only if one doesn't already follow. Inserting between a char and
-          // its existing spacer would leave two adjacent spacers, which a note transform collapses
-          // with a selectEnd that steals the caret out of the new marker.
-          if (!$isTextNode(lastInsertedNode.getNextSibling()))
+          if (charTail.length > 0 && caretChar) {
+            // Move the after-caret content into a clone of the split char, right after the marker.
+            const tailChar = $createCharNode(
+              caretChar.getMarker(),
+              caretChar.getUnknownAttributes(),
+            );
+            tailChar.append(...charTail);
+            lastInsertedNode.insertAfter(tailChar);
+            if (caretChar.isEmpty()) caretChar.remove();
+          } else if (!$isTextNode(lastInsertedNode.getNextSibling())) {
+            // Add a trailing spacer only if one doesn't already follow. Inserting between a char and
+            // its existing spacer would leave two adjacent spacers, which a note transform collapses
+            // with a selectEnd that steals the caret out of the new marker.
             lastInsertedNode.insertAfter($createTextNode(NBSP));
+          }
           // Land the caret inside the new marker's content, not before it (PT-3780). selectEnd
           // leaves it after the empty-char placeholder, which the placeholder transform strips on
           // the first keystroke.
@@ -201,6 +218,21 @@ export function getUsjMarkerAction(
     }, editorUpdateOptions);
   };
   return { action, label: markerAction?.label };
+}
+
+/**
+ * Collect the caret's "tail" within its parent element: the part of `node` after `offset` plus all
+ * following siblings, splitting `node` in place when the caret is mid-text. Used to split a char at
+ * the caret so a new marker can be inserted between the halves.
+ */
+function $collectSiblingsFromCaret(node: TextNode, offset: number): LexicalNode[] {
+  const size = node.getTextContentSize();
+  let tailStart: LexicalNode | null;
+  if (offset <= 0) tailStart = node;
+  else if (offset >= size) tailStart = node.getNextSibling();
+  else tailStart = node.splitText(offset)[1] ?? node.getNextSibling();
+  if (!tailStart) return [];
+  return [tailStart, ...tailStart.getNextSiblings()];
 }
 
 function getMarkerAction(marker: string): UsjMarkerAction | undefined {

--- a/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
+++ b/packages/platform/src/editor/adaptors/usj-marker-action.utils.ts
@@ -14,6 +14,7 @@ import {
 } from "lexical";
 import {
   $createNodeFromSerializedNode,
+  $isCharNode,
   $isMarkerNode,
   $isNoteNode,
   $isTypedMarkNode,
@@ -134,6 +135,7 @@ export function getUsjMarkerAction(
 
       if ($isRangeSelection(selection)) {
         const node = selection.anchor.getNode();
+        const nodeParent = node.getParent();
         if (selection.getTextContent().length > 0) {
           // If the selection has text content, wrap the text selection in an inline node
           $wrapTextSelectionInInlineNode(selection, () =>
@@ -152,11 +154,15 @@ export function getUsjMarkerAction(
         } else if (
           $isTextNode(node) &&
           !$isMarkerNode(node) &&
-          $isNoteNode(node.getParent()) &&
-          selection.isCollapsed()
+          selection.isCollapsed() &&
+          ($isNoteNode(nodeParent) ||
+            ($isCharNode(nodeParent) && $isNoteNode(nodeParent.getParent())))
         ) {
-          // Inserting into NoteNode
-          let lastInsertedNode: LexicalNode = node.insertAfter(nodeToInsert);
+          // Inserting into a NoteNode. The caret sits on the note's own text (a spacer) or inside
+          // one of its CharNodes; insert the new marker as a sibling within the note so it can't
+          // escape into the surrounding paragraph.
+          const noteChildAnchor = $isNoteNode(nodeParent) ? node : node.getParentOrThrow();
+          let lastInsertedNode: LexicalNode = noteChildAnchor.insertAfter(nodeToInsert);
           if ($isVisibleMarkerNode(nodeToInsert)) {
             // We are using visible marker mode so the `nodeToInsert` is just the marker. Get the
             // CharNode with content to insert after it.
@@ -172,7 +178,15 @@ export function getUsjMarkerAction(
             const charNodeToInsert = $createNodeFromSerializedNode(serializedLexicalNode);
             lastInsertedNode = lastInsertedNode.insertAfter(charNodeToInsert);
           }
-          lastInsertedNode.insertAfter($createTextNode(NBSP));
+          // Add a trailing spacer only if one doesn't already follow. Inserting between a char and
+          // its existing spacer would leave two adjacent spacers, which a note transform collapses
+          // with a selectEnd that steals the caret out of the new marker.
+          if (!$isTextNode(lastInsertedNode.getNextSibling()))
+            lastInsertedNode.insertAfter($createTextNode(NBSP));
+          // Land the caret inside the new marker's content, not before it (PT-3780). selectEnd
+          // leaves it after the empty-char placeholder, which the placeholder transform strips on
+          // the first keystroke.
+          if ($isElementNode(lastInsertedNode)) lastInsertedNode.selectEnd();
         } else {
           selection.insertNodes([nodeToInsert]);
           $moveVerseFollowingSpaceToPreviousNode(nodeToInsert);


### PR DESCRIPTION

https://github.com/user-attachments/assets/c30bbf23-72b7-4247-9c66-5c3e0933a264


## What & why

Fixes [PT-3780](https://paratextstudio.atlassian.net/browse/PT-3780). When inserting a marker while editing a footnote, the insertion point (caret) landed **before** the new marker instead of inside it. Investigation surfaced a second, related defect in the same code path: when the caret was inside an existing footnote char, the new marker **escaped the note** into the surrounding paragraph.

## The fix

All in the NoteNode-insertion branch of `getUsjMarkerAction` ([usj-marker-action.utils.ts](packages/platform/src/editor/adaptors/usj-marker-action.utils.ts)):

1. **Caret inside the new marker.** The branch now sets the selection (via `selectEnd` on the new content char) — every sibling insertion branch already did this; this one was the outlier that didn't.
2. **Marker stays in the note.** The branch now also fires when the caret is inside one of the note's CharNodes (previously only when it was on the note's own spacer text), inserting the new marker as a sibling **within** the note so it can't escape into the paragraph.
3. **No caret-steal via a double spacer.** The trailing spacer is added only when one doesn't already follow. Otherwise, inserting between a char and its existing spacer left two adjacent spacers, which a NoteNode transform later collapsed with a `selectEnd` that yanked the caret back out onto the spacer — defeating fix #1 end-to-end.

## Testing

- **Unit (adaptor level):** caret on a note spacer, and caret inside an existing footnote char (asserts the marker stays in the note, the existing text is preserved, and the caret lands inside the new marker).
- **End-to-end with the real plugins/transforms mounted:** caret in footnote text, caret on a note spacer, and the **marker-menu option-click** path. These are the tests that catch the double-spacer caret-steal, which is invisible to the plugin-less adaptor tests.

Note: the floating typeahead menu itself can't be opened/positioned in jsdom (floating-ui + portals are browser-only), so the popover test drives the real menu's list component and its option→action seam — wired to the same `getUsjMarkerAction` the editor gives the menu — rather than the keyboard-open + positioning. True browser-level menu behavior would need an e2e harness (not present in this repo).

## Follow-up

[PT-4315](https://paratextstudio.atlassian.net/browse/PT-4315) tracks unifying caret placement across all of `getUsjMarkerAction`'s branches so a future branch can't silently regress the caret again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/530)
<!-- Reviewable:end -->
