### PR TITLE
fix(platform): apply annotations issued while a load is in flight

### DIFF
--- a/libs/shared-react/src/plugins/usj/LoadStatePlugin.tsx
+++ b/libs/shared-react/src/plugins/usj/LoadStatePlugin.tsx
@@ -20,6 +20,7 @@ export function LoadStatePlugin<TLogger extends LoggerBasic>({
   nodeOptions,
   editorAdaptor,
   viewOptions,
+  onLoadingChange,
   logger,
 }: {
   scripture?: unknown;
@@ -27,6 +28,16 @@ export function LoadStatePlugin<TLogger extends LoggerBasic>({
   nodeOptions?: NodeOptions;
   editorAdaptor: EditorAdaptor;
   viewOptions?: unknown;
+  /**
+   * Called `true` when a load starts and `false` once it settles — committed, skipped (nothing to
+   * serialize), or failed. Calls are always balanced, so a caller may count them, and `false` is
+   * never reported before the loaded document is live. Use it to defer work that has to address
+   * the loaded content.
+   *
+   * Must be referentially stable (e.g. `useCallback` with stable dependencies): it is a dependency
+   * of the load effect, so a fresh identity each render would reload the document each render.
+   */
+  onLoadingChange?: (isLoading: boolean) => void;
   logger?: TLogger;
 }): null {
   const [editor] = useLexicalComposerContext();
@@ -40,32 +51,63 @@ export function LoadStatePlugin<TLogger extends LoggerBasic>({
     // otherwise fall back to the prop value
     const currentScripture = scriptureRef?.current ?? scripture;
 
-    editorAdaptor.reset?.();
-    const serializedEditorState = editorAdaptor.serializeEditorState(currentScripture, viewOptions);
-    if (serializedEditorState == null) {
-      logger?.warn(
-        "LoadStatePlugin: serializedEditorState was null or undefined. Skipping editor update.",
-      );
-      return;
-    }
+    onLoadingChange?.(true);
+    // Every exit from this effect must report `false` exactly once, including a throw out of the
+    // adaptor — otherwise a caller that gates work on the load waits forever.
+    let settled = false;
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      onLoadingChange?.(false);
+    };
+    // Set once the commit path owns settling (it reports from its own microtask, after the
+    // loaded document is live); until then the `finally` below is responsible.
+    let settlesAfterCommit = false;
 
     try {
+      editorAdaptor.reset?.();
+      const serializedEditorState = editorAdaptor.serializeEditorState(
+        currentScripture,
+        viewOptions,
+      );
+      if (serializedEditorState == null) {
+        logger?.warn(
+          "LoadStatePlugin: serializedEditorState was null or undefined. Skipping editor update.",
+        );
+        return;
+      }
+
       const editorState = editor.parseEditorState(serializedEditorState);
+      settlesAfterCommit = true;
       // Use queueMicrotask to defer the editor update outside of React's lifecycle,
       // preventing flushSync warnings when this is triggered by a parent component update
       queueMicrotask(() => {
-        editor.update(
-          () => {
-            editor.setEditorState(editorState);
-            editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
-          },
-          { tag: EXTERNAL_USJ_MUTATION_TAG },
-        );
+        try {
+          editor.update(
+            () => {
+              editor.setEditorState(editorState);
+              editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
+            },
+            { tag: EXTERNAL_USJ_MUTATION_TAG },
+          );
+          // Deliberately NOT the update's `onUpdate` option: `setEditorState` runs an intermediate
+          // commit of the OUTGOING state from inside the update, and that commit drains Lexical's
+          // deferred callbacks — so `onUpdate` fires while the old document is still installed.
+          // Lexical schedules the real commit with its own microtask before `update` returns, so a
+          // microtask queued here lands strictly after the loaded document is live.
+          queueMicrotask(settle);
+        } catch {
+          logger?.error("LoadStatePlugin: error setting editor state.");
+          settle();
+        }
       });
     } catch {
       logger?.error("LoadStatePlugin: error parsing or setting editor state.");
+    } finally {
+      // Covers the early return and any throw; the committed path settles from its own microtask.
+      if (!settlesAfterCommit) settle();
     }
-  }, [editor, editorAdaptor, logger, scripture, scriptureRef, viewOptions]);
+  }, [editor, editorAdaptor, logger, onLoadingChange, scripture, scriptureRef, viewOptions]);
 
   return null;
 }

--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -7,6 +7,7 @@ import {
   isUsjMarkerSupported,
 } from "./adaptors/usj-marker-action.utils";
 import { EditorOptions, EditorProps, EditorRef } from "./editor.model";
+import { useLoadGate } from "./use-load-gate.hook";
 import editorTheme from "./editor.theme";
 import { ActiveTextPlugin } from "./ActiveTextPlugin";
 import { ParaMarkerPrefixGuardPlugin } from "./ParaMarkerPrefixGuardPlugin";
@@ -143,6 +144,8 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
   const [usj, setUsj] = useState(defaultUsj);
   const [loadTrigger, setLoadTrigger] = useState(0);
   const [contextMarker, setContextMarker] = useState<string>();
+  // Annotations address the loaded document, so they wait for the load in flight (#515).
+  const { handleLoadingChange, noteLoadRequested, runWhenLoaded } = useLoadGate();
 
   const {
     isReadonly = false,
@@ -215,6 +218,10 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
         editedUsjRef.current = incomingUsj;
         // This can happen when using `applyUpdate` since `usj` won't change.
         const shouldForceReload = deepEqual(usj, incomingUsj);
+        // A load is now certain, but React hasn't re-rendered yet, so LoadStatePlugin hasn't
+        // reported it. Without this, an annotation set in this same tick would address the
+        // outgoing document and be discarded by the load (#515).
+        noteLoadRequested();
         setUsj(incomingUsj);
         if (shouldForceReload) setLoadTrigger((prev) => prev + 1);
       }
@@ -287,18 +294,22 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
         onMouseLeave = fourth.onMouseLeave;
       }
 
-      annotationRef.current?.setAnnotation(
-        selection,
-        externalTypedMarkType(type),
-        id,
-        onClick,
-        onRemove,
-        onMouseEnter,
-        onMouseLeave,
+      runWhenLoaded(() =>
+        annotationRef.current?.setAnnotation(
+          selection,
+          externalTypedMarkType(type),
+          id,
+          onClick,
+          onRemove,
+          onMouseEnter,
+          onMouseLeave,
+        ),
       );
     },
     removeAnnotation(type, id) {
-      annotationRef.current?.removeAnnotation(externalTypedMarkType(type), id);
+      // Also gated: removing an annotation that a queued call is about to add must happen after
+      // it, not before, or the removal is a no-op and the mark survives.
+      runWhenLoaded(() => annotationRef.current?.removeAnnotation(externalTypedMarkType(type), id));
     },
     formatPara(blockMarker) {
       editorRef.current?.update(() => {
@@ -466,6 +477,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
             nodeOptions={nodeOptions}
             editorAdaptor={usjEditorAdaptor}
             viewOptions={viewOptions}
+            onLoadingChange={handleLoadingChange}
             logger={logger}
           />
           <OnSelectionChangePlugin onChange={onSelectionChange} />

--- a/packages/platform/src/editor/annotation-before-load.test.tsx
+++ b/packages/platform/src/editor/annotation-before-load.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * #515: annotations applied before the editor's first content commit were silently lost.
+ *
+ * `LoadStatePlugin` commits USJ from inside a `queueMicrotask`, so a consumer that calls
+ * `setAnnotation` right after mount — or right after `setUsj` — runs while the document is
+ * still the empty initial state. Two ways that lost the annotation:
+ *   a) the range cannot resolve, so `$getRangeFromUsjSelection` returns undefined and the
+ *      plugin only logs "Failed to find start or end node of the annotation.";
+ *   b) the range does resolve against the outgoing document, and the load's
+ *      `editor.setEditorState()` then replaces the whole state, discarding the mark.
+ *
+ * Neither surfaces to the caller, so consumers resorted to polling the DOM for <mark> and
+ * re-applying. These tests drive the real Editor through its ref, exactly as an app does.
+ */
+import Editor from "./Editor";
+import { EditorRef } from "./editor.model";
+import { Usj, USJ_TYPE, USJ_VERSION } from "@eten-tech-foundation/scripture-utilities";
+import { act, render } from "@testing-library/react";
+import { createRef, useEffect, useRef } from "react";
+import { AnnotationRange } from "shared-react";
+import { vi } from "vitest";
+
+const v1Text = "The heavens, the earth, and all their vast array were finished.";
+const v2Text = "On the seventh day God finished his work which he had done.";
+
+const usjGen2: Usj = {
+  type: USJ_TYPE,
+  version: USJ_VERSION,
+  content: [
+    { type: "chapter", marker: "c", number: "2" },
+    {
+      type: "para",
+      marker: "p",
+      content: [
+        { type: "verse", marker: "v", number: "1" },
+        v1Text,
+        { type: "verse", marker: "v", number: "2" },
+        v2Text,
+      ],
+    },
+  ],
+};
+
+/** A second document, to exercise the same race on a later `setUsj` load. */
+const usjGen3: Usj = {
+  type: USJ_TYPE,
+  version: USJ_VERSION,
+  content: [
+    { type: "chapter", marker: "c", number: "3" },
+    {
+      type: "para",
+      marker: "p",
+      content: [{ type: "verse", marker: "v", number: "1" }, v1Text],
+    },
+  ],
+};
+
+const jsonPath = "$.content[1].content[1]";
+const earthStart = v1Text.indexOf("earth");
+const earthRange: AnnotationRange = {
+  start: { jsonPath, offset: earthStart },
+  end: { jsonPath, offset: earthStart + "earth".length },
+};
+
+function createLoggerMock() {
+  return vi.fn();
+}
+
+function markTexts() {
+  return [...document.querySelectorAll("mark")].map((mark) => mark.textContent);
+}
+
+/**
+ * A consumer that annotates from its own mount effect — the realistic shape of this bug. The
+ * effect runs right after the editor commits, while the load microtask is still pending, and it
+ * is the first moment a consumer can legitimately touch the ref.
+ */
+function AnnotatingHost({
+  annotate,
+  logError,
+}: {
+  annotate: (editor: EditorRef) => void;
+  logError: () => void;
+}) {
+  const ref = useRef<EditorRef>(null);
+  useEffect(() => {
+    if (ref.current) annotate(ref.current);
+  }, [annotate]);
+  return (
+    <Editor
+      ref={ref}
+      defaultUsj={usjGen2}
+      logger={{
+        error: logError,
+        warn: createLoggerMock(),
+        info: createLoggerMock(),
+        debug: createLoggerMock(),
+      }}
+    />
+  );
+}
+
+describe("annotating before the first content commit (#515)", () => {
+  it("applies an annotation requested from the consumer's mount effect", async () => {
+    const logError = createLoggerMock();
+
+    await act(async () => {
+      render(
+        <AnnotatingHost
+          logError={logError}
+          annotate={(editor) => editor.setAnnotation(earthRange, "spelling", "a1")}
+        />,
+      );
+    });
+
+    expect(logError).not.toHaveBeenCalled();
+    expect(markTexts()).toEqual(["earth"]);
+  });
+
+  it("applies an annotation requested in the same tick as setUsj", async () => {
+    const logError = createLoggerMock();
+    const ref = createRef<EditorRef>();
+
+    await act(async () => {
+      render(
+        <Editor
+          ref={ref}
+          defaultUsj={usjGen2}
+          logger={{
+            error: logError,
+            warn: createLoggerMock(),
+            info: createLoggerMock(),
+            debug: createLoggerMock(),
+          }}
+        />,
+      );
+    });
+
+    // Swap the document and annotate immediately, without awaiting the reload.
+    await act(async () => {
+      ref.current?.setUsj(usjGen3);
+      ref.current?.setAnnotation(earthRange, "spelling", "a2");
+    });
+
+    expect(logError).not.toHaveBeenCalled();
+    expect(markTexts()).toEqual(["earth"]);
+  });
+
+  it("still reports a range that can never resolve, instead of queueing it forever", async () => {
+    const logError = createLoggerMock();
+
+    await act(async () => {
+      render(
+        <AnnotatingHost
+          logError={logError}
+          annotate={(editor) =>
+            editor.setAnnotation(
+              {
+                start: { jsonPath: "$.content[99].content[0]", offset: 0 },
+                end: { jsonPath: "$.content[99].content[0]", offset: 3 },
+              },
+              "spelling",
+              "bad",
+            )
+          }
+        />,
+      );
+    });
+
+    // Deferring must not swallow genuine failures: once the document is live the annotation is
+    // attempted and fails loudly, exactly as it does today.
+    expect(logError).toHaveBeenCalled();
+    expect(markTexts()).toEqual([]);
+  });
+});

--- a/packages/platform/src/editor/use-load-gate.hook.ts
+++ b/packages/platform/src/editor/use-load-gate.hook.ts
@@ -1,0 +1,62 @@
+import { useCallback, useRef } from "react";
+
+/**
+ * Defers imperative work that has to address the loaded document until the load carrying it has
+ * settled.
+ *
+ * `LoadStatePlugin` commits USJ from a microtask, and `editor.setEditorState()` replaces the whole
+ * state, so an operation issued while a load is in flight either can't resolve its target or is
+ * thrown away by the commit that follows. Callers shouldn't have to know that: they hold a ref and
+ * may reasonably use it the moment they have one.
+ *
+ * When no load is pending the operation runs immediately, i.e. exactly as before.
+ */
+export function useLoadGate() {
+  // A load always follows mount, and this hook runs before LoadStatePlugin's effect reports it.
+  const isLoadRequestedRef = useRef(true);
+  const activeLoadCountRef = useRef(0);
+  const queuedOpsRef = useRef<(() => void)[]>([]);
+
+  const drain = useCallback(() => {
+    const ops = queuedOpsRef.current;
+    queuedOpsRef.current = [];
+    for (const op of ops) op();
+  }, []);
+
+  /** Report a load starting or settling. Calls must be balanced. */
+  const handleLoadingChange = useCallback(
+    (isLoading: boolean) => {
+      if (isLoading) {
+        isLoadRequestedRef.current = false;
+        activeLoadCountRef.current += 1;
+        return;
+      }
+      activeLoadCountRef.current = Math.max(0, activeLoadCountRef.current - 1);
+      if (activeLoadCountRef.current > 0 || isLoadRequestedRef.current) return;
+      // A microtask, not a direct call: this runs from inside the settle path, and deferring keeps
+      // the queued work out of it (and off React's commit phase).
+      queueMicrotask(drain);
+    },
+    [drain],
+  );
+
+  /**
+   * Note that a load is certain but hasn't started yet — e.g. `setUsj` was just called, so React
+   * hasn't re-rendered and `LoadStatePlugin` hasn't reported the load. Without this, work issued
+   * in the same tick as `setUsj` would run against the outgoing document.
+   */
+  const noteLoadRequested = useCallback(() => {
+    isLoadRequestedRef.current = true;
+  }, []);
+
+  /** Run now if the document is settled, otherwise once the in-flight load finishes. */
+  const runWhenLoaded = useCallback((op: () => void) => {
+    if (!isLoadRequestedRef.current && activeLoadCountRef.current === 0) {
+      op();
+      return;
+    }
+    queuedOpsRef.current.push(op);
+  }, []);
+
+  return { handleLoadingChange, noteLoadRequested, runWhenLoaded };
+}


### PR DESCRIPTION
Fixes #515.

## Demo

A 2-minute screencast (with narration) is attached in the comments. It runs a small consumer app that behaves like a checking tool: a single line in a mount effect asks for one word to be underlined, with no waiting and no retry. The same app is shown against a build of `main` — badge reads "no annotation applied", no underline, nothing thrown or logged — and then against this branch, where the annotation lands. The only thing that differs between the two halves is the package build.

https://github.com/user-attachments/assets/a83149bf-2ec0-4643-a9d5-330367b08d90

## What was wrong

`setAnnotation` did nothing if it was called before the editor's first content commit — from a consumer's mount effect, or in the same tick as `setUsj`. `LoadStatePlugin` commits USJ from a `queueMicrotask`, so at that moment the document is still the empty initial state, and the annotation was lost in one of three ways:

1. `annotationRef.current` is still `null` that early, so `Editor`'s own optional-chained call vanished without even reaching the plugin;
2. `$getRangeFromUsjSelection` couldn't resolve the range, so the plugin logged `"Failed to find start or end node of the annotation."` to an *optional* logger and returned;
3. a range that *did* resolve was then thrown away wholesale by the load's `editor.setEditorState()`.

None of them surface to the caller — no throw, no return value — so it presents as "annotations sometimes just don't show". In Fluent we ended up polling the DOM for `<mark>` elements and re-applying up to three times; this removes the need for that.

## The change

`LoadStatePlugin` gains one optional prop, `onLoadingChange?: (isLoading: boolean) => void`, reporting `true` when a load starts and `false` once it settles — committed, skipped, or failed. Calls are always balanced (a `finally` covers the early return and any throw).

`Editor` uses that to defer `setAnnotation` / `removeAnnotation` until the load in flight has settled. **When nothing is loading they run immediately, exactly as before.** `setUsj` also marks a load as requested, because React hasn't re-rendered yet at that point, so the plugin hasn't reported the load.

Removal is gated too: if a queued `setAnnotation` is about to run, an un-gated `removeAnnotation` would be a no-op and the mark would survive.

## The subtle part, worth a careful look

The settle signal is deliberately **not** the update's `onUpdate` option, which is the obvious choice and is wrong here. `setEditorState` runs an intermediate `$commitPendingUpdates` of the *outgoing* state from inside the update, and that commit drains Lexical's deferred callbacks — so `onUpdate` fires while the old document is still installed. Verified against lexical 0.43 with a standalone probe:

```
onUpdate option:                          settle sees OLD
microtask queued after editor.update():   settle sees NEW
```

Lexical schedules the real commit with its own `queueMicrotask` before `update()` returns, so a microtask queued after it lands strictly later. There's a comment at the call site so nobody "simplifies" it back.

## Not swallowing real failures

A queued operation runs at the end of the load it was queued behind — never waiting on a *future* load — so a range that can never resolve still fails loudly, one load later, with the same log. That's pinned by a test.

## Verification

New `annotation-before-load.test.tsx` drives the real `Editor` through its ref, the way an app does, and covers the mount-effect case, the `setUsj` case, and the never-resolves guard. With the fix reverted, the first two fail and the guard still passes.

```
shared            123 passed
platform-editor   194 passed
shared-react     1323 passed
lint, typecheck   clean
extract-api       API report identical (no public API change)
```

Backward compatible: `EditorRef`, `EditorProps` and `MarginalRef` are untouched, the new plugin prop is optional (scribe doesn't pass it), and existing tests that `await` the mount are unaffected because the gate is already open by the time they use the ref.

Happy to adjust if this collides with the editor work your team has planned — it's confined to the load/annotation path.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eten-tech-foundation/scripture-editors/531)
<!-- Reviewable:end -->

